### PR TITLE
rasterio.open returns a dataset object for all kinds of input

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,8 @@ New features:
 
 Bug fixes:
 
+- rasterio.open returns a dataset accessor and never a
+  ontextlib._GeneratorContextManager for all kinds of input (#2360).
 - Fix the "adjust" keyword argument of rasterio.plot.show (#2359).
 - Preserve origin when scaling in creating a WarpedVRT (#2364).
 - Exceptions are no longer raised for a category of errors emitted from

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -17,7 +17,7 @@ New features:
 Bug fixes:
 
 - rasterio.open returns a dataset accessor and never a
-  ontextlib._GeneratorContextManager for all kinds of input (#2360).
+  contextlib._GeneratorContextManager for all kinds of input (#2360).
 - Fix the "adjust" keyword argument of rasterio.plot.show (#2359).
 - Preserve origin when scaling in creating a WarpedVRT (#2364).
 - Exceptions are no longer raised for a category of errors emitted from

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -201,10 +201,7 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
         else:
             memfile = MemoryFile(fp.read())
             dataset = memfile.open(driver=driver, sharing=sharing)
-            ctxstack = ExitStack()
-            ctxstack.enter_context(env_ctx_if_needed())
-            ctxstack.enter_context(memfile)
-            dataset._env = ctxstack
+            dataset._env.enter_context(memfile)
             return dataset
 
     elif mode in ('w', 'w+') and hasattr(fp, 'write'):
@@ -221,9 +218,7 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
             sharing=sharing,
             **kwargs
         )
-        ctxstack = ExitStack()
-        ctxstack.enter_context(env_ctx_if_needed())
-        ctxstack.enter_context(memfile)
+        dataset._env.enter_context(memfile)
 
         # For the writing case we push an extra callback onto the
         # ExitStack. It ensures that the MemoryFile's contents are
@@ -232,8 +227,7 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
             memfile.seek(0)
             fp.write(memfile.read())
 
-        ctxstack.callback(func)
-        dataset._env = ctxstack
+        dataset._env.callback(func)
         return dataset
 
     # TODO: test for a shared base class or abstract type.

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -197,10 +197,10 @@ def open(fp, mode='r', driver=None, width=None, height=None, count=None,
     # storage will be cleaned up.
     if mode == 'r' and hasattr(fp, 'read'):
         if have_vsi_plugin:
-            return FilePath(fp).open(driver=driver, sharing=sharing)
+            return FilePath(fp).open(driver=driver, sharing=sharing, **kwargs)
         else:
             memfile = MemoryFile(fp.read())
-            dataset = memfile.open(driver=driver, sharing=sharing)
+            dataset = memfile.open(driver=driver, sharing=sharing, **kwargs)
             dataset._env.enter_context(memfile)
             return dataset
 

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -3,6 +3,7 @@
 """Numpy-free base classes."""
 
 from collections import defaultdict
+from contextlib import ExitStack
 import logging
 import math
 import os
@@ -22,7 +23,6 @@ from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
 from rasterio.enums import (
     ColorInterp, Compression, Interleaving, MaskFlags, PhotometricInterp)
-from rasterio.env import Env, env_ctx_if_needed
 from rasterio.errors import (
     DatasetAttributeError,
     RasterioIOError, CRSError, DriverRegistrationError, NotGeoreferencedWarning,
@@ -326,6 +326,8 @@ cdef class DatasetBase:
         self._read = False
 
         self._set_attrs_from_dataset_handle()
+        self._env = ExitStack()
+        self._closed = False
 
     def __repr__(self):
         return "<%s DatasetBase name='%s' mode='%s'>" % (
@@ -347,7 +349,6 @@ cdef class DatasetBase:
         # touch self.meta, triggering data type evaluation.
         _ = self.meta
 
-        self._closed = False
         log.debug("Dataset %r is started.", self)
 
     cdef GDALDatasetH handle(self) except NULL:
@@ -433,14 +434,10 @@ cdef class DatasetBase:
     def close(self):
         """Close the dataset and unwind attached exit stack."""
         self.stop()
+        self._env.close()
         self._closed = True
-        if self._env is not None:
-            self._env.__exit__(None, None, None)
 
     def __enter__(self):
-        if self._env is None:
-            self._env = env_ctx_if_needed()
-        self._env.__enter__()
         return self
 
     def __exit__(self, *exc_details):

--- a/rasterio/_io.pxd
+++ b/rasterio/_io.pxd
@@ -27,6 +27,7 @@ cdef class MemoryDataset(DatasetWriterBase):
 
 cdef class MemoryFileBase:
     cdef VSILFILE * _vsif
+    cdef public object _env
 
 
 ctypedef np.uint8_t DTYPE_UBYTE_t

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -4,7 +4,7 @@
 
 from enum import Enum, IntEnum
 from collections import Counter
-from contextlib import contextmanager
+from contextlib import contextmanager, ExitStack
 import logging
 import os
 import sys
@@ -1135,6 +1135,7 @@ cdef class MemoryFileBase:
         if self._vsif == NULL:
             raise IOError("Failed to open in-memory file.")
 
+        self._env = ExitStack()
         self.closed = False
 
     def exists(self):
@@ -1463,9 +1464,8 @@ cdef class DatasetWriterBase(DatasetReaderBase):
 
         self._transform = self.read_transform()
         self._crs = self.read_crs()
-
-        # touch self.meta
         _ = self.meta
+        self._env = ExitStack()
         self._closed = False
 
     def __repr__(self):
@@ -2169,8 +2169,8 @@ cdef class BufferedDatasetWriterBase(DatasetWriterBase):
         if options != NULL:
             CSLDestroy(options)
 
-        # touch self.meta
         _ = self.meta
+        self._env = ExitStack()
         self._closed = False
 
     def stop(self):

--- a/rasterio/_transform.pyx
+++ b/rasterio/_transform.pyx
@@ -4,6 +4,7 @@
 
 include "gdal.pxi"
 
+from contextlib import ExitStack
 import logging
 import warnings
 
@@ -124,6 +125,8 @@ cdef class RPCTransformerBase:
             CSLDestroy(options)
             CSLDestroy(papszMD)
 
+        self._env = ExitStack()
+
     def _transform(self, xs, ys, zs, transform_direction):
         """
         General computation of dataset pixel/line <-> lon/lat/height coordinates using RPCs
@@ -222,6 +225,7 @@ cdef class RPCTransformerBase:
         """
         return self._closed
 
+
 cdef class GCPTransformerBase:
     cdef void *_transformer
     cdef bint _closed
@@ -267,6 +271,8 @@ cdef class GCPTransformerBase:
             self._closed = False
         finally:
             CPLFree(gcplist)
+
+        self._env = ExitStack()
 
     def _transform(self, xs, ys, zs, transform_direction):
         """

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -4,6 +4,7 @@
 
 from collections import UserDict
 from collections.abc import Mapping
+from contextlib import ExitStack
 import logging
 import uuid
 import warnings
@@ -1187,6 +1188,9 @@ cdef class WarpedVRTReaderBase(DatasetReaderBase):
 
         if dst_alpha and len(self._nodatavals) == 3:
             self._nodatavals[dst_alpha - 1] = None
+
+        self._env = ExitStack()
+        self._closed = False
 
     @property
     def crs(self):

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -365,11 +365,6 @@ class NullContextManager:
         pass
 
 
-def dataset_exit_stack():
-    stack = ExitStack()
-    return stack
-
-
 def env_ctx_if_needed():
     """Return an Env if one does not exist
 

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -1,6 +1,6 @@
 """Rasterio's GDAL/AWS environment"""
 
-import attr
+from contextlib import ExitStack
 from functools import wraps, total_ordering
 from inspect import getfullargspec as getargspec
 import logging
@@ -8,6 +8,8 @@ import os
 import re
 import threading
 import warnings
+
+import attr
 
 import rasterio._loading
 with rasterio._loading.add_gdal_dll_directories():
@@ -361,6 +363,11 @@ class NullContextManager:
 
     def __exit__(self, *args):
         pass
+
+
+def dataset_exit_stack():
+    stack = ExitStack()
+    return stack
 
 
 def env_ctx_if_needed():

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -13,7 +13,7 @@ with rasterio._loading.add_gdal_dll_directories():
         DatasetReaderBase, DatasetWriterBase, BufferedDatasetWriterBase,
         MemoryFileBase)
     from rasterio.windows import WindowMethodsMixin
-    from rasterio.env import ensure_env, env_ctx_if_needed
+    from rasterio.env import ensure_env
     from rasterio.transform import TransformMethodsMixin
     from rasterio.path import UnparsedPath
     try:
@@ -143,13 +143,10 @@ class MemoryFile(MemoryFileBase):
                           nodata=nodata, sharing=sharing, **kwargs)
 
     def __enter__(self):
-        self._env = env_ctx_if_needed()
-        self._env.__enter__()
         return self
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, *args):
         self.close()
-        self._env.__exit__()
 
 
 class _FilePath(FilePathBase):
@@ -222,13 +219,10 @@ class _FilePath(FilePathBase):
         return DatasetReader(mempath, driver=driver, sharing=sharing, **kwargs)
 
     def __enter__(self):
-        self._env = env_ctx_if_needed()
-        self._env.__enter__()
         return self
 
-    def __exit__(self, *args, **kwargs):
+    def __exit__(self, *args):
         self.close()
-        self._env.__exit__()
 
 
 if FilePathBase is not object:

--- a/rasterio/vrt.py
+++ b/rasterio/vrt.py
@@ -8,7 +8,6 @@ with rasterio._loading.add_gdal_dll_directories():
     from rasterio._warp import WarpedVRTReaderBase
     from rasterio.dtypes import _gdal_typename
     from rasterio.enums import MaskFlags
-    from rasterio.env import env_ctx_if_needed
     from rasterio.path import parse_path
     from rasterio.transform import TransformMethodsMixin
     from rasterio.windows import WindowMethodsMixin
@@ -112,17 +111,16 @@ class WarpedVRT(WarpedVRTReaderBase, WindowMethodsMixin,
             self.closed and 'closed' or 'open', self.name, self.mode)
 
     def __enter__(self):
-        self._env = env_ctx_if_needed()
-        self._env.__enter__()
         self.start()
         return self
 
     def __exit__(self, *args, **kwargs):
-        self._env.__exit__()
-        self.close()
+        if not self._closed:
+            self.close()
 
     def __del__(self):
-        self.close()
+        if not self._closed:
+            self.close()
 
 
 def _boundless_vrt_doc(

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -172,13 +172,53 @@ def test_read(tmpdir, rgb_file_bytes):
         assert src.count == 3
 
 
-def test_file_object_read(rgb_file_object):
-    """An example of reading from a file object"""
+@pytest.mark.skipif(not rasterio.have_vsi_plugin, reason="Test requires FilePath")
+def test_file_object_read_filepath(monkeypatch, request, capfd, rgb_file_object):
+    """Opening a file object with FilePath returns a dataset with no attached MemoryFile."""
     with rasterio.open(rgb_file_object) as src:
         assert src.driver == 'GTiff'
         assert src.count == 3
         assert src.dtypes == ('uint8', 'uint8', 'uint8')
         assert src.read().shape == (3, 718, 791)
+
+
+def test_file_object_read_memfile(monkeypatch, request, capfd, rgb_file_object):
+    """Opening a file object without FilePath returns a dataset with attached MemoryFile."""
+    monkeypatch.setattr(rasterio, "have_vsi_plugin", False)
+    with rasterio.Env() as env:
+        with rasterio.open(rgb_file_object) as src:
+            assert src.driver == 'GTiff'
+            assert src.count == 3
+            assert src.dtypes == ('uint8', 'uint8', 'uint8')
+            assert src.read().shape == (3, 718, 791)
+
+        # Exiting src causes the attached MemoryFile context to be
+        # exited and the temporary in-memory file is deleted.
+        env._dump_open_datasets()
+        captured = capfd.readouterr()
+        assert "/vsimem/{}".format(request.node.name) not in captured.err
+
+
+def test_issue2360_no_with(monkeypatch, request, capfd, rgb_file_object):
+    """Opening a file object without FilePath returns a dataset with attached MemoryFile."""
+    monkeypatch.setattr(rasterio, "have_vsi_plugin", False)
+    with rasterio.Env() as env:
+        src = rasterio.open(rgb_file_object)
+        assert src.driver == 'GTiff'
+        assert src.count == 3
+        assert src.dtypes == ('uint8', 'uint8', 'uint8')
+        assert src.read().shape == (3, 718, 791)
+
+        env._dump_open_datasets()
+        captured = capfd.readouterr()
+        assert "/vsimem/{}".format(request.node.name) in captured.err
+
+        # Closing src causes the attached MemoryFile context to be
+        # exited and the temporary in-memory file is deleted.
+        src.close()
+        env._dump_open_datasets()
+        captured = capfd.readouterr()
+        assert "/vsimem/{}".format(request.node.name) not in captured.err
 
 
 def test_file_object_read_variant(rgb_file_bytes):
@@ -211,18 +251,6 @@ def test_test_file_object_write(tmpdir, rgb_data_and_profile):
         assert src.count == 3
         assert src.dtypes == ('uint8', 'uint8', 'uint8')
         assert src.read().shape == (3, 718, 791)
-
-
-def test_nonpersistemt_memfile_fail_example(rgb_data_and_profile):
-    """An example of writing to a file object"""
-    data, profile = rgb_data_and_profile
-    with BytesIO() as fout:
-        with rasterio.open(fout, 'w', **profile) as dst:
-            dst.write(data)
-
-        # This fails because the MemoryFile created in open() is
-        # gone.
-        rasterio.open(fout)
 
 
 def test_zip_closed():


### PR DESCRIPTION
Resolves #2360.

We already had an optional context manager attached to our dataset objects, see https://github.com/rasterio/rasterio/pull/2371/files#diff-9729b3413c39ccb6eea16562e513703922f21d4d94a3e27980926dd01a0c5068L445. I've replaced it in the `have_vsi_plugin=False` case with an ExitStack. First time I've used ExitStack in the implementation of a library. Seems to do the trick.

As pointed out, this is in some ways an API change, but I consider it most of all a bug fix, and not something that requires a new version.