### PR TITLE
Fix broadcasting of coords in `rasterio.transform.xy`

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -319,8 +319,9 @@ class TransformerBase():
 
     def close(self):
         self.closed = True
-    
-    def _ensure_arr_input(self, xs, ys, zs=None):
+
+    @staticmethod
+    def _ensure_arr_input(xs, ys, zs=None):
         """Ensure all input coordinates are mapped to array-like objects
         
         Raises

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -331,10 +331,10 @@ class TransformerBase():
         """
         try:
             xs, ys, zs = np.broadcast_arrays(xs, ys, 0 if zs is None else zs)
-        except ValueError:
+        except ValueError as error:
             raise TransformError(
                 "Input coordinates must be broadcastable to a 1d array"
-            )
+            ) from error
         return np.atleast_1d(xs), np.atleast_1d(ys), np.atleast_1d(zs)
 
     def __enter__(self):

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -335,7 +335,7 @@ class TransformerBase():
             raise TransformError(
                 "Input coordinates must be broadcastable to a 1d array"
             )
-        return list(np.atleast_1d(xs)), list(np.atleast_1d(ys)), list(np.atleast_1d(zs))
+        return np.atleast_1d(xs), np.atleast_1d(ys), np.atleast_1d(zs)
 
     def __enter__(self):
         self._env.enter_context(env_ctx_if_needed())

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -346,6 +346,16 @@ def test_ensure_arr_input_same_shape():
     with pytest.raises(TransformError):
         transformer.xy([0, 1, 2], [0, 1])
 
+
+def test_ensure_arr_input_with_zs():
+    assert AffineTransformer._ensure_arr_input(0, 1) == AffineTransformer._ensure_arr_input(0, 1, zs=0)
+    assert AffineTransformer._ensure_arr_input(0, [1, 2], zs=3) == ([0, 0], [1, 2], [3, 3])
+    assert AffineTransformer._ensure_arr_input([0, 1], 2, zs=3) == ([0, 1], [2, 2], [3, 3])
+    assert AffineTransformer._ensure_arr_input(0, 1, zs=[2, 3]) == ([0, 0], [1, 1], [2, 3])
+    with pytest.raises(TransformError):
+        AffineTransformer._ensure_arr_input(0, [1, 2], zs=[3, 4, 5])
+
+
 @pytest.mark.parametrize(
     'transformer_cls,transform',
     [

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -347,11 +347,23 @@ def test_ensure_arr_input_same_shape():
         transformer.xy([0, 1, 2], [0, 1])
 
 
-def test_ensure_arr_input_with_zs():
+def test_ensure_arr_input_with_default_zs():
     assert AffineTransformer._ensure_arr_input(0, 1) == AffineTransformer._ensure_arr_input(0, 1, zs=0)
-    assert AffineTransformer._ensure_arr_input(0, [1, 2], zs=3) == ([0, 0], [1, 2], [3, 3])
-    assert AffineTransformer._ensure_arr_input([0, 1], 2, zs=3) == ([0, 1], [2, 2], [3, 3])
-    assert AffineTransformer._ensure_arr_input(0, 1, zs=[2, 3]) == ([0, 0], [1, 1], [2, 3])
+    _, _, zs = AffineTransformer._ensure_arr_input(0, [1, 2], zs=0)
+    assert all(zs == [0, 0])
+
+
+def test_ensure_arr_input_with_zs():
+    _, _, zs = AffineTransformer._ensure_arr_input(0, 1, zs=2)
+    assert all(zs == [2])
+    _, _, zs = AffineTransformer._ensure_arr_input(0, [1, 2], zs=3)
+    assert all(zs == [3, 3])
+    _, _, zs = AffineTransformer._ensure_arr_input([0, 1], 2, zs=3)
+    assert all(zs == [3, 3])
+    xs, ys, zs = AffineTransformer._ensure_arr_input(0, 1, zs=[2, 3])
+    assert all(zs == [2, 3])
+    assert all(ys == [1, 1])
+    assert all(xs == [0, 0])
     with pytest.raises(TransformError):
         AffineTransformer._ensure_arr_input(0, [1, 2], zs=[3, 4, 5])
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -200,7 +200,7 @@ def test_xy_input(rows, cols, exp_xy, aff):
 
 
 @pytest.mark.parametrize("aff", [Affine.identity()])
-@pytest.mark.parametrize("rows, cols", [(0, [0]), ("0", "0")])
+@pytest.mark.parametrize("rows, cols", [([0, 1, 2], [0, 1]), ("0", "0")])
 def test_invalid_xy_input(rows, cols, aff):
     """Raise on invalid input."""
     with pytest.raises(TransformError):
@@ -294,7 +294,7 @@ def test_xy_rowcol_inverse(transform):
 
 
 @pytest.mark.parametrize("aff", [Affine.identity()])
-@pytest.mark.parametrize("xs, ys", [(0, [0]), ("0", "0")])
+@pytest.mark.parametrize("xs, ys", [([0, 1, 2], [0, 1]), ("0", "0")])
 def test_invalid_rowcol_input(xs, ys, aff):
     """Raise on invalid input."""
     with pytest.raises(TransformError):
@@ -326,9 +326,15 @@ def test_transformer_open_closed(transformer_cls, transform):
 @pytest.mark.parametrize(
     'coords,expected',
     [
-        ((0,0), (0,0)),
-        (([0],[0]), ([0], [0])),
-        (([0,1],[0,1]), ([0,1],[0,1]))
+        ((0, 1), (1, 0)),
+        (([0],[1]), ([1], [0])),
+        ((0,[1]), ([1], [0])),
+        (([0], 1), ([1], [0])),
+        (([0, 1], [2, 3]), ([2, 3],[0, 1])),
+        ((0, [1, 2]), ([1, 2], [0, 0])),
+        (([0, 1], 2), ([2, 2], [0, 1])),
+        (([0], [1, 2]), ([1, 2], [0, 0])),
+        (([0, 1], [2]), ([2, 2], [0, 1])),
     ]
 )
 def test_ensure_arr_input(coords, expected):
@@ -338,7 +344,7 @@ def test_ensure_arr_input(coords, expected):
 def test_ensure_arr_input_same_shape():
     transformer = transform.AffineTransformer(Affine.identity())
     with pytest.raises(TransformError):
-        transformer.xy([0], [0, 1])
+        transformer.xy([0, 1, 2], [0, 1])
 
 @pytest.mark.parametrize(
     'transformer_cls,transform',


### PR DESCRIPTION
This pull request fixes an error I'm seeing that seems to be a regression from *v1.2* to *v1.3* or *rasterio*. Apologies if this is the intended behavior, in which case please ignore this pull request.

With the older version the following worked,
```python
>>> rasterio.transform.xy(transform, 0, [1, 2, 3])
```
In this case, the *rows* argument argument would be broadcast to match the length of the *cols* argument. That is, it would be equivalent to,
```python
>>> rasterio.transform.xy(transform, [0, 0, 0], [1, 2, 3])
```
With the newer version I now get the following error,
```python
>>> rasterio.transform.xy(transform, 0, [1, 2, 3])
... Traceback (most recent call last)
...
... TransformError: Invalid inputs 
```

In this pull request I've modified `TransformerBase._ensure_arr_input` to broadcast *xs*, *ys*, and *zs* to 1d arrays with a common length using *numpy*'s broadcasting rules. I've also updated the tests and added some new ones to test this behavior.

I've also modified some existing tests to ensure that the *xy* method swaps its return values (i.e. rows/columns become y,x).