### PR TITLE
Produce slices that don't erronously select from an array

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -24,6 +24,9 @@ Changes:
 
 Bug fixes:
 
+- Erroneously overlapping slices (reported in #2378) are now prevented by
+  ensuring that slices indexes with negative values are always properly
+  referenced to the end of array dimmensions (#2434).
 - Prevent erroneous sign flip in a south-up dataset's res property (#2370).
 - Allow DatasetReader and DatasetWriter to take string filenames and URLs
   (#2426).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -25,8 +25,7 @@ Changes:
 Bug fixes:
 
 - Erroneously overlapping slices (reported in #2378) are now prevented by
-  ensuring that slices indexes with negative values are always properly
-  referenced to the end of array dimmensions (#2434).
+  ensuring that slice indexes with negative values are set to zero (#2434).
 - Prevent erroneous sign flip in a south-up dataset's res property (#2370).
 - Allow DatasetReader and DatasetWriter to take string filenames and URLs
   (#2426).

--- a/Dockerfile
+++ b/Dockerfile
@@ -8,7 +8,8 @@ WORKDIR /app
 COPY requirements*.txt ./
 RUN python3 -m venv /venv && \
     /venv/bin/python -m pip install -U pip && \
-    /venv/bin/python -m pip install -r requirements-dev.txt
+    /venv/bin/python -m pip install -r requirements-dev.txt && \
+    /venv/bin/python -m pip list
 
 FROM gdal
 COPY . .

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ dockertestimage:
 dockertest: dockertestimage
 	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL) -c '/venv/bin/python setup.py develop && /venv/bin/python -B -m pytest -m "not wheel" --cov rasterio --cov-report term-missing $(OPTS)'
 
+dockershell: dockertestimage
+	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL) -c '/venv/bin/python setup.py develop && /venv/bin/python'
+
 dockersdist: dockertestimage
 	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL) -c '/venv/bin/python setup.py sdist'
 

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -481,7 +481,7 @@ def window_index(window, height=0, width=0):
 
     """
     window = evaluate(window, height=height, width=width)
-    return window.toslices(shape=(height, width))
+    return window.toslices()
 
 
 def round_window_to_full_blocks(window, block_shapes, height=0, width=0):
@@ -587,13 +587,8 @@ class Window:
             (self.row_off, self.row_off + self.height),
             (self.col_off, self.col_off + self.width))
 
-    def toslices(self, shape=None):
+    def toslices(self):
         """Slice objects for use as an ndarray indexer.
-
-        Parameters
-        ----------
-        shape: tuple
-            The number of rows and cols of an array to be sliced.
 
         Returns
         -------
@@ -603,16 +598,14 @@ class Window:
         """
         (r0, r1), (c0, c1) = self.toranges()
 
-        if shape is not None:
-            height, width = shape
-            if r0 < 0:
-                r0 = r0 - height
-            if r1 < 0:
-                r1 = r1 - height
-            if c0 < 0:
-                c0 = c0 - width
-            if c1 < 0:
-                c1 = c1 - width
+        if r0 < 0:
+            r0 = 0
+        if r1 < 0:
+            r1 = 0
+        if c0 < 0:
+            c0 = 0
+        if c1 < 0:
+            c1 = 0
 
         return (
             slice(int(math.floor(r0)), int(math.ceil(r1))),

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -478,13 +478,10 @@ def window_index(window, height=0, width=0):
     -------
     row_slice, col_slice: slice
         A pair of slices in row, column order
+
     """
     window = evaluate(window, height=height, width=width)
-
-    (row_start, row_stop), (col_start, col_stop) = window.toranges()
-    return (
-        slice(int(math.floor(row_start)), int(math.ceil(row_stop))),
-        slice(int(math.floor(col_start)), int(math.ceil(col_stop))))
+    return window.toslices(shape=(height, width))
 
 
 def round_window_to_full_blocks(window, block_shapes, height=0, width=0):
@@ -590,15 +587,33 @@ class Window:
             (self.row_off, self.row_off + self.height),
             (self.col_off, self.col_off + self.width))
 
-    def toslices(self):
+    def toslices(self, shape=None):
         """Slice objects for use as an ndarray indexer.
+
+        Parameters
+        ----------
+        arr: ndarray
 
         Returns
         -------
         row_slice, col_slice: slice
             A pair of slices in row, column order
+
         """
-        return tuple(slice(*rng) for rng in self.toranges())
+        if shape is None:
+            return tuple(slice(*rng) for rng in self.toranges())
+        else:
+            height, width = shape
+            return (
+                slice(
+                    int(math.floor(self.row_off - height)),
+                    int(math.ceil(self.row_off - height + self.height)),
+                ),
+                slice(
+                    int(math.floor(self.col_off - width)),
+                    int(math.ceil(self.col_off - width + self.width)),
+                ),
+            )
 
     @classmethod
     def from_slices(cls, rows, cols, height=-1, width=-1, boundless=False):

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -592,7 +592,8 @@ class Window:
 
         Parameters
         ----------
-        arr: ndarray
+        shape: tuple
+            The number of rows and cols of an array to be sliced.
 
         Returns
         -------
@@ -600,20 +601,23 @@ class Window:
             A pair of slices in row, column order
 
         """
-        if shape is None:
-            return tuple(slice(*rng) for rng in self.toranges())
-        else:
+        (r0, r1), (c0, c1) = self.toranges()
+
+        if shape is not None:
             height, width = shape
-            return (
-                slice(
-                    int(math.floor(self.row_off - height)),
-                    int(math.ceil(self.row_off - height + self.height)),
-                ),
-                slice(
-                    int(math.floor(self.col_off - width)),
-                    int(math.ceil(self.col_off - width + self.width)),
-                ),
-            )
+            if r0 < 0:
+                r0 = r0 - height
+            if r1 < 0:
+                r1 = r1 - height
+            if c0 < 0:
+                c0 = c0 - width
+            if c1 < 0:
+                c1 = c1 - width
+
+        return (
+            slice(int(math.floor(r0)), int(math.ceil(r1))),
+            slice(int(math.floor(c0)), int(math.ceil(c1))),
+        )
 
     @classmethod
     def from_slices(cls, rows, cols, height=-1, width=-1, boundless=False):

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -105,25 +105,15 @@ def test_window_toranges(col_off, row_off, width, height):
 )
 def test_window_toslices(col_off, row_off, width, height, arr_width, arr_height):
     """window.toslices() should match inputs and be properly end indexed (see gh-2378)"""
-    row_slice, col_slice = Window(col_off, row_off, width, height).toslices(
-        shape=(arr_height, arr_width)
-    )
+    row_slice, col_slice = Window(col_off, row_off, width, height).toslices()
     assert isinstance(row_slice.start, int)
-    assert row_slice.start == int(math.floor(row_off)) or row_slice.start == int(
-        math.floor(row_off - arr_height)
-    )
+    assert row_slice.start == int(math.floor(row_off)) or row_slice.start == 0
     assert isinstance(row_slice.stop, int)
-    assert row_slice.stop == int(math.ceil(row_off + height)) or row_slice.stop == int(
-        math.ceil(row_off + height - arr_height)
-    )
+    assert row_slice.stop == int(math.ceil(row_off + height)) or row_slice.stop == 0
     assert isinstance(col_slice.start, int)
-    assert col_slice.start == int(math.floor(col_off)) or col_slice.start == int(
-        math.floor(col_off - arr_width)
-    )
+    assert col_slice.start == int(math.floor(col_off)) or col_slice.start == 0
     assert isinstance(col_slice.stop, int)
-    assert col_slice.stop == int(math.ceil(col_off + width)) or col_slice.stop == int(
-        math.ceil(col_off + width - arr_width)
-    )
+    assert col_slice.stop == int(math.ceil(col_off + width)) or col_slice.stop == 0
 
 
 @settings(suppress_health_check=[HealthCheck.filter_too_much])

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -95,18 +95,34 @@ def test_window_toranges(col_off, row_off, width, height):
 
 
 @settings(suppress_health_check=[HealthCheck.filter_too_much])
-@given(col_off=F_OFF, row_off=F_OFF, width=F_LEN, height=F_LEN)
-def test_window_toslices(col_off, row_off, width, height):
-    """window.toslices() should match inputs"""
-
-    expected_slices = (slice(row_off, row_off + height),
-                       slice(col_off, col_off + width))
-
-    slices = Window(col_off, row_off, width, height).toslices()
-
-    assert np.allclose(
-        [(s.start, s.stop) for s in slices],
-        [(s.start, s.stop) for s in expected_slices]
+@given(
+    col_off=F_OFF,
+    row_off=F_OFF,
+    width=F_LEN,
+    height=F_LEN,
+    arr_width=I_LEN,
+    arr_height=I_LEN,
+)
+def test_window_toslices(col_off, row_off, width, height, arr_width, arr_height):
+    """window.toslices() should match inputs and be properly end indexed (see gh-2378)"""
+    row_slice, col_slice = Window(col_off, row_off, width, height).toslices(
+        shape=(arr_height, arr_width)
+    )
+    assert isinstance(row_slice.start, int)
+    assert row_slice.start == int(math.floor(row_off)) or row_slice.start == int(
+        math.floor(row_off - arr_height)
+    )
+    assert isinstance(row_slice.stop, int)
+    assert row_slice.stop == int(math.ceil(row_off + height)) or row_slice.stop == int(
+        math.ceil(row_off + height - arr_height)
+    )
+    assert isinstance(col_slice.start, int)
+    assert col_slice.start == int(math.floor(col_off)) or col_slice.start == int(
+        math.floor(col_off - arr_width)
+    )
+    assert isinstance(col_slice.stop, int)
+    assert col_slice.stop == int(math.ceil(col_off + width)) or col_slice.stop == int(
+        math.ceil(col_off + width - arr_width)
     )
 
 


### PR DESCRIPTION
By subtracting array dimensions from the slice indexes when they are left of the dial (negative).

Resolves #2378