### PR TITLE
Sort pixel locations during sampling

### DIFF
--- a/rasterio/sample.py
+++ b/rasterio/sample.py
@@ -60,10 +60,16 @@ def sample_gen(dataset, xy, indexes=None, masked=False, sorter=None):
     masked : bool, default: False
         Whether to mask samples that fall outside the extent of the
         dataset.
-    sort : bool, default: False
-        Sort coordinates for hopefully better performance.
+    sorter : iterable|callable, default: None
+        A sequence of indices that sort xy. A callable function is
+        also accepted that takes two arguments (dataset, xy) and 
+        returns a sequence of indices.
+        Reordering xy can often yield better performance.
         This will hold all the points in memory at once and may be
         memory intensive.
+
+        Note: The sorting function is called on the transformed
+        x, y coordinates.
 
     Yields
     ------

--- a/rasterio/sample.py
+++ b/rasterio/sample.py
@@ -113,4 +113,4 @@ def sample_gen(dataset, xy, indexes=None, masked=False, sorter=None):
             samples[i] = data[:, 0, 0]
         else:
             samples[i] = nodata
-    return samples
+    return iter(samples)


### PR DESCRIPTION
Following up on @sgillies comment here: https://github.com/rasterio/rasterio/pull/2338#discussion_r847710362

Now that 1.3.0 is out, I played around with sorting the points and it resulted in another nice speedup. The test raster is 671MB tiff with a shape of (21058, 22812) pixels.
For comparison:
With 1.3.0 and 100k uniformly random sampling points: 55.8s
With PR and 100k uniformly random sampling points: 13.2s

With 100 points the sorting overhead is more noticeable, though still tolerable:
1.3.0: 6.75ms
PR: 7.38ms

Note that this changes sample_gen to return a list instead of a generator. I think it is important to return points in the same order they were received. An alternative would be to return tuples of the original point and the sampled value (which could be returned in any order) instead of just the ordered sampled values. Finally, we could return `iter(samples)` to preserve the iterator behavior.

EDIT: This PR contains two attempts. The first attempt was to map each point to a block, read that block and then retrieve all pixel values contained in that block. This was reasonably fast if a lot of pixels lived in the same block. However, it uses way more memory than single pixel reads.

The second attempt just sorts the pixel coordinates before calling read. @sgillies thinks this might use the cache better, but I don't know enough about how to the cache works to say definitively.