### PR TITLE
Avoid narrowing file stream position to `int` inside `filepath_tell`

### DIFF
--- a/rasterio/_filepath.pyx
+++ b/rasterio/_filepath.pyx
@@ -130,7 +130,7 @@ cdef void* filepath_open(void *pUserData, const char *pszFilename, const char *p
 cdef vsi_l_offset filepath_tell(void *pFile) with gil:
     cdef object file_wrapper = <object>pFile
     cdef object file_obj = file_wrapper._file_obj
-    cdef int pos = file_obj.tell()
+    cdef long pos = file_obj.tell()
     return <vsi_l_offset>pos
 
 

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -65,7 +65,7 @@ cdef extern from "sys/stat.h" nogil:
 
 cdef extern from "cpl_vsi.h" nogil:
 
-    ctypedef int vsi_l_offset
+    ctypedef unsigned long long vsi_l_offset
     ctypedef FILE VSILFILE
     ctypedef stat VSIStatBufL
     ctypedef enum VSIRangeStatus:


### PR DESCRIPTION
Hi, this is my first time submitting a change request to this project. I've read the `CODE_OF_CONDUCT.md` and I agree to abide by it. Let me know if there is anything else I need to do.

This PR concerns a bug that I discovered while operating on large (larger than 2^31 bytes) GeoTIFF files with Rasterio. If you pass such a file into `rasterio.open` using a file-like object, Rasterio will raise a runtime exception when it tries to read that file past the 2^31 byte mark. From what I can tell, this is because Rasterio holds the file stream position in an `int`, but the actual file stream offset obtained from `tell()` is `long`, so this value ends up getting narrowed.

This behavior will only occur if you pass a Python file-like object to `rasterio.open`, and won't happen if you pass the path of a file. (I've already applied this as a mitigation inside my code which uses the Rasterio API.) 

Description of this change:
* I changed the type of `pos` inside `filepath_tell` from `int` to `long`. (It appears that this value [should be a `long` in CPython](https://github.com/python/cpython/blob/db115682bd639a2642c617f0b7d5b30cd7d7f472/Modules/_io/bytesio.c#L379-L391) as it is in POSIX `ftell`.)
* `filepath_tell` returns a `vsi_l_offset` type which is also typedef to `int`, but [in GDAL, this is a `GUIntBig`](https://gdal.org/doxygen/cpl__vsi_8h.html#af56f9ebab1994e4c2ed3f0a50af787b2) (= [`unsigned long long`](https://gdal.org/doxygen/cpl__port_8h.html#a4f0794a0fb78d55ba284a414191dbc93)) so I updated this typedef as well.

I have also [written a short C program](https://gist.github.com/elisw93/6548c42390fab176bc0c99f1578114be) that generates a problem TIF file with the LibTIFF API. (You can decompress `problem.tif.bz2` if you don't want to run this program.) Before applying this code change, `readtiff.py` should produce a runtime error similar to the following snippet. After applying this change to Rasterio, it should print the string `OK`.

```
OverflowError: value too large to convert to int
Exception ignored in: 'rasterio._filepath.filepath_tell'
Traceback (most recent call last):
  File "/.../rasterio/io.py", line 220, in open
    return DatasetReader(mempath, driver=driver, sharing=sharing, **kwargs)
OverflowError: value too large to convert to int
Traceback (most recent call last):
  File "rasterio/_base.pyx", line 302, in rasterio._base.DatasetBase.__init__
  File "rasterio/_base.pyx", line 213, in rasterio._base.open_dataset
  File "rasterio/_err.pyx", line 217, in rasterio._err.exc_wrap_pointer
rasterio._err.CPLE_AppDefinedError: /vsipythonfilelike/bd0b47a9-8eea-4bba-af6c-455e6d4f43d2/bd0b47a9-8eea-4bba-af6c-455e6d4f43d2: TIFFReadDirectory:Failed to read directory at offset 2415919122

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/.../readtiff.py", line 7, in <module>
    with rasterio.open(tif_fp) as tif:
  File "/.../rasterio/env.py", line 444, in wrapper
    return f(*args, **kwds)
  File "/.../rasterio/__init__.py", line 241, in open
    return FilePath(fp).open(driver=driver, sharing=sharing, **kwargs)
  File "/.../rasterio/env.py", line 391, in wrapper
    return f(*args, **kwds)
  File "/.../rasterio/io.py", line 220, in open
    return DatasetReader(mempath, driver=driver, sharing=sharing, **kwargs)
  File "rasterio/_base.pyx", line 304, in rasterio._base.DatasetBase.__init__
rasterio.errors.RasterioIOError: /vsipythonfilelike/bd0b47a9-8eea-4bba-af6c-455e6d4f43d2/bd0b47a9-8eea-4bba-af6c-455e6d4f43d2: TIFFReadDirectory:Failed to read directory at offset 2415919122
```