### PR TITLE
BUG: Fixes for unsigned access to S3 (#2669)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ Changes
 
 Bug fixes:
 
+- Fixes for unsigned access to S3 (#2688, backport of #2669).
 - Ignore blockysize when converting untiled datasets to tiled datasets (#2687,
   backport of #2678).
 

--- a/rasterio/session.py
+++ b/rasterio/session.py
@@ -2,6 +2,7 @@
 
 import logging
 import os
+from types import SimpleNamespace
 
 from rasterio._path import _parse_path, _UnparsedPath
 
@@ -243,7 +244,7 @@ class AWSSession(Session):
     """
 
     def __init__(
-            self, session=None, aws_unsigned=False, aws_access_key_id=None,
+            self, session=None, aws_unsigned=None, aws_access_key_id=None,
             aws_secret_access_key=None, aws_session_token=None,
             region_name=None, profile_name=None, endpoint_url=None,
             requester_pays=False):
@@ -271,8 +272,13 @@ class AWSSession(Session):
             True if the requester agrees to pay transfer costs (default:
             False)
         """
+        if aws_unsigned is None:
+            aws_unsigned = parse_bool(os.getenv("AWS_NO_SIGN_REQUEST", False))
+
         if session:
             self._session = session
+        elif aws_unsigned:
+            self._session = SimpleNamespace(region_name=region_name)
         else:
             self._session = boto3.Session(
                 aws_access_key_id=aws_access_key_id,
@@ -282,11 +288,11 @@ class AWSSession(Session):
                 profile_name=profile_name)
 
         self.requester_pays = requester_pays
-        self.unsigned = bool(os.getenv("AWS_NO_SIGN_REQUEST", aws_unsigned))
+        self.unsigned = aws_unsigned
         self.endpoint_url = endpoint_url
         self._creds = (
             self._session.get_credentials()
-            if not self.unsigned and self._session
+            if not self.unsigned
             else None
         )
 
@@ -338,8 +344,8 @@ class AWSSession(Session):
         """
         if self.unsigned:
             opts = {'AWS_NO_SIGN_REQUEST': 'YES'}
-            if 'aws_region' in self.credentials:
-                opts['AWS_REGION'] = self.credentials['aws_region']
+            opts.update({k.upper(): v for k, v in self.credentials.items()
+                        if k in ('aws_region', 'aws_s3_endpoint')})
             return opts
         else:
             return {k.upper(): v for k, v in self.credentials.items()}
@@ -562,7 +568,7 @@ class AzureSession(Session):
             If True, requests will be unsigned.
         """
 
-        self.unsigned = bool(os.getenv("AZURE_NO_SIGN_REQUEST", azure_unsigned))
+        self.unsigned = parse_bool(os.getenv("AZURE_NO_SIGN_REQUEST", azure_unsigned))
         self.storage_account = azure_storage_account or os.getenv("AZURE_STORAGE_ACCOUNT")
         self.storage_access_key = azure_storage_access_key or os.getenv("AZURE_STORAGE_ACCESS_KEY")
 
@@ -622,3 +628,11 @@ class AzureSession(Session):
             }
         else:
             return {k.upper(): v for k, v in self.credentials.items()}
+
+def parse_bool(v):
+    """CPLTestBool equivalent"""
+    if isinstance(v, bool):
+        return v
+    if isinstance(v, str):
+        return not(v.lower() in ("no", "false", "off", "0"))
+    return bool(v)

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -12,6 +12,7 @@ from rasterio.session import (
     GSSession,
     SwiftSession,
     AzureSession,
+    parse_bool,
 )
 
 
@@ -32,6 +33,28 @@ def test_dummy_session():
     assert sesh.get_credential_options() == {}
 
 
+@pytest.mark.parametrize(("v", "vparsed"), [
+    (None, False),
+    (False, False),
+    (0, False),
+    (True, True),
+    ("", True),
+    ("yes", True),
+    ("YES", True),
+    ("no", False),
+    ("No", False),
+    ("NO", False),
+    ("off", False),
+    ("0", False),
+    ("false", False),
+    ("FaLsE", False),
+])
+def test_parse_bool(v, vparsed):
+    """parse_bool works"""
+    assert isinstance(parse_bool(v), bool)
+    assert parse_bool(v) == vparsed
+
+
 def test_aws_session_class():
     """AWSSession works"""
     sesh = AWSSession(aws_access_key_id='foo', aws_secret_access_key='bar')
@@ -49,12 +72,39 @@ def test_aws_session_class_session():
     assert sesh.get_credential_options()['AWS_SECRET_ACCESS_KEY'] == 'bar'
 
 
-def test_aws_session_class_unsigned():
+def test_aws_session_class_unsigned(monkeypatch):
     """AWSSession works"""
-    pytest.importorskip("boto3")
-    sesh = AWSSession(aws_unsigned=True, region_name='us-mountain-1')
+    sesh = AWSSession(aws_unsigned=True, region_name='us-mountain-1',
+                      endpoint_url="http://localhost:9090")
     assert sesh.get_credential_options()['AWS_NO_SIGN_REQUEST'] == 'YES'
     assert sesh.get_credential_options()['AWS_REGION'] == 'us-mountain-1'
+    assert sesh.get_credential_options()['AWS_S3_ENDPOINT'] == 'http://localhost:9090'
+
+    # default to environment variable when not set 
+    monkeypatch.setenv("AWS_NO_SIGN_REQUEST", "YES")
+    sesh = AWSSession()
+    assert sesh.unsigned is True
+    assert sesh.get_credential_options()['AWS_NO_SIGN_REQUEST'] == 'YES'
+
+    # Arguments override environment variable 
+    sesh = AWSSession(aws_access_key_id="fake", aws_secret_access_key="fake", aws_unsigned=False)
+    assert sesh.unsigned is False
+    assert 'AWS_NO_SIGN_REQUEST' not in sesh.get_credential_options()
+
+    monkeypatch.undo()
+
+
+def test_aws_session_class_unsigned_noboto3(monkeypatch):
+    """AWSSession works without boto3"""
+    import rasterio.session
+    monkeypatch.setenv("AWS_NO_SIGN_REQUEST", "YES")
+    monkeypatch.setattr(rasterio.session, "boto3", None)
+    assert rasterio.session.boto3 is None
+
+    sesh = AWSSession()
+    assert sesh.unsigned is True
+    assert sesh.get_credential_options()['AWS_NO_SIGN_REQUEST'] == 'YES'
+    monkeypatch.undo()
 
 
 def test_aws_session_class_profile(tmpdir, monkeypatch):
@@ -79,6 +129,9 @@ def test_aws_session_class_endpoint():
     """Confirm that endpoint_url kwarg works."""
     pytest.importorskip("boto3")
     sesh = AWSSession(endpoint_url="example.com")
+    assert sesh.get_credential_options()['AWS_S3_ENDPOINT'] == 'example.com'
+
+    sesh = AWSSession(endpoint_url="example.com", aws_unsigned=True)
     assert sesh.get_credential_options()['AWS_S3_ENDPOINT'] == 'example.com'
 
 


### PR DESCRIPTION
* Add parse_bool helper method

This is for parsing boolean environment variables

* Fix s3_endpoint config when unsigned

S3 endpoint configuration was not propagated to GDAL when accessing public buckets.

* Allow AWSSession construction without boto3

Should be able to use AWSSession even when boto3 is not installed so long as unsigned access is used.

AWSSession is responsible to configuration of things like region and endpoint url, so it's needed even when accessing public buckets without relying on environment variables. `boto3` dependency is only needed for obtaining credentials though.

* Convert parse_bool test to parametrize for clarity