### PR TITLE
Fixes for unsigned access to S3

### DIFF
--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -338,8 +338,8 @@ class AWSSession(Session):
         """
         if self.unsigned:
             opts = {'AWS_NO_SIGN_REQUEST': 'YES'}
-            if 'aws_region' in self.credentials:
-                opts['AWS_REGION'] = self.credentials['aws_region']
+            opts.update({k.upper(): v for k, v in self.credentials.items()
+                        if k in ('aws_region', 'aws_s3_endpoint')})
             return opts
         else:
             return {k.upper(): v for k, v in self.credentials.items()}

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -562,7 +562,7 @@ class AzureSession(Session):
             If True, requests will be unsigned.
         """
 
-        self.unsigned = bool(os.getenv("AZURE_NO_SIGN_REQUEST", azure_unsigned))
+        self.unsigned = parse_bool(os.getenv("AZURE_NO_SIGN_REQUEST", azure_unsigned))
         self.storage_account = azure_storage_account or os.getenv("AZURE_STORAGE_ACCOUNT")
         self.storage_access_key = azure_storage_access_key or os.getenv("AZURE_STORAGE_ACCESS_KEY")
 
@@ -622,3 +622,11 @@ class AzureSession(Session):
             }
         else:
             return {k.upper(): v for k, v in self.credentials.items()}
+
+def parse_bool(v):
+    """CPLTestBool equivalent"""
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return not(v.lower() in ("no", "false", "off", "0"))
+    return bool(v)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -92,6 +92,9 @@ def test_aws_session_class_endpoint():
     sesh = AWSSession(endpoint_url="example.com")
     assert sesh.get_credential_options()['AWS_S3_ENDPOINT'] == 'example.com'
 
+    sesh = AWSSession(endpoint_url="example.com", aws_unsigned=True)
+    assert sesh.get_credential_options()['AWS_S3_ENDPOINT'] == 'example.com'
+
 
 def test_session_factory_unparsed():
     """Get a DummySession for unparsed paths"""

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -60,12 +60,39 @@ def test_aws_session_class_session():
     assert sesh.get_credential_options()['AWS_SECRET_ACCESS_KEY'] == 'bar'
 
 
-def test_aws_session_class_unsigned():
+def test_aws_session_class_unsigned(monkeypatch):
     """AWSSession works"""
-    pytest.importorskip("boto3")
-    sesh = AWSSession(aws_unsigned=True, region_name='us-mountain-1')
+    sesh = AWSSession(aws_unsigned=True, region_name='us-mountain-1',
+                      endpoint_url="http://localhost:9090")
     assert sesh.get_credential_options()['AWS_NO_SIGN_REQUEST'] == 'YES'
     assert sesh.get_credential_options()['AWS_REGION'] == 'us-mountain-1'
+    assert sesh.get_credential_options()['AWS_S3_ENDPOINT'] == 'http://localhost:9090'
+
+    # default to environment variable when not set 
+    monkeypatch.setenv("AWS_NO_SIGN_REQUEST", "YES")
+    sesh = AWSSession()
+    assert sesh.unsigned is True
+    assert sesh.get_credential_options()['AWS_NO_SIGN_REQUEST'] == 'YES'
+
+    # Arguments override environment variable 
+    sesh = AWSSession(aws_access_key_id="fake", aws_secret_access_key="fake", aws_unsigned=False)
+    assert sesh.unsigned is False
+    assert 'AWS_NO_SIGN_REQUEST' not in sesh.get_credential_options()
+
+    monkeypatch.undo()
+
+
+def test_aws_session_class_unsigned_noboto3(monkeypatch):
+    """AWSSession works without boto3"""
+    import rasterio.session
+    monkeypatch.setenv("AWS_NO_SIGN_REQUEST", "YES")
+    monkeypatch.setattr(rasterio.session, "boto3", None)
+    assert rasterio.session.boto3 is None
+
+    sesh = AWSSession()
+    assert sesh.unsigned is True
+    assert sesh.get_credential_options()['AWS_NO_SIGN_REQUEST'] == 'YES'
+    monkeypatch.undo()
 
 
 def test_aws_session_class_profile(tmpdir, monkeypatch):

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -32,16 +32,28 @@ def test_dummy_session():
     assert sesh._session is None
     assert sesh.get_credential_options() == {}
 
-def test_parse_bool():
+
+@pytest.mark.parametrize(("v", "vparsed"), [
+    (None, False),
+    (False, False),
+    (0, False),
+    (True, True),
+    ("", True),
+    ("yes", True),
+    ("YES", True),
+    ("no", False),
+    ("No", False),
+    ("NO", False),
+    ("off", False),
+    ("0", False),
+    ("false", False),
+    ("FaLsE", False),
+])
+def test_parse_bool(v, vparsed):
     """parse_bool works"""
-    assert parse_bool(None) is False
-    assert parse_bool(False) is False
-    assert parse_bool(0) is False
-    assert parse_bool(True) is True
-    assert parse_bool("") is True
-    for no in ["no", "off", "0", "false"]:
-        assert parse_bool(no) is False
-        assert parse_bool(no.upper()) is False
+    assert isinstance(parse_bool(v), bool)
+    assert parse_bool(v) == vparsed
+
 
 def test_aws_session_class():
     """AWSSession works"""

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,6 +12,7 @@ from rasterio.session import (
     GSSession,
     SwiftSession,
     AzureSession,
+    parse_bool,
 )
 
 
@@ -31,6 +32,16 @@ def test_dummy_session():
     assert sesh._session is None
     assert sesh.get_credential_options() == {}
 
+def test_parse_bool():
+    """parse_bool works"""
+    assert parse_bool(None) is False
+    assert parse_bool(False) is False
+    assert parse_bool(0) is False
+    assert parse_bool(True) is True
+    assert parse_bool("") is True
+    for no in ["no", "off", "0", "false"]:
+        assert parse_bool(no) is False
+        assert parse_bool(no.upper()) is False
 
 def test_aws_session_class():
     """AWSSession works"""


### PR DESCRIPTION
This PR fixes several issues around use of `AWSSession` when accessing public resources (`aws_unsigned=True` case)

1. S3 endpoint configuration was not propagated in the unsigned case
2. Value stored inside `AWS_NO_SIGN_REQUEST` and `AZURE_NO_SIGN_REQUEST` was always parsed as `True`
3. `AWSSession` could not be constructed when `boto3` is missing
4. No way to force `aws_unsigned=False` configuration when `AWS_NO_SIGN_REQUEST=YES` is configured in the environment.

`AWSSession` does more than just credential management for S3 access, so it's needed even when accessing public S3 buckets without relying on environment variables. `boto3` is an optional dependency of `rasterio`, and I think `rasterio` should work without `boto3` when accessing public S3 buckets.

Example of user confusion:

```
conda create -n rio python=3.10 rasterio=1.3.4
conda activate rio
rio --aws-no-sign-requests info s3://sentinel-cogs/sentinel-s2-l2a-cogs/42/C/WA/2020/1/S2B_42CWA_20200103_0_L2A/B01.tif
```

This currently fails with:

```
  File "/envs/rio/lib/python3.10/site-packages/rasterio/session.py", line 277, in __init__
    self._session = boto3.Session(
AttributeError: 'NoneType' object has no attribute 'Session'
```

After changes in this PR it should work without needing to install `boto3`.
