### PR TITLE
pull AZURE_STORAGE_ACCESS_KEY from env if not provided as arg to AzureSession

### DIFF
--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -563,7 +563,8 @@ class AzureSession(Session):
         """
 
         self.unsigned = bool(os.getenv("AZURE_NO_SIGN_REQUEST", azure_unsigned))
-        self.storage_account = os.getenv("AZURE_STORAGE_ACCOUNT", azure_storage_account)
+        self.storage_account = azure_storage_account or os.getenv("AZURE_STORAGE_ACCOUNT")
+        self.storage_access_key = azure_storage_access_key or os.getenv("AZURE_STORAGE_ACCESS_KEY")
 
         if azure_storage_connection_string:
             self._creds = {
@@ -572,7 +573,7 @@ class AzureSession(Session):
         elif not self.unsigned:
             self._creds = {
                 "azure_storage_account": self.storage_account,
-                "azure_storage_access_key": azure_storage_access_key
+                "azure_storage_access_key": self.storage_access_key
             }
         else:
             self._creds = {

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -282,6 +282,16 @@ def test_session_factory_az_kwargs_connection_string():
     assert sesh.get_credential_options()['AZURE_STORAGE_CONNECTION_STRING'] == 'AccountName=myaccount;AccountKey=MY_ACCOUNT_KEY'
 
 
+def test_session_factory_az_env(monkeypatch):
+    """Get an AzureSession for az:// paths with environment variables"""
+    monkeypatch.setenv('AZURE_STORAGE_ACCOUNT', 'foo')
+    monkeypatch.setenv('AZURE_STORAGE_ACCESS_KEY', 'bar')
+    sesh = Session.from_path("az://lol/wut")
+    assert isinstance(sesh, AzureSession)
+    assert sesh.get_credential_options()['AZURE_STORAGE_ACCOUNT'] == 'foo'
+    assert sesh.get_credential_options()['AZURE_STORAGE_ACCESS_KEY'] == 'bar'
+
+
 def test_azure_no_sign_request(monkeypatch):
     """If AZURE_NO_SIGN_REQUEST is set do not default to azure_unsigned=False"""
     monkeypatch.setenv('AZURE_NO_SIGN_REQUEST', 'YES')


### PR DESCRIPTION
I believe adding `AZURE_STORAGE_ACCESS_KEY` to the credentials in an `AzureSession` follows the authentication logic: use `AZURE_CONNECTION_STRING` if available, use `AZURE_STORAGE_ACCOUNT` and `AZURE_STORAGE_ACCESS_KEY` unless `AZURE_NO_SIGN_REQUEST` is set in which case we only need `AZURE_STORAGE_ACCOUTN`. I assume that we get away without passing any secrets for S3 authentication because `boto` handles it.

resolves #2636