### PR TITLE
BUG: Exclude *.cpp from dist

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -4,6 +4,7 @@ include rasterio/*.pyx
 include rasterio/*.pxd
 include rasterio/*.pxi
 exclude rasterio/*.c
+exclude rasterio/*.cpp
 recursive-include examples *.py
 recursive-include tests *.py *.rst
 recursive-exclude tests/data *.tif


### PR DESCRIPTION
Related to #2130
```bash
tar -tf rasterio-1.3a2.tar.gz  | grep .cpp
```
```
rasterio-1.3a2/rasterio/_fill.cpp
rasterio-1.3a2/rasterio/_pyvsi.cpp
rasterio-1.3a2/rasterio/_warp.cpp

```