### PR TITLE
An experimental rasterio-based Zarr storage class

### DIFF
--- a/rasterio/zarr.py
+++ b/rasterio/zarr.py
@@ -1,0 +1,72 @@
+"""Zarr storage"""
+
+from collections.abc import MutableMapping
+import json
+import logging
+from pathlib import Path
+
+import numpy
+from rasterio.windows import Window
+
+log = logging.getLogger(__name__)
+
+
+class RasterioStore(MutableMapping):
+    def __init__(self, dataset):
+        self.dataset = dataset
+        chunk_height, chunk_width = self.dataset.block_shapes[0]
+        self._data = {
+            ".zgroup": json.dumps({"zarr_format": 2}).encode("utf-8"),
+            Path(self.dataset.name).name
+            + "/.zarray": json.dumps(
+                {
+                    "zarr_format": 2,
+                    "shape": (
+                        self.dataset.count,
+                        self.dataset.height,
+                        self.dataset.width,
+                    ),
+                    "chunks": (
+                        1,
+                        chunk_height,
+                        chunk_width,
+                    ),
+                    "dtype": numpy.dtype(self.dataset.dtypes[0]).str,
+                    "compressor": None,
+                    "fill_value": None,
+                    "order": "C",
+                    "filters": None,
+                }
+            ).encode("utf-8"),
+            Path(self.dataset.name).name + "/.zattrs": json.dumps({}),
+        }
+
+    def __getitem__(self, key):
+        if key in self._data:
+            return self._data[key]
+        elif key.startswith(Path(self.dataset.name).name):
+            chunk_height, chunk_width = self.dataset.block_shapes[0]
+            chunking = key.split("/")[-1]
+            bc, rc, cc = [int(x) for x in chunking.split(".")]
+            chunk = self.dataset.read(
+                bc + 1,
+                window=Window(
+                    cc * chunk_width, rc * chunk_height, chunk_width, chunk_height
+                ),
+                boundless=True,
+            )
+            return chunk
+        else:
+            raise KeyError("Key not found")
+
+    def __setitem__(self, key, val):
+        pass
+
+    def __delitem__(self, key, val):
+        pass
+
+    def __len__(self):
+        return len(self._data)
+
+    def __iter__(self):
+        return iter(self._data)

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -15,3 +15,4 @@ sphinx
 sphinx-click
 sphinx-rtd-theme
 wheel
+zarr

--- a/setup.py
+++ b/setup.py
@@ -291,6 +291,7 @@ extra_reqs = {
         "pytest-cov>=2.2.0",
         "pytest>=2.8.2",
         "shapely",
+        "zarr",
     ],
 }
 

--- a/tests/test_zarr_store.py
+++ b/tests/test_zarr_store.py
@@ -1,0 +1,13 @@
+"""Test of rasterio Zarr store"""
+
+import rasterio
+from rasterio.zarr import RasterioStore
+import zarr
+
+
+def test_zarr_store(path_rgb_byte_tif):
+    """Open sesame"""
+    with rasterio.open(path_rgb_byte_tif) as dataset:
+        store = RasterioStore(dataset)
+        z = zarr.group(store)
+        assert (z["RGB.byte.tif"][:] == dataset.read()).all()


### PR DESCRIPTION
Access to good ole flat rasters via a hierarchical data API could be handy if you want to zarr-ify some GeoTIFFs, JP2s, or VRTs. That's what this Zarr storage adapter does. This work is related to #1759.

RasterioStore represents a flat raster as a group with one array and translates flat raster blocks or strips into zarr chunks.

```python
import matplotlib.pyplot as plt
import numpy
import rasterio
from rasterio.zarr import RasterioStore
import zarr

with rasterio.open("tests/data/RGB.byte.tif") as dataset:
    store = RasterioStore(dataset)
    z = zarr.group(store)
    rgb = z["RGB.byte.tif"][:]
    plt.imshow(numpy.moveaxis(rgb, 0, -1))
    plt.show()
```
![Figure_1](https://user-images.githubusercontent.com/33697/198415890-6661cc4e-b46b-4dbe-987f-1a21e43e3968.png)

