### PR TITLE
BUG: ensure default driver for tif to be GTiff

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -148,6 +148,11 @@ def _raster_driver_extensions():
 
         for extension in extensions.split():
             driver_extensions[extension] = drivername
+
+    # ensure default driver for tif to be GTiff instead of COG
+    driver_extensions.update(
+        {'tif': 'GTiff', 'tiff': 'GTiff'}
+    )
     return driver_extensions
 
 


### PR DESCRIPTION
Related #2632

Some change made COG preferred over GTiff driver in the defaults in 3.6.0.
This ensures it is consistent moving forward.

Before:
```python
>>> from rasterio.drivers import raster_driver_extensions
>>> raster_driver_extensions()
{'tif': 'COG', 'tiff': 'COG', ...}
```