### PR TITLE
Transform decomposition

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -171,16 +171,21 @@ def guard_transform(transform):
 
 
 def decompose(transform):
-    """ For a conformal mapping, extract rotation, scale, and translation """
+    """ For a conformal mapping, extract rotation, scale, and translation
+    
+    Rotation and scale are found using a polar decompostion (based on
+    the implementation in scipy.linalg.polar). """
     if not transform.is_conformal:
         raise TransformError("shear detected, transform must be conformal")
 
     translation = transform.xoff, transform.yoff
     transform = np.asarray(transform).reshape(3,3)
     transform[:2, 2] = 0
+    # Polar decomposition via SVD
     u, s, vh = np.linalg.svd(transform)
     U = u @ vh
     P = (vh.T.conj() * s) @ vh
+    # Avoid numerical stability issues with inverse sine around 0
     if np.isclose(U[0,0], 0):
         rotation_angle = math.degrees(math.asin(U[1, 0]))
     else:

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -175,8 +175,8 @@ def decompose(transform):
     if not transform.is_conformal:
         raise TransformError("shear detected, transform must be conformal")
 
+    translation = transform.xoff, transform.yoff
     transform = np.asarray(transform).reshape(3,3)
-    translation = tuple(transform[:2, 2])
     transform[:2, 2] = 0
     u, s, vh = np.linalg.svd(transform)
     U = u @ vh

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -408,13 +408,14 @@ def test_2421_rpc_height_ignored():
         assert abs(x2 - x1) > 0
         assert abs(y2 - y1) > 0
 
+
 def test_decompose_translation():
     transform = Affine.translation(1, 5)
-
     t, r, s = decompose(transform)
     assert t == (1, 5)
     assert r == 0
     assert s == (1.0, 1.0)
+
 
 def test_decompose_rotation():
     transform = Affine.rotation(75)
@@ -423,6 +424,7 @@ def test_decompose_rotation():
     assert numpy.isclose(r, 75)
     assert numpy.allclose(s, (1.0, 1.0))
 
+
 def test_decompose_scaling():
     transform = Affine.scale(15, 12)
     t, r, s, = decompose(transform)
@@ -430,10 +432,12 @@ def test_decompose_scaling():
     assert r == 0
     assert numpy.allclose(s, (15, 12))
 
+
 def test_decompose_shear():
     transform = Affine.shear(5)
     with pytest.raises(TransformError):
         decompose(transform)
+
 
 def test_decompose_trs():
     transform = Affine.translation(2, 4)


### PR DESCRIPTION
A useful utility for decomposing a conformal transform into its translation, rotation, and scale parameters.

```python
from rasterio.transform import decompose
# transform = Affine.translation(1, 3) * Affine.scale(3, 3) * Affine.rotation(45)
decompose(transform)
# ((1.0, 3.0), 44.999999999999986, (3.0, 3.0))
```