### PR TITLE
Accelerate rasterio.sample.sample_gen

### DIFF
--- a/rasterio/sample.py
+++ b/rasterio/sample.py
@@ -1,6 +1,6 @@
 # Workaround for issue #378. A pure Python generator.
 
-import numpy
+import numpy as np
 
 import rasterio._loading
 with rasterio._loading.add_gdal_dll_directories():
@@ -33,24 +33,26 @@ def sample_gen(dataset, xy, indexes=None, masked=False):
     """
     index = dataset.index
     read = dataset.read
+    height = dataset.height
+    width = dataset.width
 
     if indexes is None:
         indexes = dataset.indexes
     elif isinstance(indexes, int):
         indexes = [indexes]
 
+    nodata = np.full(len(indexes), (dataset.nodata or 0),  dtype=dataset.dtypes[0])
+    if masked:
+        # Masks for masked arrays are inverted (False means valid)
+        mask = [~(MaskFlags.all_valid in dataset.mask_flag_enums[i-1]) for i in indexes]
+        nodata = np.ma.array(nodata, mask=mask)
+
     for x, y in xy:
 
         row_off, col_off = index(x, y)
 
-        if row_off < 0 or col_off < 0 or row_off >= dataset.height or col_off >= dataset.width:
-            data = numpy.ones((len(indexes),), dtype=dataset.dtypes[0]) * (dataset.nodata or 0)
-            if masked:
-                mask = [False if MaskFlags.all_valid in dataset.mask_flag_enums[i - 1] else True for i in indexes]
-                yield numpy.ma.array(data, mask=mask)
-            else:
-                yield data
-
+        if row_off < 0 or col_off < 0 or row_off >= height or col_off >= width:
+            yield nodata
         else:
             window = Window(col_off, row_off, 1, 1)
             data = read(indexes, window=window, masked=masked)

--- a/rasterio/sample.py
+++ b/rasterio/sample.py
@@ -6,6 +6,16 @@ import rasterio._loading
 with rasterio._loading.add_gdal_dll_directories():
     from rasterio.enums import MaskFlags
     from rasterio.windows import Window
+    from rasterio.transform import rowcol
+
+from itertools import zip_longest
+
+def _grouper(iterable, n, fillvalue=None):
+    "Collect data into non-overlapping fixed-length chunks or blocks"
+    # grouper('ABCDEFG', 3, 'x') --> ABC DEF Gxx
+    # from itertools recipes
+    args = [iter(iterable)] * n
+    return zip_longest(*args, fillvalue=fillvalue)
 
 
 def sample_gen(dataset, xy, indexes=None, masked=False):
@@ -31,7 +41,7 @@ def sample_gen(dataset, xy, indexes=None, masked=False):
         those indexes.
 
     """
-    index = dataset.index
+    dt = dataset.transform
     read = dataset.read
     height = dataset.height
     width = dataset.width
@@ -44,16 +54,16 @@ def sample_gen(dataset, xy, indexes=None, masked=False):
     nodata = np.full(len(indexes), (dataset.nodata or 0),  dtype=dataset.dtypes[0])
     if masked:
         # Masks for masked arrays are inverted (False means valid)
-        mask = [~(MaskFlags.all_valid in dataset.mask_flag_enums[i-1]) for i in indexes]
+        mask = [MaskFlags.all_valid not in dataset.mask_flag_enums[i-1] for i in indexes]
         nodata = np.ma.array(nodata, mask=mask)
 
-    for x, y in xy:
+    for pts in _grouper(xy, 256):
+        pts = zip(*filter(None, pts))
 
-        row_off, col_off = index(x, y)
-
-        if row_off < 0 or col_off < 0 or row_off >= height or col_off >= width:
-            yield nodata
-        else:
-            window = Window(col_off, row_off, 1, 1)
-            data = read(indexes, window=window, masked=masked)
-            yield data[:, 0, 0]
+        for row_off, col_off in zip(*rowcol(dt, *pts)):
+            if row_off < 0 or col_off < 0 or row_off >= height or col_off >= width:
+                yield nodata
+            else:
+                window = Window(col_off, row_off, 1, 1)
+                data = read(indexes, window=window, masked=masked)
+                yield data[:, 0, 0]


### PR DESCRIPTION
I have encountered a use case where I am querying millions of points from a raster and realized there was some very low hanging fruit to optimize `sample_gen`. 

With 10 million points query time has dropped from 2m29s (1.2.8) to 28s (with this PR). Moved the masking check out of the loop and allocated the nodata array once. Also chunked the point transformations using rowcol.