### PR TITLE
Catch overflows in from_epsg and raise CRSError (#2394)

### DIFF
--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -346,7 +346,11 @@ class CRS(Mapping):
 
         """
         obj = cls()
-        obj._crs = _CRS.from_epsg(code)
+
+        try:
+            obj._crs = _CRS.from_epsg(code)
+        except OverflowError as err:
+            raise CRSError(f"could not convert EPSG code to int: {err}") from err
         return obj
 
     @classmethod
@@ -571,7 +575,7 @@ def epsg_treats_as_northingeasting(input):
     > Important change of behavior since GDAL 3.0.
     In previous versions, projected CRS with northing, easting axis order
     imported with importFromEPSG() would cause this method to return FALSE
-    on them, whereas now it returns TRUE, since importFromEPSG() is now 
+    on them, whereas now it returns TRUE, since importFromEPSG() is now
     equivalent to importFromEPSGA().
 
     Parameters

--- a/rasterio/crs.py
+++ b/rasterio/crs.py
@@ -350,7 +350,7 @@ class CRS(Mapping):
         try:
             obj._crs = _CRS.from_epsg(code)
         except OverflowError as err:
-            raise CRSError(f"could not convert EPSG code to int: {err}") from err
+            raise CRSError(f"Not in the range of valid EPSG codes: {code}") from err
         return obj
 
     @classmethod

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -162,6 +162,12 @@ def test_from_epsg_string():
         assert CRS.from_string('epsg:xyz')
 
 
+def test_from_epsg_overflow():
+    with pytest.raises(CRSError):
+        # the argument is large enough to cause an overflow in Cython
+        CRS.from_epsg(1111111111111111111111)
+
+
 def test_from_string():
     wgs84_crs = CRS.from_string('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
     assert wgs84_crs.to_dict() == {'init': 'epsg:4326'}


### PR DESCRIPTION
This fixes #2394. Catching `OverflowError` in Cython in `crs.pyx` somehow didn't work (`OverflowError` was still raised in Python), so I caught it in Python instead.

The test passes a large enough argument to `from_epsg` to cause an `OverflowError`. Not sure if it's needed.

Edit: sorry about the unrelated removed space on line 578, I have VSCode configured to remove trailing spaces.