### PR TITLE
BUG: Set GDAL/PROJ_CURL_CA_BUNDLE environment

### DIFF
--- a/rasterio/_env.pyx
+++ b/rasterio/_env.pyx
@@ -57,7 +57,9 @@ log = logging.getLogger(__name__)
 
 try:
     import certifi
-    os.environ.setdefault("CURL_CA_BUNDLE", certifi.where())
+    ca_bundle = certifi.where()
+    os.environ.setdefault("GDAL_CURL_CA_BUNDLE", ca_bundle)
+    os.environ.setdefault("PROJ_CURL_CA_BUNDLE", ca_bundle)
 except ImportError:
     pass
 


### PR DESCRIPTION
Closes #2455

The CA Bundle path is for wheel distributions. Since those will contain recent versions of GDAL/PROJ, this is a safe change to make.