### PR TITLE
Fix broadcasting of coords in `rasterio.transform.xy` (#2538)

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -4,6 +4,7 @@ from collections.abc import Iterable
 from contextlib import ExitStack
 from functools import partial
 import math
+import numpy as np
 import sys
 
 from affine import Affine
@@ -318,8 +319,9 @@ class TransformerBase():
 
     def close(self):
         self.closed = True
-    
-    def _ensure_arr_input(self, xs, ys, zs=None):
+
+    @staticmethod
+    def _ensure_arr_input(xs, ys, zs=None):
         """Ensure all input coordinates are mapped to array-like objects
         
         Raises
@@ -327,20 +329,13 @@ class TransformerBase():
         TransformError
             If input coordinates are not all of the same length
         """
-        if (isinstance(xs, Iterable) and not isinstance(ys, Iterable)) or (
-            isinstance(ys, Iterable) and not isinstance(xs, Iterable)
-        ):
-            raise TransformError("Invalid inputs")
-        if not isinstance(xs, Iterable) and not isinstance(ys, Iterable):
-            xs = [xs]
-            ys = [ys]
-        if zs is None:
-            zs = [0] * len(xs)
-        elif not isinstance(zs, Iterable):
-            zs = [zs]
-        if len(set((len(xs), len(ys), len(zs)))) > 1:
-            raise TransformError("Input coordinates must be of equal length")
-        return xs, ys, zs
+        try:
+            xs, ys, zs = np.broadcast_arrays(xs, ys, 0 if zs is None else zs)
+        except ValueError as error:
+            raise TransformError(
+                "Input coordinates must be broadcastable to a 1d array"
+            ) from error
+        return np.atleast_1d(xs), np.atleast_1d(ys), np.atleast_1d(zs)
 
     def __enter__(self):
         self._env.enter_context(env_ctx_if_needed())

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -200,7 +200,7 @@ def test_xy_input(rows, cols, exp_xy, aff):
 
 
 @pytest.mark.parametrize("aff", [Affine.identity()])
-@pytest.mark.parametrize("rows, cols", [(0, [0]), ("0", "0")])
+@pytest.mark.parametrize("rows, cols", [([0, 1, 2], [0, 1]), ("0", "0")])
 def test_invalid_xy_input(rows, cols, aff):
     """Raise on invalid input."""
     with pytest.raises(TransformError):
@@ -294,7 +294,7 @@ def test_xy_rowcol_inverse(transform):
 
 
 @pytest.mark.parametrize("aff", [Affine.identity()])
-@pytest.mark.parametrize("xs, ys", [(0, [0]), ("0", "0")])
+@pytest.mark.parametrize("xs, ys", [([0, 1, 2], [0, 1]), ("0", "0")])
 def test_invalid_rowcol_input(xs, ys, aff):
     """Raise on invalid input."""
     with pytest.raises(TransformError):
@@ -326,9 +326,15 @@ def test_transformer_open_closed(transformer_cls, transform):
 @pytest.mark.parametrize(
     'coords,expected',
     [
-        ((0,0), (0,0)),
-        (([0],[0]), ([0], [0])),
-        (([0,1],[0,1]), ([0,1],[0,1]))
+        ((0, 1), (1, 0)),
+        (([0],[1]), ([1], [0])),
+        ((0,[1]), ([1], [0])),
+        (([0], 1), ([1], [0])),
+        (([0, 1], [2, 3]), ([2, 3],[0, 1])),
+        ((0, [1, 2]), ([1, 2], [0, 0])),
+        (([0, 1], 2), ([2, 2], [0, 1])),
+        (([0], [1, 2]), ([1, 2], [0, 0])),
+        (([0, 1], [2]), ([2, 2], [0, 1])),
     ]
 )
 def test_ensure_arr_input(coords, expected):
@@ -338,7 +344,29 @@ def test_ensure_arr_input(coords, expected):
 def test_ensure_arr_input_same_shape():
     transformer = transform.AffineTransformer(Affine.identity())
     with pytest.raises(TransformError):
-        transformer.xy([0], [0, 1])
+        transformer.xy([0, 1, 2], [0, 1])
+
+
+def test_ensure_arr_input_with_default_zs():
+    assert AffineTransformer._ensure_arr_input(0, 1) == AffineTransformer._ensure_arr_input(0, 1, zs=0)
+    _, _, zs = AffineTransformer._ensure_arr_input(0, [1, 2], zs=0)
+    assert all(zs == [0, 0])
+
+
+def test_ensure_arr_input_with_zs():
+    _, _, zs = AffineTransformer._ensure_arr_input(0, 1, zs=2)
+    assert all(zs == [2])
+    _, _, zs = AffineTransformer._ensure_arr_input(0, [1, 2], zs=3)
+    assert all(zs == [3, 3])
+    _, _, zs = AffineTransformer._ensure_arr_input([0, 1], 2, zs=3)
+    assert all(zs == [3, 3])
+    xs, ys, zs = AffineTransformer._ensure_arr_input(0, 1, zs=[2, 3])
+    assert all(zs == [2, 3])
+    assert all(ys == [1, 1])
+    assert all(xs == [0, 0])
+    with pytest.raises(TransformError):
+        AffineTransformer._ensure_arr_input(0, [1, 2], zs=[3, 4, 5])
+
 
 @pytest.mark.parametrize(
     'transformer_cls,transform',


### PR DESCRIPTION
Related #2555

* broadcast arrays to 1d arrays

* update ensure_arr tests for broadcasting coordinates

* make tests/test_transform.py a staticmethod

* add tests for ensure_arr_input that use zs

* change _ensure_arr_input to return numpy arrays, not lists

* transform ValueError into TransformError