### PR TITLE
Custom S3 path support

### DIFF
--- a/docs/topics/vsi.rst
+++ b/docs/topics/vsi.rst
@@ -44,6 +44,24 @@ your code.
     #        0.0, -30.0, 2512815.0),
     #  'width': 7621}
 
+S3 URIs and custom S3 Service
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+By default, rasterio open with an AWS Session object all URIs that begin with
+``s3://`` or containing ``amazonaws.com`` (except for Pre-signed URLs identified 
+by the ``X-Amz-Signature`` query parameter).
+
+It is possible to set addditional domains suffixes to be considered as S3 URIs by
+setting the ``RIO_AWS_S3_DOMAINS`` environment variable with comma-separated domain names.
+For instance ``s3.acme.com,s3.test.com`` will make rasterio consider
+all URIs with these domain name suffixes as S3 URIs (e.g. ``"https://s3.acme.com/bucket/key"``
+or ``"https://bucket.s3.test.com/key"``).
+In this case, it is probably necessary to set as well the ``AWS_S3_ENDPOINT_URL`` environment
+variable to the alternative endpoint for S3 service.
+See `GDAL's documentation<https://gdal.org/user/virtual_file_systems.html#vsis3-aws-s3-files>` 
+of the ``AWS_S3_ENDPOINT`` configuration option for more details.
+
+
 .. note:: AWS pricing concerns
    While this feature can reduce latency by reading fewer bytes from S3
    compared to downloading the entire TIFF and opening locally, it does

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -98,14 +98,17 @@ class Session:
 
         path = _parse_path(path)
 
-        aws_path_regex = r"^s3://|^https?://.*\.s3\.amazonaws\.com/"
-        aws_path_regex = os.getenv("AWS_PATH_REGEX", aws_path_regex)
+        aws_path_regex = r"a^"
+        rio_aws_s3_domains = os.getenv("RIO_AWS_S3_DOMAINS")
+        if rio_aws_s3_domains:
+            aws_path_regex = r"^https://.*(?:%s)" % "|".join(rio_aws_s3_domains.split(","))
 
         if isinstance(path, _UnparsedPath) or path.is_local:
             return DummySession
 
         elif (
-            re.match(aws_path_regex, path.name)
+            path.scheme == "s3" or "amazonaws.com" in path.path
+            or re.match(aws_path_regex, path.name)
         ) and not "X-Amz-Signature" in path.path:
             if boto3 is not None:
                 return AWSSession

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+import re
 
 from rasterio._path import _parse_path, _UnparsedPath
 
@@ -97,11 +98,14 @@ class Session:
 
         path = _parse_path(path)
 
+        aws_path_regex = r"^s3://|^https?://.*\.s3\.amazonaws\.com/"
+        aws_path_regex = os.getenv("AWS_PATH_REGEX", aws_path_regex)
+
         if isinstance(path, _UnparsedPath) or path.is_local:
             return DummySession
 
         elif (
-            path.scheme == "s3" or "amazonaws.com" in path.path
+            re.match(aws_path_regex, path.name)
         ) and not "X-Amz-Signature" in path.path:
             if boto3 is not None:
                 return AWSSession

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -101,7 +101,7 @@ class Session:
         aws_path_regex = r"a^"
         rio_aws_s3_domains = os.getenv("RIO_AWS_S3_DOMAINS")
         if rio_aws_s3_domains:
-            aws_path_regex = r"^https://.*(?:%s)" % "|".join(rio_aws_s3_domains.split(","))
+            aws_path_regex = r"^https://.*(?:%s)" % "|".join(rio_aws_s3_domains.replace(".", r"\.").replace("*", ".*").split(","))
 
         if isinstance(path, _UnparsedPath) or path.is_local:
             return DummySession

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -136,6 +136,18 @@ def test_session_factory_s3_kwargs():
     assert sesh._session.get_credentials().access_key == 'foo'
     assert sesh._session.get_credentials().secret_key == 'bar'
 
+def test_session_factory_custom_s3(monkeypatch):
+    """Get an AWSSession for a custom s3 paths"""
+    pytest.importorskip("boto3")
+    monkeypatch.setenv("AWS_PATH_REGEX", "s3://|^https?://.*\.s3\.amazonaws\.com/|^https://s3.acme.com/")
+    sesh = Session.from_path("https://s3.acme.com/bucket/key")
+    assert isinstance(sesh, AWSSession)
+
+def test_session_factory_custom_s3_without_env():
+    """Get an AWSSession for a custom s3 paths"""
+    pytest.importorskip("boto3")
+    sesh = Session.from_path("https://s3.acme.com/bucket/key")
+    assert isinstance(sesh, DummySession)
 
 def test_foreign_session_factory_dummy():
     sesh = Session.from_foreign_session(None)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -139,9 +139,15 @@ def test_session_factory_s3_kwargs():
 def test_session_factory_custom_s3(monkeypatch):
     """Get an AWSSession for a custom s3 paths"""
     pytest.importorskip("boto3")
-    monkeypatch.setenv("AWS_PATH_REGEX", "s3://|^https?://.*\.s3\.amazonaws\.com/|^https://s3.acme.com/")
+    monkeypatch.setenv("RIO_AWS_S3_DOMAINS", "s3.acme.com,s3.test.com,s3.example.com")
     sesh = Session.from_path("https://s3.acme.com/bucket/key")
     assert isinstance(sesh, AWSSession)
+    sesh = Session.from_path("https://bucket.s3.test.com/key")
+    assert isinstance(sesh, AWSSession)
+    sesh = Session.from_path("https://s3.example.com/bucket/key")
+    assert isinstance(sesh, AWSSession)
+    sesh = Session.from_path("https://s3-console.example.com/bucket/key")
+    assert isinstance(sesh, DummySession)
 
 def test_session_factory_custom_s3_without_env():
     """Get an AWSSession for a custom s3 paths"""


### PR DESCRIPTION
**Proposed Changes:**

This PR add support for creating S3 sessions for custom urls passing an environment variable `AWS_PATH_REGEX`.
All matching path would the be handled as S3 input

**PR Checklist:**

- [X] This PR has **no** breaking changes.
- [X] Tests passes