### PR TITLE
ENH: Add show_versions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -48,10 +48,16 @@ For example: I expected to read a band from a file and an exception occurred.
 
 For example: a brief script with required inputs.
 
-## Operating system
+#### Environment Information
+<!-- If you have rasterio>=1.3.0 -->
+ - Output from: `rio --show-versions` or `python -c "import rasterio; rasterio.show_versions()"`
+<!-- If you have rasterio<1.3.0 -->
+ - rasterio version (`python -c "import rasterio; print(rasterio.__version__)"`)
+ - GDAL version (`python -c "import rasterio; print(rasterio.__gdal_version__)"`)
+ - Python version (`python -c "import sys; print(sys.version.replace('\n', ' '))"`)
+ - Operation System Information (`python -c "import platform; print(platform.platform())"`)
 
-For example: Mac OS X 10.12.3.
 
-## Rasterio version and provenance
+## Installation Method
 
 For example: the 1.0a11 manylinux1 wheel installed from PyPI using pip 9.0.1.

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -8,6 +8,7 @@ import os
 
 import rasterio._loading
 with rasterio._loading.add_gdal_dll_directories():
+    from rasterio._show_versions import show_versions
     from rasterio._version import gdal_version, get_geos_version, get_proj_version
     from rasterio.crs import CRS
     from rasterio.drivers import driver_from_extension, is_blacklisted
@@ -50,7 +51,7 @@ with rasterio._loading.add_gdal_dll_directories():
             pass
         have_vsi_plugin = False
 
-__all__ = ['band', 'open', 'pad', 'Env', 'CRS']
+__all__ = ['band', 'open', 'pad', 'Env', 'CRS', 'show_versions']
 __version__ = "1.3a3"
 __gdal_version__ = gdal_version()
 __proj_version__ = ".".join([str(version) for version in get_proj_version()])

--- a/rasterio/_env.pyx
+++ b/rasterio/_env.pyx
@@ -451,3 +451,37 @@ def set_proj_data_search_path(path):
     path_c = path_b
     paths = CSLAddString(paths, path_c)
     OSRSetPROJSearchPaths(<const char *const *>paths)
+
+
+def get_proj_data_search_paths():
+    """
+    Get the PROJ DATA search paths
+
+    Requires GDAL 3.0.3+
+
+    Returns
+    -------
+    List[str]
+    """
+    path_list = []
+    IF (CTE_GDAL_MAJOR_VERSION, CTE_GDAL_MINOR_VERSION, CTE_GDAL_PATCH_VERSION) >= (3, 0, 3):
+        cdef char **paths = OSRGetPROJSearchPaths()
+        cdef int iii = 0
+        while paths[iii] != NULL:
+            path_list.append(paths[iii])
+            iii += 1
+    return path_list
+
+
+def get_gdal_data():
+    """
+    Get the GDAL DATA path
+
+    Returns
+    -------
+    str
+    """
+    cdef const char *gdal_data = CPLGetConfigOption("GDAL_DATA", NULL)
+    if gdal_data != NULL:
+        return gdal_data
+    return None

--- a/rasterio/_show_versions.py
+++ b/rasterio/_show_versions.py
@@ -1,0 +1,115 @@
+"""
+Utility methods to print system info for debugging
+
+adapted from :func:`sklearn.utils._show_versions`
+which was adapted from :func:`pandas.show_versions`
+"""
+import importlib
+import os
+import platform
+import sys
+
+
+def _get_sys_info():
+    """System information
+
+    Return
+    ------
+    dict:
+        system and Python version information
+    """
+    blob = [
+        ("python", sys.version.replace("\n", " ")),
+        ("executable", sys.executable),
+        ("machine", platform.platform()),
+    ]
+
+    return dict(blob)
+
+
+def _get_gdal_info():
+    """Information on system GDAL
+
+    Returns
+    -------
+    dict:
+        system GDAL information
+    """
+    # pylint: disable=import-outside-toplevel
+    import rasterio
+
+    blob = [
+        ("rasterio", rasterio.__version__),
+        ("GDAL", rasterio.__gdal_version__),
+        ("PROJ", rasterio.__proj_version__),
+        ("GEOS", rasterio.__geos_version__),
+        ("PROJ DATA", os.pathsep.join(rasterio._env.get_proj_data_search_paths())),
+        ("GDAL DATA", rasterio._env.get_gdal_data()),
+    ]
+
+    return dict(blob)
+
+
+def _get_deps_info():
+    """Overview of the installed version of main dependencies
+
+    Returns
+    -------
+    dict:
+        version information on relevant Python libraries
+    """
+    deps = [
+        "affine",
+        "attrs",
+        "certifi",
+        "click",
+        "cligj",
+        "cython",
+        "numpy",
+        "snuggs",
+        "click-plugins",
+        "setuptools",
+    ]
+
+    def get_version(module):
+        try:
+            return module.__version__
+        except AttributeError:
+            return module.version
+
+    deps_info = {}
+
+    for modname in deps:
+        try:
+            if modname in sys.modules:
+                mod = sys.modules[modname]
+            else:
+                mod = importlib.import_module(modname)
+            deps_info[modname] = get_version(mod)
+        except ImportError:
+            deps_info[modname] = None
+
+    return deps_info
+
+
+def _print_info_dict(info_dict):
+    """Print the information dictionary"""
+    for key, stat in info_dict.items():
+        print(f"{key:>10}: {stat}")
+
+
+def show_versions():
+    """
+    Print useful debugging information
+
+    Example
+    -------
+    > python -c "import rasterio; rasterio.show_versions()"
+
+    """
+    print("rasterio info:")
+    _print_info_dict(_get_gdal_info())
+    print("\nSystem:")
+    _print_info_dict(_get_sys_info())
+    print("\nPython deps:")
+    _print_info_dict(_get_deps_info())

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -181,6 +181,7 @@ cdef extern from "ogr_srs_api.h" nogil:
     const char* OSRGetName(OGRSpatialReferenceH hSRS)
     void OSRSetAxisMappingStrategy(OGRSpatialReferenceH hSRS, OSRAxisMappingStrategy)
     void OSRSetPROJSearchPaths(const char *const *papszPaths)
