### PR TITLE
Minor improvements to rasterio._crs.

### DIFF
--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -587,26 +587,24 @@ cdef class _CRS:
             _safe_osr_release(osr)
 
         def parse(v):
-            _v = v.lower()
-            if _v == "true":
-                return True
-            elif _v == "false":
-                return False
-            else:
-                try:
-                    return int(v)
-                except ValueError:
-                    pass
-                try:
-                    return float(v)
-                except ValueError:
-                    return v
+            try:
+                return int(v)
+            except ValueError:
+                pass
+            try:
+                return float(v)
+            except ValueError:
+                return v
 
         rv = {}
         for key, value in _RE_PROJ_PARAM.findall(proj):
-            value = parse(value)
-            if key in all_proj_keys and value:
-                rv[key] = value
+            lvalue = value.lower()
+            if key not in all_proj_keys or lvalue == "false":
+                continue
+            if not value or lvalue == "true":
+                rv[key] = True
+            else:
+                rv[key] = parse(value)
         return rv
 
 

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -21,7 +21,14 @@ from rasterio._err cimport exc_wrap_ogrerr, exc_wrap_int, exc_wrap_pointer
 
 log = logging.getLogger(__name__)
 
-_RE_PROJ_PARAM = re.compile(r"\+(\w+)\=?(\S*)?\s*?")
+_RE_PROJ_PARAM = re.compile(r"""
+    \+              # parameter starts with '+' character
+    (?P<param>\w+)    # capture parameter name
+    \=?             # match both key only and key-value parameters
+    (?P<value>\S+)? # capture all characters up to next space (None if no value)
+    \s*?            # consume remaining whitespace, if any
+""", re.X)
+
 
 def gdal_version():
     """Return the version as a major.minor.patchlevel string."""

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -455,8 +455,6 @@ cdef class _CRS:
             # PROJ JSON
             return _CRS.from_user_input(json.dumps(data))
 
-        data = {k: v for k, v in data.items() if k in all_proj_keys}
-
         # "+init=epsg:xxxx" is deprecated in GDAL. If we find this, we will
         # extract the epsg code and dispatch to from_epsg.
         if 'init' in data and data['init'].lower().startswith('epsg:'):
@@ -465,7 +463,8 @@ cdef class _CRS:
 
         # Continue with the general case.
         pjargs = []
-        for key, val in data.items():
+        for key in data.keys() & all_proj_keys:
+            val = data[key]
             if val is None or val is True:
                 pjargs.append('+{}'.format(key))
             elif val is False:

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -414,13 +414,13 @@ cdef class _CRS:
 
         # Filter out nonsensical items that might have crept in.
         items_filtered = []
-        items = proj.split()
-        for item in items:
-            parts = item.split('=')
-            if len(parts) == 2 and parts[1] in ('false', 'False'):
+        for key, value in _RE_PROJ_PARAM.findall(proj):
+            if value.lower() == "false":
                 continue
-            items_filtered.append(item)
-
+            if value:
+                items_filtered.append(f"+{key}={value}")
+            else:
+                items_filtered.append(f"+{key}")
         proj = ' '.join(items_filtered)
         proj_b = proj.encode('utf-8')
 

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -586,12 +586,11 @@ cdef class _CRS:
             CPLFree(proj_c)
             _safe_osr_release(osr)
 
-        parts = [o.lstrip('+') for o in proj.strip().split()]
-
         def parse(v):
-            if v in ('True', 'true'):
+            _v = v.lower()
+            if _v == "true":
                 return True
-            elif v in ('False', 'false'):
+            elif _v == "false":
                 return False
             else:
                 try:
@@ -603,11 +602,13 @@ cdef class _CRS:
                 except ValueError:
                     return v
 
-        items = map(
-            lambda kv: len(kv) == 2 and (kv[0], parse(kv[1])) or (kv[0], True),
-            (p.split('=') for p in parts))
+        rv = {}
+        for key, value in _RE_PROJ_PARAM.findall(proj):
+            value = parse(value)
+            if key in all_proj_keys and value:
+                rv[key] = value
+        return rv
 
-        return {k: v for k, v in items if k in all_proj_keys and v is not False}
 
 # Below is the big list of PROJ4 parameters from
 # http://trac.osgeo.org/proj/wiki/GenParms.

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -723,5 +723,6 @@ _param_data = """
 +zone      UTM zone
 """
 
-_lines = filter(lambda x: len(x) > 1, _param_data.split("\n"))
-all_proj_keys = list(set(line.split()[0].lstrip("+").strip() for line in _lines)) + ['no_mayo']
+_lines = filter(None, _param_data.splitlines())
+all_proj_keys = set(line.split(' ', 1)[0][1:] for line in filter(None, _param_data.splitlines()))
+all_proj_keys.add('no_mayo')

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -723,6 +723,5 @@ _param_data = """
 +zone      UTM zone
 """
 
-_lines = filter(None, _param_data.splitlines())
 all_proj_keys = set(line.split(' ', 1)[0][1:] for line in filter(None, _param_data.splitlines()))
 all_proj_keys.add('no_mayo')

--- a/rasterio/_crs.pyx
+++ b/rasterio/_crs.pyx
@@ -7,6 +7,7 @@ from collections import defaultdict
 import json
 import logging
 import warnings
+import re
 
 import rasterio._env
 from rasterio._err import CPLE_BaseError, CPLE_NotSupportedError
@@ -20,6 +21,7 @@ from rasterio._err cimport exc_wrap_ogrerr, exc_wrap_int, exc_wrap_pointer
 
 log = logging.getLogger(__name__)
 
+_RE_PROJ_PARAM = re.compile(r"\+(\w+)\=?(\S*)?\s*?")
 
 def gdal_version():
     """Return the version as a major.minor.patchlevel string."""

--- a/tests/test__crs.py
+++ b/tests/test__crs.py
@@ -180,3 +180,33 @@ def test_exception_proj4():
 def test_linear_units():
     """CRS linear units can be had"""
     assert _CRS.from_epsg(3857).linear_units == 'metre'
+
+def test_crs_to_dict():
+    x = _CRS.from_proj4("+proj=merc +a=6378137 +b=6378137 +lat_ts=0.0 +lon_0=0.0 +x_0=0.0 +y_0=0 +k=1.0 +units=m +nadgrids=@null +wktext  +no_defs")
+    expected = {'proj': 'merc',
+                'a': 6378137,
+                'b': 6378137,
+                'lat_ts': 0,
+                'lon_0': 0,
+                'x_0': 0,
+                'y_0': 0,
+                'k': 1,
+                'units': 'm',
+                'nadgrids': '@null',
+                'wktext': True,
+                'no_defs': True}
+    assert x.to_dict() == expected
+
+def test_crs_from_dict():
+    expected = {'proj': 'lcc',
+                'lat_0': 40,
+                'lon_0': -96,
+                'lat_1': 20,
+                'lat_2': 60,
+                'x_0': 0,
+                'y_0': 0,
+                'datum': 'NAD83',
+                'units': 'm',
+                'no_defs': True}
+    x = _CRS.from_dict(expected)
+    assert x.to_dict() == expected


### PR DESCRIPTION
A collection of small improvements to CRS cython code with the intention of making the code clearer to read and probably run slightly faster.
* Make `all_proj_keys` a set for faster lookups
* Use regex for parsing of proj4 strings into keys and values
* Added some basic tests that execute `from_proj4`, `from_dict`, and `to_dict`