### PR TITLE
REF:transform: Rename variables in TransformerBase.xy for clarity

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -439,19 +439,19 @@ class TransformerBase():
         temp_rows = []
         temp_cols = []
         try:
-            for pt in zip(cols, rows):
-                y, x = T * pt
-                temp_rows.append(y)
-                temp_cols.append(x)
+            for colrow in zip(cols, rows):
+                col, row = T * colrow
+                temp_rows.append(row)
+                temp_cols.append(col)
 
-            new_ys, new_xs = self._transform(
-                temp_rows, temp_cols, zs, transform_direction=TransformDirection.forward
+            new_xs, new_ys = self._transform(
+                temp_cols, temp_rows, zs, transform_direction=TransformDirection.forward
             )
 
-            if len(new_ys) == 1 and not AS_ARR:
-                return (new_ys[0], new_xs[0])
+            if len(new_xs) == 1 and not AS_ARR:
+                return (new_xs[0], new_ys[0])
             else:
-                return (new_ys, new_xs)
+                return (new_xs, new_ys)
         except TypeError:
             raise TransformError("Invalid inputs")
     

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -436,16 +436,16 @@ class TransformerBase():
         
         # shift input coordinates according to offset
         T = IDENTITY.translation(coff, roff)
-        temp_rows = []
-        temp_cols = []
+        offset_rows = []
+        offset_cols = []
         try:
             for colrow in zip(cols, rows):
-                col, row = T * colrow
-                temp_rows.append(row)
-                temp_cols.append(col)
+                offset_col, offset_row = T * colrow
+                offset_rows.append(offset_row)
+                offset_cols.append(offset_col)
 
             new_xs, new_ys = self._transform(
-                temp_cols, temp_rows, zs, transform_direction=TransformDirection.forward
+                offset_cols, offset_rows, zs, transform_direction=TransformDirection.forward
             )
 
             if len(new_xs) == 1 and not AS_ARR:


### PR DESCRIPTION
Related to #2584

The variable names are incorrect, though they happen to be incorrect in a way that makes everything work. For the `xy` functions, the response order should be `x, y` as is in the docstrings of several of the `xy` functions. This just makes the internal variable naming match what is returned externally for clarity.