### PR TITLE
No more epsilon usage in transform.rowcol and window.from_bounds

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,10 @@ Changes
 
 Deprecations:
 
+- The precision keyword arguments of methods in rasterio.transform,
+  rasterio.windows, and rasterio.merge are unused and will be removed in
+  version 2.0. The --precision option of rio-merge is similarly deprecated
+  (#2432).
 - The rasterio.path module will be removed in version 1.4 and a deprecation
   warning is issued when the module is imported (#2423).
 

--- a/Makefile
+++ b/Makefile
@@ -31,7 +31,7 @@ dockertestimage:
 	docker build --build-arg GDAL=$(GDAL) --target gdal -t rasterio:$(GDAL) .
 
 dockertest: dockertestimage
-	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL) -c '/venv/bin/python setup.py develop && /venv/bin/python -B -m pytest -rP -m "not wheel" --cov rasterio --cov-report term-missing $(OPTS)'
+	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL) -c '/venv/bin/python setup.py develop && /venv/bin/python -B -m pytest -m "not wheel" --cov rasterio --cov-report term-missing $(OPTS)'
 
 dockersdist: dockertestimage
 	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL) -c '/venv/bin/python setup.py sdist'

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -15,6 +15,7 @@ with rasterio._loading.add_gdal_dll_directories():
     import rasterio
     from rasterio.coords import disjoint_bounds
     from rasterio.enums import Resampling
+    from rasterio.errors import RasterioDeprecationWarning
     from rasterio import windows
     from rasterio.transform import Affine
 
