### PR TITLE
Update error message wording if a driver is not found

### DIFF
--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -267,7 +267,7 @@ class ZipMemoryFile(MemoryFile):
 def get_writer_for_driver(driver):
     """Return the writer class appropriate for the specified driver."""
     if not driver:
-        raise ValueError("'driver' is required to write dataset.")
+        raise ValueError("'driver' is required to read/write dataset.")
     cls = None
     if driver_can_create(driver):
         cls = DatasetWriter


### PR DESCRIPTION
There can be cases where the get_writer_for_driver function is reached when a file is being opened, hence adding note about read/write in the ValueError.