### PR TITLE
Replace IOError alias with OSError

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1101,7 +1101,7 @@ cdef class MemoryFileBase:
             self.mode = "w+"
 
         if self._vsif == NULL:
-            raise IOError("Failed to open in-memory file.")
+            raise OSError("Failed to open in-memory file.")
 
         self.closed = False
 

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -41,7 +41,7 @@ class FileOverwriteError(FileError):
         super().__init__('', hint=message)
 
 
-class RasterioIOError(IOError):
+class RasterioIOError(OSError):
     """Raised when a dataset cannot be opened using one of the
     registered format drivers."""
 

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -127,7 +127,7 @@ class MemoryFile(MemoryFileBase):
         mempath = UnparsedPath(self.name)
 
         if self.closed:
-            raise IOError("I/O operation on closed file.")
+            raise OSError("I/O operation on closed file.")
         if len(self) > 0:
             log.debug("VSI path: {}".format(mempath.path))
             return DatasetReader(mempath, driver=driver, sharing=sharing, **kwargs)
@@ -178,7 +178,7 @@ class ZipMemoryFile(MemoryFile):
         zippath = UnparsedPath('/vsizip{0}/{1}'.format(self.name, path.lstrip('/')))
 
         if self.closed:
-            raise IOError("I/O operation on closed file.")
+            raise OSError("I/O operation on closed file.")
         return DatasetReader(zippath, driver=driver, sharing=sharing, **kwargs)
 
 

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -115,14 +115,14 @@ def file_in_handler(ctx, param, value):
                 archive = abspath_forward_slashes(path.archive)
                 return "{}://{}!{}".format(path.scheme, archive, path.path)
             else:
-                raise IOError(
+                raise OSError(
                     "Input archive {} does not exist".format(path.archive))
 
         else:
             if os.path.exists(path.path) and rasterio.shutil.exists(value):
                 return abspath_forward_slashes(path.path)
             else:
-                raise IOError(
+                raise OSError(
                     "Input file {} does not exist".format(path.path))
 
     except Exception:

--- a/rasterio/rio/sample.py
+++ b/rasterio/rio/sample.py
@@ -61,7 +61,7 @@ def sample(ctx, files, bidx):
     # Handle the case of file, stream, or string input.
     try:
         points = click.open_file(input).readlines()
-    except IOError:
+    except OSError:
         points = [input]
 
     try:

--- a/rasterio/rio/transform.py
+++ b/rasterio/rio/transform.py
@@ -25,7 +25,7 @@ def transform(ctx, input, src_crs, dst_crs, precision):
     # Handle the case of file, stream, or string input.
     try:
         src = click.open_file(input).readlines()
-    except IOError:
+    except OSError:
         src = [input]
 
     try:

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -96,7 +96,7 @@ def test_closed():
     """A closed MemoryFile can not be opened"""
     with MemoryFile() as memfile:
         pass
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         memfile.open()
 
 
@@ -229,7 +229,7 @@ def test_zip_closed():
     """A closed ZipMemoryFile can not be opened"""
     with ZipMemoryFile() as zipmemfile:
         pass
-    with pytest.raises(IOError):
+    with pytest.raises(OSError):
         zipmemfile.open('foo')
 
 


### PR DESCRIPTION
Since Python 3.3,  IO and OS exceptions were re-worked as per [PEP 3151](https://www.python.org/dev/peps/pep-3151/). The new main base class is [OSError](https://docs.python.org/3/library/exceptions.html#OSError), with several other exceptions merged, including IOError (i.e. `assert IOError is OSError`).

This PR changes the old IOError alias to OSError.