### PR TITLE
BUG: fix get_data_window for nodata=nan, fixes #2628

### DIFF
--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -160,7 +160,10 @@ def get_data_window(arr, nodata=None):
     # Otherwise retrieve mask from array (if it is masked)
     # Finally try returning a full window (nodata=None and nothing in arr is masked)
     if nodata is not None:
-        arr_mask = arr != nodata
+        if np.isnan(nodata):
+            arr_mask = ~np.isnan(arr)
+        else:
+            arr_mask = arr != nodata
     elif np.ma.is_masked(arr):
         arr_mask = ~np.ma.getmask(arr)
     else:
@@ -180,10 +183,10 @@ def get_data_window(arr, nodata=None):
             v.append((nz.min(), nz.max() + 1))
         else:
             v.append((0, 0))
-    
+
     if arr_mask.ndim == 1:
         v.append((0, 0))
-        
+
     return Window.from_slices(*v)
 
 

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -508,6 +508,14 @@ def test_data_window_nodata():
     assert window == Window.from_slices((1, 3), (0, 3))
 
 
+def test_data_window_nodata_nan():
+    """Get window of arr with nodata."""
+    arr = np.ones((3, 3))
+    arr[0, :] = np.nan
+    window = get_data_window(arr, nodata=np.nan)
+    assert window == Window.from_slices((1, 3), (0, 3))
+
+
 def test_data_window_novalid():
     """Get window of arr with nodata."""
     arr = np.ones((3, 3))


### PR DESCRIPTION
Closes #2628 

Added an analogous test to the `test_data_window_nodata`, using `nan` instead of 0 as the nodata.