### PR TITLE
Dockerfile for local development

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,21 +1,20 @@
+ARG GDAL=ubuntugis
+
 FROM ubuntu:20.04 AS ubuntugis
-
 ENV LANG="C.UTF-8" LC_ALL="C.UTF-8"
-
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     python3 python3-pip python3-dev python3-venv cython3 g++ libgdal-dev gdal-bin && \
     rm -rf /var/lib/apt/lists/*
-
-
-FROM ubuntugis AS rio
-
 WORKDIR /tmp
 COPY . .
 RUN python3 -m venv /venv && /venv/bin/python -m pip install -U pip && /venv/bin/python -m pip install -r requirements-dev.txt
-RUN /venv/bin/python -m pip install .
 
+FROM ubuntugis AS latest
+RUN echo "hi!"
+
+FROM ${GDAL} AS rio
+RUN /venv/bin/python -m pip install .
 WORKDIR /usr/src/app
 COPY tests ./tests
-
 ENTRYPOINT ["/venv/bin/rio"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,21 @@
+FROM ubuntu:20.04 AS ubuntugis
+
+ENV LANG="C.UTF-8" LC_ALL="C.UTF-8"
+
+RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    python3 python3-pip python3-dev python3-venv cython3 g++ libgdal-dev gdal-bin && \
+    rm -rf /var/lib/apt/lists/*
+
+
+FROM ubuntugis AS rio
+
+WORKDIR /tmp
+COPY . .
+RUN python3 -m venv /venv && /venv/bin/python -m pip install -U pip && /venv/bin/python -m pip install -r requirements-dev.txt
+RUN /venv/bin/python -m pip install .
+
+WORKDIR /usr/src/app
+COPY tests ./tests
+
+ENTRYPOINT ["/venv/bin/rio"]
+CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,17 @@
 ARG GDAL=ubuntu-small-3.3.3
-FROM osgeo/gdal:${GDAL}
+FROM osgeo/gdal:${GDAL} AS gdal 
 ENV LANG="C.UTF-8" LC_ALL="C.UTF-8"
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
     python3 python3-pip python3-dev python3-venv cython3 g++ && \
     rm -rf /var/lib/apt/lists/*
-WORKDIR /tmp
-COPY . .
+WORKDIR /app
+COPY requirements*.txt ./
 RUN python3 -m venv /venv && \
     /venv/bin/python -m pip install -U pip && \
-    /venv/bin/python -m pip install -r requirements-dev.txt && \
-    /venv/bin/python -m pip install .
-WORKDIR /usr/src/app
-COPY tests ./tests
+    /venv/bin/python -m pip install -r requirements-dev.txt
+
+FROM gdal
+COPY . .
+RUN /venv/bin/python setup.py install
 ENTRYPOINT ["/venv/bin/rio"]
 CMD ["--help"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,19 +1,15 @@
-ARG GDAL=ubuntugis
-
-FROM ubuntu:20.04 AS ubuntugis
+ARG GDAL=ubuntu-small-3.3.3
+FROM osgeo/gdal:${GDAL}
 ENV LANG="C.UTF-8" LC_ALL="C.UTF-8"
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    python3 python3-pip python3-dev python3-venv cython3 g++ libgdal-dev gdal-bin && \
+    python3 python3-pip python3-dev python3-venv cython3 g++ && \
     rm -rf /var/lib/apt/lists/*
 WORKDIR /tmp
 COPY . .
-RUN python3 -m venv /venv && /venv/bin/python -m pip install -U pip && /venv/bin/python -m pip install -r requirements-dev.txt
-
-FROM ubuntugis AS latest
-RUN echo "hi!"
-
-FROM ${GDAL} AS rio
-RUN /venv/bin/python -m pip install .
+RUN python3 -m venv /venv && \
+    /venv/bin/python -m pip install -U pip && \
+    /venv/bin/python -m pip install -r requirements-dev.txt && \
+    /venv/bin/python -m pip install .
 WORKDIR /usr/src/app
 COPY tests ./tests
 ENTRYPOINT ["/venv/bin/rio"]

--- a/Makefile
+++ b/Makefile
@@ -26,3 +26,9 @@ docs:
 
 doctest:
 	py.test --doctest-modules rasterio --doctest-glob='*.rst' docs/*.rst
+
+dockertestimage:
+	docker build --build-arg GDAL=$(GDAL) --target gdal -t rasterio:$(GDAL) .
+
+dockertest: dockertestimage
+	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL) -c '/venv/bin/python setup.py develop && /venv/bin/python -B -m pytest -m "not wheel" --cov rasterio --cov-report term-missing $(OPTS)'

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -55,7 +55,7 @@ cdef const char *get_driver_name(GDALDriverH driver):
 
 
 def get_dataset_driver(path):
-    """Return the name of the driver that opens a dataset
+    """Get the name of the driver that opens a dataset.
 
     Parameters
     ----------
@@ -65,6 +65,7 @@ def get_dataset_driver(path):
     Returns
     -------
     str
+
     """
     cdef GDALDatasetH dataset = NULL
     cdef GDALDriverH driver = NULL

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -51,7 +51,7 @@ gdal33_version_met = False
 
 
 def validate_resampling(resampling):
-    """Validate that the resampling method is compatible of reads/writes"""
+    """Validate that the resampling method is compatible of reads/writes."""
 
     if resampling == Resampling.rms:
         global gdal33_version_checked


### PR DESCRIPTION
Inspired by #1928.

Instead of having multiple dockerfiles I'd like to try cramming multiple targets into one. The first provides (slightly outdated) dependencies, makes a Python environment at `/venv`, and installs rasterio's dependencies. The second will (when done) build and install the latest PROJ and GDAL. The third installs rasterio and copies rasterio's `tests` directory to `/usr/src/app/tests`.

We can use this to run rio-info in a container.

```
docker run -v /home/seangillies/projects/rasterio/tests/data:/io 647ffce97b32 info /io/RGB.byte.tif
{"bounds": [101985.0, 2611485.0, 339315.0, 2826915.0], "colorinterp": ["red", "green", "blue"], "count": 3, "crs": "EPSG:32618", "descriptions": [null, null, null], "driver": "GTiff", "dtype": "uint8", "height": 718, "indexes": [1, 2, 3], "interleave": "pixel", "lnglat": [-77.75790625254565, 24.56158328533282], "mask_flags": [["nodata"], ["nodata"], ["nodata"]], "nodata": 0.0, "res": [300.0379266750948, 300.041782729805], "shape": [718, 791], "tiled": false, "transform": [300.0379266750948, 0.0, 101985.0, 0.0, -300.041782729805, 2826915.0, 0.0, 0.0, 1.0], "units": [null, null, null], "width": 791}
```

We can also use it to run rasterio's tests.

```
docker run -it --entrypoint=/venv/bin/python 5c41588f8fb9 -m pytest -m "not wheel"
```

Next steps: try adding a layer with the latest PROJ and GDAL.