### PR TITLE
Accept masked arrays and fill or write a mask

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,17 @@ Changes
 1.3.0 (TBD)
 -----------
 
+1.3b1 (2022-05-10)
+------------------
+
+New features:
+
+- A dataset's write method now accepts Numpy masked arrays and has a "masked"
+  keyword argument. In this case, if masked is False, the masked array's filled
+  method is called with the dataset's nodata value or else the masked array's
+  fill value. If the masked argument is True, the dataset's write_mask method
+  is called.
+
 1.3a4 (2022-04-20)
 ------------------
 

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -52,7 +52,7 @@ with rasterio._loading.add_gdal_dll_directories():
         have_vsi_plugin = False
 
 __all__ = ['band', 'open', 'pad', 'Env', 'CRS']
-__version__ = "1.3a4"
+__version__ = "1.3b1"
 __gdal_version__ = gdal_version()
 __proj_version__ = ".".join([str(version) for version in get_proj_version()])
 __geos_version__ = ".".join([str(version) for version in get_geos_version()])


### PR DESCRIPTION
The write() method can take a masked array. This is new. When it does, and the masked keyword argument is False, we collapse the masked array by calling its filled method with either the dataset's nodata value or (if that is None) the masked array's own fill value.

If the masked keyword argument is True, we call self.write_mask before writing the band data. There is some redundant computation which we can optimize away in the future, but calling write_mask seemed the most reliable approach for now.

Resolves #2347