+    char ** OSRGetPROJSearchPaths()
     OGRErr OSRExportToWktEx(OGRSpatialReferenceH, char ** ppszResult,
                             const char* const* papszOptions)
 

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -56,6 +56,14 @@ def gdal_version_cb(ctx, param, value):
     click.echo("{0}".format(rasterio.__gdal_version__), color=ctx.color)
     ctx.exit()
 
+def show_versions_cb(ctx, param, value):
+    if not value or ctx.resilient_parsing:
+        return
+
+    rasterio.show_versions()
+    ctx.exit()
+
+
 
 @with_plugins(
     ep
@@ -74,6 +82,7 @@ def gdal_version_cb(ctx, param, value):
 )
 @click.version_option(version=rasterio.__version__, message="%(version)s")
 @click.option("--gdal-version", is_eager=True, is_flag=True, callback=gdal_version_cb)
+@click.option("--show-versions", help="Show dependency versions", is_eager=True, is_flag=True, callback=show_versions_cb)
 @click.pass_context
 def main_group(
     ctx,

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -92,6 +92,7 @@ def main_group(
     aws_no_sign_requests,
     aws_requester_pays,
     gdal_version,
+    show_versions,
 ):
     """Rasterio command line interface.
     """

--- a/tests/test__env.py
+++ b/tests/test__env.py
@@ -1,8 +1,14 @@
 """Tests of _env util module"""
 
+from numpy import isin
 import pytest
 
-from rasterio._env import GDALDataFinder, PROJDataFinder
+from rasterio._env import (
+    GDALDataFinder,
+    PROJDataFinder,
+    get_proj_data_search_paths,
+    get_gdal_data,
+)
 
 from .conftest import gdal_version, requires_gdal_lt_3
 
@@ -125,3 +131,13 @@ def test_search_proj_data_wheel(mock_wheel):
 def test_search_proj_data_fhs(mock_fhs):
     finder = PROJDataFinder()
     assert finder.search(str(mock_fhs)) == str(mock_fhs.join("share").join("proj"))
+
+
+def test_get_proj_data_search_paths():
+    assert isinstance(get_proj_data_search_paths(), list)
+
+
+def test_get_gdal_data():
+    gdal_data = get_gdal_data()
+    if gdal_data is not None:
+        assert isinstance(gdal_data, str) and gdal_data

--- a/tests/test_rio_main.py
+++ b/tests/test_rio_main.py
@@ -19,3 +19,12 @@ def test_gdal_version(runner):
     result = runner.invoke(main_group, ['--gdal-version'])
     assert result.exit_code == 0
     assert parse(result.output.strip())
+
+
+def test_show_versions(runner):
+    result = runner.invoke(main_group, ['--show-versions'])
+    assert result.exit_code == 0
+    assert "System" in result.output
+    assert "python" in result.output
+    assert "GDAL" in result.output
+    assert "Python deps" in result.output

--- a/tests/test_show_versions.py
+++ b/tests/test_show_versions.py
@@ -1,0 +1,48 @@
+from rasterio._show_versions import (
+    _get_deps_info,
+    _get_gdal_info,
+    _get_sys_info,
+    show_versions,
+)
+
+
+def test_get_gdal_info():
+    yagdal_info = _get_gdal_info()
+    assert "rasterio" in yagdal_info
+    assert "GDAL" in yagdal_info
+    assert "PROJ" in yagdal_info
+    assert "GEOS" in yagdal_info
+    assert "PROJ DATA" in yagdal_info
+    assert "GDAL DATA" in yagdal_info
+
+
+def test_get_sys_info():
+    sys_info = _get_sys_info()
+
+    assert "python" in sys_info
+    assert "executable" in sys_info
+    assert "machine" in sys_info
+
+
+def test_get_deps_info():
+    deps_info = _get_deps_info()
+
+    assert "affine" in deps_info
+    assert "attrs" in deps_info
+    assert "certifi" in deps_info
+    assert "click" in deps_info
+    assert "click-plugins" in deps_info
+    assert "cligj" in deps_info
+    assert "cython" in deps_info
+    assert "numpy" in deps_info
+    assert "setuptools" in deps_info
+    assert "snuggs" in deps_info
+
+
+def test_show_versions_with_gdal(capsys):
+    show_versions()
+    out, err = capsys.readouterr()
+    assert "System" in out
+    assert "python" in out
+    assert "GDAL" in out
+    assert "Python deps" in out


### PR DESCRIPTION
Closes #2349

```
$ rio --show-versions
rasterio info:
  rasterio: 1.3a3
      GDAL: 3.4.0
      PROJ: 8.2.0
      GEOS: 3.10.1
 PROJ DATA: ~/miniconda/envs/rio/share/proj
 GDAL DATA: ~/miniconda/envs/rio/share/gdal

System:
    python: 3.9.7 | packaged by conda-forge | (default, Sep 29 2021, 19:23:11)  [GCC 9.4.0]
executable: ~/miniconda/envs/rio/bin/python
   machine: Linux-5.13.0-39-generic-x86_64-with-glibc2.31

Python deps:
    affine: 2.3.0
     attrs: None
   certifi: 2021.10.08
     click: 8.0.3
     cligj: 0.7.2
    cython: 0.29.24
     numpy: 1.22.2
    snuggs: 1.4.7
click-plugins: None
setuptools: 59.4.0

```