### PR TITLE
Fix ignored z values when using transform mixin methods with rpcs

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -71,7 +71,7 @@ class TransformMethodsMixin:
             transform = transform[0]
         if not transform:
             raise AttributeError("Dataset has no {}".format(transform_method))
-        return xy(transform, row, col, z=z, offset=offset, **rpc_options)
+        return xy(transform, row, col, zs=z, offset=offset, **rpc_options)
 
     def index(self, x, y, z=None, op=math.floor, precision=None, transform_method=TransformMethod.affine, **rpc_options):
         """
@@ -111,7 +111,7 @@ class TransformMethodsMixin:
             transform = transform[0]
         if not transform:
             raise AttributeError("Dataset has no {}".format(transform_method))
-        return rowcol(transform, x, y, z=z, op=op, precision=precision, **rpc_options)
+        return rowcol(transform, x, y, zs=z, op=op, precision=precision, **rpc_options)
 
 def get_transformer(transform, **rpc_options):
     """Return the appropriate transformer class"""

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -401,3 +401,11 @@ def test_dataset_mixins(dataset, transform_method, expected):
     with rasterio.open(dataset) as src:
         assert src.xy(0, 0, transform_method=transform_method) == pytest.approx(expected)
         assert src.index(*expected, transform_method=transform_method) == (0, 0)
+
+def test_2421_rpc_height_ignored():
+    transform_method = rasterio.enums.TransformMethod.rpcs
+    with rasterio.open("tests/data/RGB.byte.rpc.vrt") as src:
+        x1, y1 = src.xy(0, 0, z=0, transform_method=transform_method)
+        x2, y2 = src.xy(0, 0, z=2000, transform_method=transform_method)
+        assert abs(x2 - x1) > 0
+        assert abs(y2 - y1) > 0


### PR DESCRIPTION
closes #2421 