@@ -108,8 +109,9 @@ def merge(
     dtype: numpy dtype or string
         dtype to use in outputfile. If not set, uses the dtype value in the
         first input raster.
-    precision: float, optional
-        Number of decimal points of precision when computing inverse transform.
+    precision: int, optional
+        This parameters is unused, deprecated in rasterio 1.3.0, and
+        will be removed in version 2.0.0.
     indexes : list of ints or a single int, optional
         bands to read and merge
     output_count: int, optional
@@ -164,6 +166,12 @@ def merge(
                 coordinate system
 
     """
+    if precision is not None:
+        warnings.warn(
+            "The precision parameter is unused, deprecated, and will be removed in 2.0.0.",
+            RasterioDeprecationWarning,
+        )
+
     if method in MERGE_METHODS:
         copyto = MERGE_METHODS[method]
     elif callable(method):
@@ -305,13 +313,11 @@ def merge(
             int_n = src_n if src_n < dst_n else dst_n
 
             # 2. Compute the source window
-            src_window = windows.from_bounds(
-                int_w, int_s, int_e, int_n, src.transform, precision=precision
-            )
+            src_window = windows.from_bounds(int_w, int_s, int_e, int_n, src.transform)
 
             # 3. Compute the destination window
             dst_window = windows.from_bounds(
-                int_w, int_s, int_e, int_n, output_transform, precision=precision
+                int_w, int_s, int_e, int_n, output_transform
             )
 
             # 4. Read data in source window into temp

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -1,11 +1,21 @@
 """$ rio merge"""
 
+import warnings
 
 import click
 
 from rasterio.enums import Resampling
+from rasterio.errors import RasterioDeprecationWarning
 from rasterio.rio import options
 from rasterio.rio.helpers import resolve_inout
+
+
+def deprecated_precision(*args):
+    warnings.warn(
+        "The --precision option is unused, deprecated, and will be removed in 2.0.0.",
+        RasterioDeprecationWarning,
+    )
+    return None
 
 
 @click.command(short_help="Merge a stack of raster datasets.")
@@ -25,7 +35,8 @@ from rasterio.rio.helpers import resolve_inout
     "--precision",
     type=int,
     default=None,
-    help="Number of decimal places of precision in alignment of pixels",
+    callback=deprecated_precision,
+    help="Unused, deprecated, and will be removed in 2.0.0.",
 )
 @options.creation_options
 @click.pass_context
@@ -49,6 +60,7 @@ def merge(ctx, files, output, driver, bounds, res, resampling,
     \b
       --res 0.1 0.1  => --res 0.1 (square)
       --res 0.1 0.2  => --res 0.1 --res 0.2  (rectangular)
+
     """
     from rasterio.merge import merge as merge_tool
 
@@ -63,7 +75,6 @@ def merge(ctx, files, output, driver, bounds, res, resampling,
             bounds=bounds,
             res=res,
             nodata=nodata,
-            precision=precision,
             indexes=(bidx or None),
             resampling=resampling,
             dst_path=output,

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -280,10 +280,7 @@ def from_bounds(
         Top (north) bounding coordinates
     transform: Affine, required
         Affine transform matrix.
-    precision: int or float, optional
-        An integer number of decimal points of precision when computing
-        inverse transform, or an absolute float precision.
-    height, width: int, optional
+    precision, height, width: int, optional
         These parameters are unused, deprecated in rasterio 1.3.0, and
         will be removed in version 2.0.0.
 
@@ -318,7 +315,6 @@ def from_bounds(
         [left, right, right, left],
         [top, top, bottom, bottom],
         op=float,
-        precision=precision,
     )
     row_start, row_stop = min(rows), max(rows)
     col_start, col_stop = min(cols), max(cols)
@@ -729,7 +725,7 @@ class Window:
         Window
 
         """
-        operator = lambda x: int(math.floor(x + 0.1))
+        operator = lambda x: int(math.floor(x + 0.001))
         row_off = operator(self.row_off)
         col_off = operator(self.col_off)
         return Window(col_off, row_off, self.width, self.height)

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -39,7 +39,8 @@ class WindowMethodsMixin:
     `rasterio.windows` module.
 
     A subclass with this mixin MUST provide the following
-    properties: `transform`, `height` and `width`
+    properties: `transform`, `height` and `width`.
+
     """
 
     def window(self, left, bottom, right, top, precision=None):
@@ -59,17 +60,30 @@ class WindowMethodsMixin:
         top: float
             Top (north) bounding coordinate
         precision: int, optional
-            Number of decimal points of precision when computing inverse
-            transform.
+            This parameters is unused, deprecated in rasterio 1.3.0, and
+            will be removed in version 2.0.0.
 
         Returns
         -------
         window: Window
+
         """
+        if precision is not None:
+            warnings.warn(
+                "The precision parameter is unused, deprecated, and will be removed in 2.0.0.",
+                RasterioDeprecationWarning,
+            )
+
         transform = guard_transform(self.transform)
         return from_bounds(
-            left, bottom, right, top, transform=transform,
-            height=self.height, width=self.width, precision=precision)
+            left,
+            bottom,
+            right,
+            top,
+            transform=transform,
+            height=self.height,
+            width=self.width,
+        )
 
     def window_transform(self, window):
         """Get the affine transform for a dataset window.
@@ -83,8 +97,8 @@ class WindowMethodsMixin:
         -------
         transform: Affine
             The affine transform matrix for the given window
-        """
 
+        """
         gtransform = guard_transform(self.transform)
         return transform(window, gtransform)
 
@@ -100,8 +114,8 @@ class WindowMethodsMixin:
         -------
         bounds : tuple
             x_min, y_min, x_max, y_max for the given window
-        """
 
+        """
         transform = guard_transform(self.transform)
         return bounds(window, transform)
 
@@ -295,20 +309,18 @@ def from_bounds(
         If a window can't be calculated.
 
     """
-    if not isinstance(transform, Affine):  # TODO: RPCs?
-        raise WindowError("A transform object is required to calculate the window")
-
-    if (right - left) / transform.a < 0:
-        raise WindowError("Bounds and transform are inconsistent")
-
-    if (bottom - top) / transform.e < 0:
-        raise WindowError("Bounds and transform are inconsistent")
-
-    if height is not None or width is not None:
+    if height is not None or width is not None or precision is not None:
         warnings.warn(
-            "The height and width parameters are unused, deprecated, and will be removed in Rasterio 2.0.0.",
+            "The height, width, and precision parameters are unused, deprecated, and will be removed in 2.0.0.",
             RasterioDeprecationWarning,
         )
+
+    if not isinstance(transform, Affine):  # TODO: RPCs?
+        raise WindowError("A transform object is required to calculate the window")
+    if (right - left) / transform.a < 0:
+        raise WindowError("Bounds and transform are inconsistent")
+    if (bottom - top) / transform.e < 0:
+        raise WindowError("Bounds and transform are inconsistent")
 
     rows, cols = rowcol(
         transform,
@@ -341,9 +353,9 @@ def transform(window, transform):
     -------
     Affine
         The affine transform matrix for the given window
+
     """
     window = evaluate(window, height=0, width=0)
-
     x, y = transform * (window.col_off or 0.0, window.row_off or 0.0)
     return Affine.translation(
         x - transform.c, y - transform.f) * transform

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -460,14 +460,13 @@ def test_merge_tiny_res_bounds(tiffs, runner):
 
     # Output should be
     # [[[120  90]
-    #   [60    0]]]
+    #   [40    0]]]
 
     with rasterio.open(outputname) as src:
         data = src.read()
-        print(data)
         assert data[0, 0, 0] == 120
         assert data[0, 0, 1] == 90
-        assert data[0, 1, 0] == 60
+        assert data[0, 1, 0] == 40
         assert data[0, 1, 1] == 0
 
 


### PR DESCRIPTION
Responsibility is on the caller (merge.merge).

Resolves #2374

The gist of it: https://github.com/rasterio/rasterio/pull/2432/commits/dcc9ef498c10b33231c3b81eecaaed2ccb677840#diff-59130575b4fb2932c957db2922977d7d89afb0b2085357db1a14615a2fcad776R12-R15