### PR TITLE
Pass along strides to GDAL in MemoryDataset #2511

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,13 @@
 Changes
 =======
 
+1.3.1 ()
+------------------
+
+Bug fixes:
+
+- Support arrays with strides in `MemoryDataset` (#2511, #2509)
+
 1.3.0 (2022-07-05)
 ------------------
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -2066,6 +2066,16 @@ cdef class MemoryDataset(DatasetWriterBase):
             "BANDS": count,
             "DATATYPE": _gdal_typename(arr.dtype.name)
         }
+        strides = arr_info.get("strides", None)
+
+        if strides is not None:
+            if len(strides) == 2:
+                lineoffset, pixeloffset = strides
+                info.update(LINEOFFSET=lineoffset, PIXELOFFSET=pixeloffset)
+            else:
+                bandoffset, lineoffset, pixeloffset = strides
+                info.update(BANDOFFSET=bandoffset, LINEOFFSET=lineoffset, PIXELOFFSET=pixeloffset)
+
         dataset_options = ",".join(f"{name}={val}" for name, val in info.items())
         datasetname = f"MEM:::{dataset_options}"
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -910,6 +910,30 @@ def test_shapes(basic_image):
     assert value == 0
 
 
+def test_shapes_2509(basic_image):
+    """Test creation of shapes from pixel values, issue #2509."""
+    image_with_strides = np.pad(basic_image, 1)[1:-1, 1:-1]
+    np.testing.assert_array_equal(basic_image, image_with_strides)
+    assert image_with_strides.__array_interface__["strides"] is not None
+
+    results = list(shapes(image_with_strides))
+
+    assert len(results) == 2
+
+    shape, value = results[0]
+    assert shape == {
+        'coordinates': [
+            [(2, 2), (2, 5), (5, 5), (5, 2), (2, 2)]
+        ],
+        'type': 'Polygon'
+    }
+    assert value == 1
+
+    shape, value = results[1]
+    assert shapely.geometry.shape(shape).area == 91.0
+    assert value == 0
+
+
 def test_shapes_band(pixelated_image, pixelated_image_file):
     """Shapes from a band should match shapes from an array."""
     truth = list(shapes(pixelated_image))

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -453,6 +453,41 @@ def test_reproject_ndarray():
     )
     assert (out > 0).sum() == 438113
 
+    
+def test_reproject_ndarray_slice():
+    """Test for issue #2511, destination with strides"""
+
+    with rasterio.open("tests/data/RGB.byte.tif") as src:
+        source = src.read(1)
+
+    dst_crs = dict(
+        proj="merc",
+        a=6378137,
+        b=6378137,
+        lat_ts=0.0,
+        lon_0=0.0,
+        x_0=0.0,
+        y_0=0,
+        k=1.0,
+        units="m",
+        nadgrids="@null",
+        wktext=True,
+        no_defs=True,
+    )
+
+    out = np.zeros((src.count, src.height, src.width+2), dtype=np.uint8)[..., 1:-1]
+    assert out.__array_interface__["strides"] is not None
+    reproject(
+        source,
+        out,
+        src_transform=src.transform,
+        src_crs=src.crs,
+        dst_transform=DST_TRANSFORM,
+        dst_crs=dst_crs,
+        resampling=Resampling.nearest,
+    )
+    assert (out > 0).sum() == 438113
+
 
 def test_reproject_view():
     """Source views are reprojected properly"""


### PR DESCRIPTION
when given non-contigous array on output pass along strides
information to GDAL.

closes #2511 
closes #2509 