### PR TITLE
DOC: Update matplotlib API doc links in rasterio.plot.show

### DIFF
--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -68,9 +68,9 @@ def show(source, with_bounds=True, contour=False, contour_label_kws=None,
         These will be passed to the matplotlib imshow or contour method
         depending on contour argument.
         See full lists at:
-        http://matplotlib.org/api/axes_api.html?highlight=imshow#matplotlib.axes.Axes.imshow
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.imshow.html
         or
-        http://matplotlib.org/api/axes_api.html?highlight=imshow#matplotlib.axes.Axes.contour
+        https://matplotlib.org/stable/api/_as_gen/matplotlib.pyplot.contour.html
 
     Returns
     -------


### PR DESCRIPTION
This PR updates the links to `imshow` and `contour` matplotlib API docs in the `rasterio.plot.show` method's docstring.