### PR TITLE
Fix possible init crash when Windows PATH has empty entry

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -19,7 +19,7 @@ if platform.system() == "Windows":
     else:
         if "PATH" in os.environ:
             for p in os.environ["PATH"].split(os.pathsep):
-                if glob.glob(os.path.join(p, "gdal*.dll")):
+                if p and glob.glob(os.path.join(p, "gdal*.dll")):
                     os.add_dll_directory(p)
 
 


### PR DESCRIPTION
Rasterio might fall back to search the gdal lib in PATH. For the not so unusual case that PATH has an empty element (most likely a trailing ';') the current method would glob for "gdal*.dll" in the current working directory and if found something would try to pass empty string to os.add_dll_directory which raise an error.

Problematic example PATH=C:\WINDOWS\system32;C:\WINDOWS;
I have seen such a trailing PATH separator on a quite clean Windows installation so I assume it is not too uncommon.