### PR TITLE
Simplify DatasetBase.closed

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -426,7 +426,7 @@ cdef class DatasetBase:
             refcount = GDALDereferenceDataset(self._hds)
             if refcount == 0:
                 GDALClose(self._hds)
-        self._hds = NULL
+            self._hds = NULL
 
     def close(self):
         """Close the dataset"""


### PR DESCRIPTION
_closed essentially tracked if hds was NULL using a bool. Removed extra state by returning the result of hds == NULL. `closed` property is simply an alias for this null check. In addition, only set hds to NULL when the dataset is dereferenced instead of every time close() is called.