### PR TITLE
fix RPC metadata parsing

### DIFF
--- a/rasterio/rpc.py
+++ b/rasterio/rpc.py
@@ -93,16 +93,16 @@ class RPC:
         out = {}
 
         for key, val in rpcs.items():
-            vals = val.split()
+            vals = []
+            for v in val.split():
+                try:
+                    vals.append(float(v))
+                except ValueError:
+                    pass
             if len(vals) > 1:
-                out[key] = []
-                for v in vals:
-                    try:
-                        out[key] = float(v)
-                    except ValueError:
-                        pass
+                out[key] = vals
             else:
-                out[key] = float(vals[0])
+                out[key] = vals[0]
 
         return cls(
             err_bias=out.get("ERR_BIAS"),

--- a/rasterio/rpc.py
+++ b/rasterio/rpc.py
@@ -95,7 +95,12 @@ class RPC:
         for key, val in rpcs.items():
             vals = val.split()
             if len(vals) > 1:
-                out[key] = [float(v) for v in vals]
+                out[key] = []
+                for v in vals:
+                    try:
+                        out[key] = float(v)
+                    except ValueError:
+                        pass
             else:
                 out[key] = float(vals[0])
 


### PR DESCRIPTION
We have a RPC referenced file from a customer with tags that cause a `ValueError` when calling rasterio `src.rpcs`:

```
$ gdalinfo foo.tif
...
RPC Metadata:
  HEIGHT_OFF=482.50 meters
  HEIGHT_SCALE=397.45 meters
  LAT_OFF=26.80851366 degrees
  LAT_SCALE=0.08428740 degrees
...
```
Obviously the units are not expected here but using `gdalwarp` seems to be fault tolerant as it can warp the file correctly.

This PR fixes this behavior but I don't have a small enough example image to add a test case. Is this an issue?

