### PR TITLE
Travis CI: Add Python 3.10 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-dist: xenial
+dist: focal
 
 language: python
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,13 +35,21 @@ jobs:
         PROJVERSION="7.2.1"
     - python: "3.8"
       env:
-        GDALVERSION="3.3.2"
+        GDALVERSION="3.3.3"
         PROJVERSION="8.0.1"
     - python: "3.9"
       env:
-        GDALVERSION="3.3.2"
+        GDALVERSION="3.3.3"
         PROJVERSION="8.1.1"
     - python: "3.9"
+      env:
+        GDALVERSION="3.4.0"
+        PROJVERSION="8.1.1"
+    - python: "3.10"
+      env:
+        GDALVERSION="3.4.0"
+        PROJVERSION="8.1.1"
+    - python: "3.10"
       env:
         GDALVERSION="master"
         PROJVERSION="8.1.1"


### PR DESCRIPTION
 - Updates the GDAL 3.3.2 builds to [3.3.3](https://github.com/OSGeo/gdal/releases/tag/v3.3.3) (for Python 3.8 and 3.9)
 - Updates the Python 3.9 with GDAL master to [3.4.0](https://github.com/OSGeo/gdal/releases/tag/v3.4.0)
 - Adds Python 3.10 builds with GDAL 3.4.0 and master

Related issue: #2307.