### PR TITLE
Remove type specific precision behavior of rowcol

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -354,10 +354,10 @@ class TransformerBase():
         
         if precision is None:
             eps = sys.float_info.epsilon
-        elif isinstance(precision, int) and precision > 0:
-            eps = 10.0 ** -precision
+        elif precision > 1:
+            eps = 10.0 ** -int(precision)
         else:
-            eps = precision
+            raise ValueError("Precision must be a positive integer or None")
         
         # If op rounds up, switch the sign of eps.
         if op(0.1) >= 1:

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -354,7 +354,7 @@ class TransformerBase():
         
         if precision is None:
             eps = sys.float_info.epsilon
-        elif isinstance(precision, int):
+        elif isinstance(precision, int) and precision > 0:
             eps = 10.0 ** -precision
         else:
             eps = precision

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -354,7 +354,7 @@ class TransformerBase():
         
         if precision is None:
             eps = sys.float_info.epsilon
-        elif precision > 1:
+        elif precision >= 1:
             eps = 10.0 ** -int(precision)
         else:
             raise ValueError("Precision must be a positive integer or None")

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -266,6 +266,20 @@ def test_rowcol():
         assert rowcol(aff, 101985.0, 2826915.0) == (0, 0)
 
 
+def test_rowcol_precision():
+    t = transform.from_origin(0, 0, 1, 1)
+
+    with pytest.raises(ValueError):
+        # make sure 0 and 0.0 produce same results
+        assert rowcol(t, 1, 1, precision=0.0)
+    
+    # Make sure that float/int of same value produce same result
+    assert rowcol(t, 1, 1, precision=5.0) == rowcol(t, 1, 1, precision=5)
+
+    # Make sure that floats are coerced to ints
+    assert rowcol(t, 1, 1, precision=5.3) == rowcol(t, 1, 1, precision=5)
+    
+
 @pytest.mark.parametrize(
     "xs, ys, exp_rowcol",
     [


### PR DESCRIPTION
The original code could produce strange epsilons if negative or 0 values were used for precision.
This PR tightens the constraints on precision to make sure it is a positive number greater than 1. Floats are cast to int.

This "bug"manifested itself when I was using a precision of 0 and got different results if precision was an integer (eps=1.0) or float (eps = 0.0). Such type specific behavior would surely be surprising to any user of rasterio.

The eps formula of `10.0 ** -precision` really only seems to make sense with positive values of 1 or more. Any float values are now cast to int before computing eps. None still results in the system float epsilon