### PR TITLE
BUG: Raise exception with debugging information when NULL return

### DIFF
--- a/rasterio/_err.pyx
+++ b/rasterio/_err.pyx
@@ -10,6 +10,10 @@ import sys
 
 log = logging.getLogger(__name__)
 
+_GDAL_DEBUG_DOCS = (
+    "https://rasterio.readthedocs.io/en/latest/topics/errors.html"
+    "#debugging-internal-gdal-functions"
+)
 
 class CPLE_BaseError(Exception):
     """Base CPL error class
@@ -215,6 +219,9 @@ cdef void *exc_wrap_pointer(void *ptr) except NULL:
         exc = exc_check()
         if exc:
             raise exc
+        raise SystemError(
+            f"Unkown GDAL Error. To debug: {_GDAL_DEBUG_DOCS}"
+        )
     CPLErrorReset()
     return ptr
 
@@ -229,5 +236,8 @@ cdef VSILFILE *exc_wrap_vsilfile(VSILFILE *vsifile) except NULL:
         exc = exc_check()
         if exc:
             raise exc
+        raise SystemError(
+            f"Unkown GDAL Error. To debug: {_GDAL_DEBUG_DOCS}"
+        )
     CPLErrorReset()
     return vsifile


### PR DESCRIPTION
Closes #2492

Not sure of a great way to test this other than the exploration in the issue. It is for edge cases that shouldn't happen normally.