### PR TITLE
BUG: Fix output file dtype in merge

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -261,6 +261,7 @@ def merge(
     out_profile["height"] = output_height
     out_profile["width"] = output_width
     out_profile["count"] = output_count
+    out_profile["dtype"] = dt
     if nodata is not None:
         out_profile["nodata"] = nodata
 

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -82,6 +82,8 @@ def merge(
         files=files, output=output, overwrite=overwrite)
 
     resampling = Resampling[resampling]
+    if driver:
+        creation_options.update(driver=driver)
 
     with ctx.obj["env"]:
         merge_tool(

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -29,6 +29,7 @@ def deprecated_precision(*args):
               default='nearest', help="Resampling method.",
               show_default=True)
 @options.nodata_opt
+@options.dtype_opt
 @options.bidx_mult_opt
 @options.overwrite_opt
 @click.option(
@@ -40,8 +41,21 @@ def deprecated_precision(*args):
 )
 @options.creation_options
 @click.pass_context
-def merge(ctx, files, output, driver, bounds, res, resampling,
-          nodata, bidx, overwrite, precision, creation_options):
+def merge(
+    ctx,
+    files,
+    output,
+    driver,
+    bounds,
+    res,
+    resampling,
+    nodata,
+    dtype,
+    bidx,
+    overwrite,
+    precision,
+    creation_options,
+):
     """Copy valid pixels from input files to an output file.
 
     All files must have the same number of bands, data type, and
@@ -75,6 +89,7 @@ def merge(ctx, files, output, driver, bounds, res, resampling,
             bounds=bounds,
             res=res,
             nodata=nodata,
+            dtype=dtype,
             indexes=(bidx or None),
             resampling=resampling,
             dst_path=output,

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -103,6 +103,21 @@ def test_data_dir_3(tmpdir):
     return tmpdir
 
 
+def test_rio_merge_dtype(test_data_dir_1, runner):
+    outputname = str(test_data_dir_1.join("merged.tif"))
+    inputs = [str(x) for x in test_data_dir_1.listdir()]
+    inputs.sort()
+
+    result = runner.invoke(
+        main_group, ["merge", "--dtype", "uint16"] + inputs + [outputname]
+    )
+    assert result.exit_code == 0
+    assert os.path.exists(outputname)
+
+    with rasterio.open(outputname) as out:
+        assert all(dt == "uint16" for dt in out.dtypes)
+
+
 def test_merge_with_colormap(test_data_dir_1, runner):
     outputname = str(test_data_dir_1.join('merged.tif'))
     inputs = [str(x) for x in test_data_dir_1.listdir()]


### PR DESCRIPTION
When passing dtype as a parameter in merge, the output file was not compliant with the docstring explicit behavior. This was due to the given dtype being only used for the array, and not updated in the out_profile.