### PR TITLE
Allow np.min/max to output to a new array.

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -39,7 +39,10 @@ def copy_min(merged_data, new_data, merged_mask, new_mask, **kwargs):
     mask = np.empty_like(merged_mask, dtype="bool")
     np.logical_or(merged_mask, new_mask, out=mask)
     np.logical_not(mask, out=mask)
-    np.minimum(merged_data, new_data, out=merged_data, where=mask)
+
+    # Allowing np.minimum to allocate a new array avoids
+    # a strange memory artifact in rare cases.
+    merged_data[mask] = np.minimum(merged_data, new_data, where=mask)[mask]
     np.logical_not(new_mask, out=mask)
     np.logical_and(merged_mask, mask, out=mask)
     np.copyto(merged_data, new_data, where=mask, casting="unsafe")
@@ -49,7 +52,10 @@ def copy_max(merged_data, new_data, merged_mask, new_mask, **kwargs):
     mask = np.empty_like(merged_mask, dtype="bool")
     np.logical_or(merged_mask, new_mask, out=mask)
     np.logical_not(mask, out=mask)
-    np.maximum(merged_data, new_data, out=merged_data, where=mask)
+
+    # Allowing np.maximum to allocate a new array avoids
+    # a strange memory artifact in rare cases.
+    merged_data[mask] = np.maximum(merged_data, new_data, where=mask)[mask]
     np.logical_not(new_mask, out=mask)
     np.logical_and(merged_mask, mask, out=mask)
     np.copyto(merged_data, new_data, where=mask, casting="unsafe")


### PR DESCRIPTION
This introduces two new array allocations, however avoids a strange memory issue. The two new arrays are temporary and should be garbage collected immedately after use.

Appears to resolve #2245.

@sgillies this may not be a big enough issue to warrant merging this. If you would rather keep the inplace method, that's fine with me too. However, in that case, min/max should also have `casting='unsafe'`