### PR TITLE
warn when reprojecting with RPCs using a source CRS that is not EPSG:4326

### DIFF
--- a/docs/topics/reproject.rst
+++ b/docs/topics/reproject.rst
@@ -211,7 +211,7 @@ reference system with a newly computed geotransform.
     When reprojecting a dataset with gcps or rpcs, the src_crs parameter should
     be supplied with the coordinate reference system that the gcps or rpcs are
     referenced against. By definition rpcs are always referenced against WGS84
-    ellipsoid with geographic coordinates (EPSG:4326).
+    ellipsoid with geographic coordinates (EPSG:4326) [2]_.
 
 
 
@@ -219,3 +219,4 @@ References
 ----------
 
 .. [1] https://docs.scipy.org/doc/scipy/reference/generated/scipy.ndimage.geometric_transform.html#scipy.ndimage.geometric_transform
+.. [2] http://geotiff.maptools.org/rpc_prop.html

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -62,6 +62,9 @@ class NotGeoreferencedWarning(UserWarning):
 class TransformWarning(UserWarning):
     """Warn that coordinate transformations may behave unexpectedly"""
 
+class RPCError(ValueError):
+    """Raised when RPC transformation is invalid"""
+
 
 class ShapeSkipWarning(UserWarning):
     """Warn that an invalid or empty shape in a collection has been skipped"""

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -60,7 +60,7 @@ class NotGeoreferencedWarning(UserWarning):
 
 
 class TransformWarning(UserWarning):
-    """Error raised when a GDALRPCTransform or GDALGCPTransform call fails."""
+    """Warn that coordinate transformations may behave unexpectedly"""
 
 
 class ShapeSkipWarning(UserWarning):

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -13,7 +13,7 @@ with rasterio._loading.add_gdal_dll_directories():
     from rasterio._base import _transform
     from rasterio.enums import Resampling
     from rasterio.env import GDALVersion, ensure_env, require_gdal_version
-    from rasterio.errors import GDALBehaviorChangeException, TransformError, TransformWarning
+    from rasterio.errors import GDALBehaviorChangeException, TransformError, RPCError
     from rasterio.transform import array_bounds
     from rasterio._warp import (
         _calculate_default_transform,
@@ -313,14 +313,14 @@ def reproject(source, destination=None, src_transform=None, gcps=None, rpcs=None
 
             src_crs = src_crs or src_rdr.crs
 
-            # warn against reprojecting with rpcs using a CRS that is not EPSG:4326
+            # raise exception when reprojecting with rpcs using a CRS that is not EPSG:4326
             if rpcs:
                 if isinstance(src_crs, str):
                     src_crs_obj = rasterio.crs.CRS.from_string(src_crs)
                 else:
                     src_crs_obj = src_crs
                 if src_crs is not None and src_crs_obj.to_epsg() != 4326:
-                    warnings.warn("Reprojecting with rational polynomial coefficients using source CRS other than EPSG:4326", TransformWarning)
+                    raise RPCError("Reprojecting with rational polynomial coefficients using source CRS other than EPSG:4326")
 
             if isinstance(src_bidx, int):
                 src_bidx = [src_bidx]

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -1,6 +1,7 @@
 """Raster warping and reprojection."""
 
 from math import ceil, floor
+import warnings
 
 from affine import Affine
 import numpy as np
@@ -12,7 +13,7 @@ with rasterio._loading.add_gdal_dll_directories():
     from rasterio._base import _transform
     from rasterio.enums import Resampling
     from rasterio.env import GDALVersion, ensure_env, require_gdal_version
-    from rasterio.errors import GDALBehaviorChangeException, TransformError
+    from rasterio.errors import GDALBehaviorChangeException, TransformError, TransformWarning
     from rasterio.transform import array_bounds
     from rasterio._warp import (
         _calculate_default_transform,
@@ -312,12 +313,21 @@ def reproject(source, destination=None, src_transform=None, gcps=None, rpcs=None
 
             src_crs = src_crs or src_rdr.crs
 
+            # warn against reprojecting with rpcs using a CRS that is not EPSG:4326
+            if rpcs:
+                if isinstance(src_crs, str):
+                    src_crs_obj = rasterio.crs.CRS.from_user_input(src_crs)
+                else:
+                    src_crs_obj = src_crs
+                if src_crs is not None and src_crs_obj.to_epsg() != 4326:
+                    warnings.warn("Reprojecting with rational polynomial coefficients using source CRS other than EPSG:4326", TransformWarning)
+
             if isinstance(src_bidx, int):
                 src_bidx = [src_bidx]
 
             src_count = len(src_bidx)
             src_height, src_width = src_shape
-            gcps = src_rdr.gcps[0] if src_rdr.gcps[0] else None
+            gcps = src_rdr.gcps[0] if src_rdr.gcps[0] and not rpcs else None
 
         dst_height = None
         dst_width = None

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -316,7 +316,7 @@ def reproject(source, destination=None, src_transform=None, gcps=None, rpcs=None
             # warn against reprojecting with rpcs using a CRS that is not EPSG:4326
             if rpcs:
                 if isinstance(src_crs, str):
-                    src_crs_obj = rasterio.crs.CRS.from_user_input(src_crs)
+                    src_crs_obj = rasterio.crs.CRS.from_string(src_crs)
                 else:
                     src_crs_obj = src_crs
                 if src_crs is not None and src_crs_obj.to_epsg() != 4326:

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -19,7 +19,7 @@ from rasterio.errors import (
     CRSError,
     GDALVersionError,
     TransformError,
-    TransformWarning,
+    RPCError,
     WarpOperationError,
 )
 from rasterio.warp import (
@@ -2026,8 +2026,8 @@ def test_reproject_error_propagation(http_error_server, caplog):
     assert len([rec for rec in caplog.records if "Retrying again" in rec.message]) == 2
 
 
-def test_rpcs_warn_non_epsg4326():
-    with pytest.warns(TransformWarning):
+def test_rpcs_non_epsg4326():
+    with pytest.raises(RPCError):
         with rasterio.open('tests/data/RGB.byte.rpc.vrt') as src:
             src_rpcs = src.rpcs
             reproject(

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -19,6 +19,7 @@ from rasterio.errors import (
     CRSError,
     GDALVersionError,
     TransformError,
+    TransformWarning,
     WarpOperationError,
 )
 from rasterio.warp import (
@@ -2023,3 +2024,16 @@ def test_reproject_error_propagation(http_error_server, caplog):
             )
 
     assert len([rec for rec in caplog.records if "Retrying again" in rec.message]) == 2
+
+
+def test_rpcs_warn_non_epsg4326():
+    with pytest.warns(TransformWarning):
+        with rasterio.open('tests/data/RGB.byte.rpc.vrt') as src:
+            src_rpcs = src.rpcs
+            reproject(
+                rasterio.band(src, src.indexes),
+                src_crs="EPSG:3857",
+                rpcs=src_rpcs,
+                dst_crs="EPSG:4326",
+                resampling=Resampling.nearest,
+            )


### PR DESCRIPTION
closes #2362 

Also fixes a usage issue when passing `src_rpcs` with a dataset that also has gcps
