### PR TITLE
prevent None return in get_minimum_dtype

### DIFF
--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -132,6 +132,8 @@ def get_minimum_dtype(values):
             return int16
         elif min_value >= -2147483648 and max_value <= 2147483647:
             return int32
+        else:
+            return float64
 
     else:
         if min_value >= -3.4028235e+38 and max_value <= 3.4028235e+38:


### PR DESCRIPTION
integers exceeding int32 aren't captured by get_minimum_dtype.
Writing rasters in int64 is not supported properly. To catch the issue, I propose to use Float64.