### PR TITLE
Backport fix to allow building rasterio with python 3.10

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,2 +1,2 @@
 [build-system]
-requires = ["setuptools", "wheel", "cython==0.29.21", "oldest-supported-numpy"]
+requires = ["setuptools", "wheel", "cython~=0.29.24", "oldest-supported-numpy"]


### PR DESCRIPTION
This PR is just a cherry-pick of the commit 329c481bfdad4fa3272d07a548001f5ec1e8bda4 to allow building rasterio `1.2.*` with Python 3.10. Without this fix, one must vendorize rasterio to be able to compile it with Python 3.10.