### PR TITLE
[WIP] Tiled merge

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -1,7 +1,6 @@
 """Copy valid pixels from input files to an output file."""
 
 from contextlib import contextmanager
-from collections import namedtuple
 from collections.abc import Sequence
 from functools import reduce
 from operator import mul
@@ -66,7 +65,6 @@ MERGE_METHODS = {
     'max': copy_max
 }
 
-Source = namedtuple('Source', ('res', 'bounds', 'dtype', 'transform', 'nodataval', 'profile', 'count', 'colormap', 'window'))
 
 def merge(
     datasets,

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -1,6 +1,10 @@
 """Copy valid pixels from input files to an output file."""
 
 from contextlib import contextmanager
+from collections import namedtuple
+from collections.abc import Sequence
+from functools import reduce
+from operator import mul
 import logging
 import math
 from pathlib import Path
@@ -12,7 +16,7 @@ import rasterio._loading
 
 with rasterio._loading.add_gdal_dll_directories():
     import rasterio
-    from rasterio.coords import disjoint_bounds
+    from rasterio.coords import BoundingBox, disjoint_bounds
     from rasterio.enums import Resampling
     from rasterio import windows
     from rasterio.transform import Affine
@@ -61,6 +65,7 @@ MERGE_METHODS = {
     'max': copy_max
 }
 
+Source = namedtuple('Source', ('res', 'bounds', 'dtype', 'transform', 'nodataval', 'profile', 'count', 'colormap', 'window'))
 
 def merge(
     datasets,
@@ -363,3 +368,265 @@ def merge(
             dst.write(dest)
             if first_colormap:
                 dst.write_colormap(1, first_colormap)
+
+
+def arrbytes(shape, dtype):
+    return reduce(mul, shape) * np.dtype(dtype).itemsize
+
+
+def arrblocks(shape, dtype, mem_limit=1024*1024):
+    i = 1
+    new_shape = [shape[0], shape[1]//i, shape[2]//i]
+    while arrbytes(new_shape, dtype) >= mem_limit:
+        i += 1
+        new_shape[1] = shape[1] // i
+        new_shape[2] = shape[2] // i
+    return tuple(new_shape), _gen_blocks(shape, new_shape)
+
+def arrblocksxy(shape, width, height):
+    return _gen_blocks(shape, (shape[0], height, width))
+
+def _gen_blocks(shape, block_shape):
+    blocks = []
+    row_blocks = divmod(shape[1], block_shape[1])
+    col_blocks = divmod(shape[2], block_shape[2])
+    #breakpoint()
+    for j in range(row_blocks[0] + (row_blocks[1] > 0)): # rows
+        for k in range(col_blocks[0] + (col_blocks[1] > 0)):  # cols
+            h, w = block_shape[1:]
+            col_off = w * k
+            row_off = h * j
+
+            if col_off < shape[2] and col_off + w > shape[2]:
+                w = shape[2] % w
+            if row_off < shape[1] and row_off + h > shape[1]:
+                h = shape[1] % h
+            blocks.append(windows.Window(col_off, row_off, w, h))
+    return blocks
+
+
+def dataset_opener(dataset):
+    if isinstance(dataset, (str, Path)):
+        fin = rasterio.open(dataset)
+        return fin
+    else:
+        return dataset
+
+
+def merge_tiled(
+    datasets,
+    dst_path,
+    bounds=None,
+    res=None,
+    nodata=None,
+    dtype=None,
+    indexes=None,
+    output_count=None,
+    resampling=Resampling.nearest,
+    method="first",
+    target_aligned_pixels=False,
+    dst_kwds=None,
+):
+    """Copy valid pixels from input files to an output file.
+
+    All files must have the same number of bands, data type, and
+    coordinate reference system.
+
+    Input files are merged in their listed order using the reverse
+    painter's algorithm (default) or another method. If the output file exists,
+    its values will be overwritten by input values.
+
+    Geospatial bounds and resolution of a new output file in the
+    units of the input file coordinate reference system may be provided
+    and are otherwise taken from the first input file.
+
+    Parameters
+    ----------
+    datasets : list of dataset objects opened in 'r' mode, filenames or pathlib.Path objects
+        source datasets to be merged.
+    bounds: tuple, optional
+        Bounds of the output image (left, bottom, right, top).
+        If not set, bounds are determined from bounds of input rasters.
+    res: tuple, optional
+        Output resolution in units of coordinate reference system. If not set,
+        the resolution of the first raster is used. If a single value is passed,
+        output pixels will be square.
+    nodata: float, optional
+        nodata value to use in output file. If not set, uses the nodata value
+        in the first input raster.
+    dtype: numpy dtype or string
+        dtype to use in outputfile. If not set, uses the dtype value in the
+        first input raster.
+    precision: float, optional
+        Number of decimal points of precision when computing inverse transform.
+    indexes : list of ints or a single int, optional
+        bands to read and merge
+    output_count: int, optional
+        If using callable it may be useful to have additional bands in the output
+        in addition to the indexes specified for read
+    resampling : Resampling, optional
+        Resampling algorithm used when reading input files.
+        Default: `Resampling.nearest`.
+    method : str or callable
+        pre-defined method:
+            first: reverse painting
+            last: paint valid new on top of existing
+            min: pixel-wise min of existing and new
+            max: pixel-wise max of existing and new
+        or custom callable with signature:
+
+        def function(merged_data, new_data, merged_mask, new_mask, index=None, roff=None, coff=None):
+
+            Parameters
+            ----------
+            merged_data : array_like
+                array to update with new_data
+            new_data : array_like
+                data to merge
+                same shape as merged_data
+            merged_mask, new_mask : array_like
+                boolean masks where merged/new data pixels are invalid
+                same shape as merged_data
+            index: int
+                index of the current dataset within the merged dataset collection
+            roff: int
+                row offset in base array
+            coff: int
+                column offset in base array
+
+    target_aligned_pixels : bool, optional
+        Whether to adjust output image bounds so that pixel coordinates
+        are integer multiples of pixel size, matching the ``-tap``
+        options of GDAL utilities.  Default: False.
+    dst_path : str or Pathlike, optional
+        Path of output dataset
+    dst_kwds : dict, optional
+        Dictionary of creation options and other paramters that will be
+        overlaid on the profile of the output dataset.
+
+    Returns
+    -------
+    tuple
+
+        Two elements:
+
+            dest: numpy ndarray
+                Contents of all input rasters in single array
+
+            out_transform: affine.Affine()
+                Information for mapping pixel coordinates in `dest` to another
+                coordinate system
+
+    """
+    if method in MERGE_METHODS:
+        copyto = MERGE_METHODS[method]
+    elif callable(method):
+        copyto = method
+    else:
+        raise ValueError('Unknown method {0}, must be one of {1} or callable'
+                         .format(method, list(MERGE_METHODS.keys())))
+
+    DS = tuple(map(dataset_opener, datasets))
+
+    # Compute destination bounds
+    if bounds:
+        dst_w, dst_s, dst_e, dst_n = bounds
+    else:
+        dst_w, dst_s, dst_e, dst_n = (np.inf, np.inf, -np.inf, -np.inf)
+        for src in DS:
+            dst_w = min(src.bounds[0], dst_w)
+            dst_s = min(src.bounds[1], dst_s)
+            dst_e = max(src.bounds[2], dst_e)
+            dst_n = max(src.bounds[3], dst_n)
+
+    # Compute destination resolution
+    if not res:
+        res = min(src.res for src in DS)
+    elif isinstance(res, (float, int)):
+        res = (res, res)
+    elif isinstance(res, Sequence) and len(res) == 1:
+        res = (res[0], res[0])
+
+    if dtype is not None:
+        dt = dtype
+        logger.debug("Set dtype: %s", dt)
+    
+    if nodata is not None:
+        nodataval = nodata
+        logger.debug("Set nodataval: %r", nodataval)
+
+    inrange = False
+    if nodataval is not None:
+        # Only fill if the nodataval is within dtype's range
+        if np.issubdtype(dt, np.integer):
+            info = np.iinfo(dt)
+            inrange = (info.min <= nodataval <= info.max)
+        elif np.issubdtype(dt, np.floating):
+            if math.isnan(nodataval):
+                inrange = True
+            else:
+                info = np.finfo(dt)
+                inrange = (info.min <= nodataval <= info.max)
+        if not inrange:
+            warnings.warn(
+                "The nodata value, %s, is beyond the valid "
+                "range of the chosen data type, %s. Consider overriding it "
+                "using the --nodata option for better results." % (
+                    nodataval, dt))
+    else:
+        nodataval = 0
+
+
+    if target_aligned_pixels:
+        dst_w = math.floor(dst_w / res[0]) * res[0]
+        dst_e = math.ceil(dst_e / res[0]) * res[0]
+        dst_s = math.floor(dst_s / res[1]) * res[1]
+        dst_n = math.ceil(dst_n / res[1]) * res[1]
+
+    # Compute output array shape. We guarantee it will cover the output
+    # bounds completely
+    output_count = min(src.count for src in DS)
+    output_width = round((dst_e - dst_w) / res[0])
+    output_height = round((dst_n - dst_s) / res[1])
+    output_transform = Affine.translation(dst_w, dst_n) * Affine.scale(res[0], -res[1])
+
+    out_profile = dict(DS[0].profile)
+    out_profile.update(**(dst_kwds or {}))
+    out_profile['transform'] = output_transform
+    out_profile['height'] = output_height
+    out_profile['width'] = output_width
+    out_profile['count'] = output_count
+    if nodata is not None:
+        out_profile['nodata'] = nodata
+    
+    dest_shape = (output_count, output_width, output_height)
+    block_shape, blocks = arrblocks(dest_shape, dt)
+    with rasterio.open(dst_path, 'w', **out_profile) as dest:
+        for i, block in enumerate(blocks):
+            tile_shape = (output_count, block.height, block.width)
+            tile = np.zeros(tile_shape, dtype='float32')
+            tile.fill(nodataval)
+
+            tile_window = windows.bounds(block, output_transform)
+            for idx, ds in enumerate(DS):
+                tw = ds.window(*tile_window)
+                sw = windows.from_bounds(*ds.bounds, ds.transform)
+                if not windows.intersect(tw, sw):
+                    continue
+                new_data = ds.read(
+                    indexes=indexes,
+                    masked=True,
+                    boundless=True,
+                    window=tw,
+                    resampling=resampling
+                )
+                copyto(tile, new_data, tile==nodataval, new_data.mask, index=idx, roff=tw.row_off, coff=tw.col_off)
+            dest.write(tile, window=block)
+        try:
+            cmap = DS[0].colormap(1)
+            dest.write_colormap(1, cmap)
+        except ValueError:
+            pass
+
+    for ds in DS:
+        ds.close()


### PR DESCRIPTION
An experiment to see if merge could be made more memory efficient using windowed read/write. Testing with the dataset in #2174 seems to produce good results when visually inspected (ie no lines of missing data). I've only manually tested at this point, but thought I would open a draft PR for early feedback.

Advantages:
 * Tries to keep only one or two tiles in memory at a time. Memory usage of tiles is tunable (see `arrblocks`). This probably allows arbitrary sized merges.
 * ~~Using windowed reads/writes seem to side-step the rounding issues in #2205~~
 * Each block is independent. Perhaps parallel merges are in the future?
 * Window reads can be aligned to the block sizes of the input datasets allowing for efficient reads. See the `arrblocksxy` function.
 * Merge loop seems to be shorter and more concise.

Disadvantages
 * Code is super new and therefore super untested.
 * Appears to trade speed for memory efficiency 