### PR TITLE
TST: Use GDALVersion in test_gdal_version

### DIFF
--- a/tests/test_rio_main.py
+++ b/tests/test_rio_main.py
@@ -1,6 +1,7 @@
 import logging
 import sys
 
+from rasterio.env import GDALVersion
 from packaging.version import parse
 
 from rasterio.rio.main import main_group
@@ -18,7 +19,7 @@ def test_version(runner):
 def test_gdal_version(runner):
     result = runner.invoke(main_group, ['--gdal-version'])
     assert result.exit_code == 0
-    assert parse(result.output.strip())
+    assert GDALVersion.parse(result.output.strip())
 
 
 def test_show_versions(runner):


### PR DESCRIPTION
Note: This adds the fix test failure https://github.com/rasterio/rasterio/actions/runs/3705505518/jobs/6279503388

```
______________________________ test_gdal_version _______________________________

runner = <click.testing.CliRunner object at 0x7f04c18e4d90>

    def test_gdal_version(runner):
        result = runner.invoke(main_group, ['--gdal-version'])
        assert result.exit_code == 0
>       assert parse(result.output.strip())

tests/test_rio_main.py:21: 
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 
testenv/lib/python3.10/site-packages/packaging/version.py:52: in parse
    return Version(version)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

self = <[AttributeError("'Version' object has no attribute '_version'") raised in repr()] Version object at 0x7f04c18e4f70>
version = '3.7.0dev-87fda0221a'

    def __init__(self, version: str) -> None:
        """Initialize a Version object.
    
        :param version:
            The string representation of a version which will be parsed and normalized
            before use.
        :raises InvalidVersion:
            If the ``version`` does not conform to PEP 440 in any way then this
            exception will be raised.
        """
    
        # Validate the version and parse it into pieces
        match = self._regex.search(version)
        if not match:
>           raise InvalidVersion(f"Invalid version: '{version}'")
E           packaging.version.InvalidVersion: Invalid version: '3.7.0dev-87fda0221a'
```