### PR TITLE
BUG: Allow reading file-like objects without with statement

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -190,15 +190,16 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
             "Blacklisted: file cannot be opened by "
             "driver '{0}' in '{1}' mode".format(driver, mode))
 
+    # wrap file object with FilePath
+    if have_vsi_plugin and mode == 'r' and hasattr(fp, 'read'):
+        fp = FilePath(fp)
+
     # Special case for file object argument.
-    if mode == 'r' and hasattr(fp, 'read'):
+    if not have_vsi_plugin and mode == 'r' and hasattr(fp, 'read'):
 
         @contextmanager
         def fp_reader(fp):
-            if have_vsi_plugin:
-                vsi_file = FilePath(fp)
-            else:
-                vsi_file = MemoryFile(fp.read())
+            vsi_file = MemoryFile(fp.read())
             dataset = vsi_file.open(driver=driver, sharing=sharing)
             try:
                 yield dataset

--- a/tests/test_filepath.py
+++ b/tests/test_filepath.py
@@ -92,6 +92,18 @@ def test_file_object_read(rgb_file_object):
         assert src.read().shape == (3, 718, 791)
 
 
+def test_file_object_read__no_with_statement(rgb_file_object):
+    """An example of reading from a file object without with statement"""
+    src = rasterio.open(rgb_file_object)
+    try:
+        assert src.driver == 'GTiff'
+        assert src.count == 3
+        assert src.dtypes == ('uint8', 'uint8', 'uint8')
+        assert src.read().shape == (3, 718, 791)
+    finally:
+        src.close()
+
+
 def test_file_object_read_variant(rgb_file_object):
     """An example of reading from a FilePath object"""
     with rasterio.open(FilePath(rgb_file_object)) as src:


### PR DESCRIPTION
Closes #2360

Since the file FilePath doesn't actually handle opening/closing the file, I believe this is safe to do.

cc: @djhoese 