### PR TITLE
Handle and silence sigpipe errors

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,10 @@ Changes
 
 Bug fixes:
 
+- Python ignores SIGPIPE by default. By never catching BrokenPipeError via
+  `except Exception` when, for example, piping the output of rio-shapes to
+  the Unix head program, we avoid getting an unhandled BrokenPipeError message
+  when the interpreter shuts down (#2689).
 - Fixes for unsigned access to S3 (#2688, backport of #2669).
 - Ignore blockysize when converting untiled datasets to tiled datasets (#2687,
   backport of #2678).

--- a/rasterio/rio/blocks.py
+++ b/rasterio/rio/blocks.py
@@ -10,7 +10,7 @@ import cligj
 
 import rasterio
 from rasterio.rio import options
-from rasterio.rio.helpers import hushpipe, write_features
+from rasterio.rio.helpers import write_features
 from rasterio.warp import transform_bounds
 
 
@@ -95,7 +95,6 @@ class _Collection:
     '--bidx', type=click.INT, default=0,
     help="Index of the band that is the source of shapes.")
 @click.pass_context
-@hushpipe
 def blocks(
     ctx, input, output, precision, indent, compact, projection, sequence, use_rs, bidx
 ):

--- a/rasterio/rio/blocks.py
+++ b/rasterio/rio/blocks.py
@@ -10,7 +10,7 @@ import cligj
 
 import rasterio
 from rasterio.rio import options
-from rasterio.rio.helpers import write_features
+from rasterio.rio.helpers import hushpipe, write_features
 from rasterio.warp import transform_bounds
 
 
@@ -95,10 +95,10 @@ class _Collection:
     '--bidx', type=click.INT, default=0,
     help="Index of the band that is the source of shapes.")
 @click.pass_context
+@hushpipe
 def blocks(
-        ctx, input, output, precision, indent, compact, projection, sequence,
-        use_rs, bidx):
-
+    ctx, input, output, precision, indent, compact, projection, sequence, use_rs, bidx
+):
     """Write dataset blocks as GeoJSON features.
 
     This command writes features describing a raster's internal blocks, which
@@ -131,8 +131,8 @@ def blocks(
 
     For more information on exactly what blocks and windows represent, see
     'dataset.block_windows()'.
-    """
 
+    """
     dump_kwds = {'sort_keys': True}
 
     if indent:
@@ -152,11 +152,13 @@ def blocks(
             dataset=src,
             bidx=bidx,
             precision=precision,
-            geographic=projection != 'projected')
-
+            geographic=projection != "projected",
+        )
         write_features(
-            stdout, collection,
+            stdout,
+            collection,
             sequence=sequence,
-            geojson_type='feature' if sequence else 'collection',
+            geojson_type="feature" if sequence else "collection",
             use_rs=use_rs,
-            **dump_kwds)
+            **dump_kwds
+        )

--- a/rasterio/rio/bounds.py
+++ b/rasterio/rio/bounds.py
@@ -8,7 +8,7 @@ from cligj import (
     use_rs_opt, geojson_type_feature_opt, geojson_type_bbox_opt,
     geojson_type_collection_opt)
 
-from .helpers import hushpipe, write_features, to_lower
+from .helpers import write_features, to_lower
 from rasterio.rio import options
 from rasterio.warp import transform_bounds
 
@@ -35,7 +35,6 @@ logger = logging.getLogger(__name__)
 @geojson_type_feature_opt(True)
 @geojson_type_bbox_opt(False)
 @click.pass_context
-@hushpipe
 def bounds(
     ctx,
     input,

--- a/rasterio/rio/bounds.py
+++ b/rasterio/rio/bounds.py
@@ -8,8 +8,7 @@ from cligj import (
     use_rs_opt, geojson_type_feature_opt, geojson_type_bbox_opt,
     geojson_type_collection_opt)
 
-from .helpers import write_features, to_lower
-import rasterio
+from .helpers import hushpipe, write_features, to_lower
 from rasterio.rio import options
 from rasterio.warp import transform_bounds
 
@@ -36,8 +35,19 @@ logger = logging.getLogger(__name__)
 @geojson_type_feature_opt(True)
 @geojson_type_bbox_opt(False)
 @click.pass_context
-def bounds(ctx, input, precision, indent, compact, projection, dst_crs,
-           sequence, use_rs, geojson_type):
+@hushpipe
+def bounds(
+    ctx,
+    input,
+    precision,
+    indent,
+    compact,
+    projection,
+    dst_crs,
+    sequence,
+    use_rs,
+    geojson_type,
+):
     """Write bounding boxes to stdout as GeoJSON for use with, e.g.,
     geojsonio
 
@@ -104,13 +114,12 @@ def bounds(ctx, input, precision, indent, compact, projection, dst_crs,
                 self._xs.extend(bbox[::2])
                 self._ys.extend(bbox[1::2])
 
-    try:
-        with ctx.obj['env'] as env:
-            write_features(
-                stdout, Collection(env), sequence=sequence,
-                geojson_type=geojson_type, use_rs=use_rs,
-                **dump_kwds)
-
-    except Exception:
-        logger.exception("Exception caught during processing")
-        raise click.Abort()
+    with ctx.obj["env"] as env:
+        write_features(
+            stdout,
+            Collection(env),
+            sequence=sequence,
+            geojson_type=geojson_type,
+            use_rs=use_rs,
+            **dump_kwds
+        )

--- a/rasterio/rio/gcps.py
+++ b/rasterio/rio/gcps.py
@@ -12,7 +12,6 @@ from cligj import (
 import rasterio
 import rasterio.crs
 from rasterio.rio import options
-from rasterio.rio.helpers import hushpipe
 from rasterio.warp import transform_geom
 
 
@@ -37,7 +36,6 @@ sequence_opt = click.option(
 @indent_opt
 @compact_opt
 @click.pass_context
-@hushpipe
 def gcps(ctx, input, geojson_type, projection, precision, use_rs, indent, compact):
     """Print GeoJSON representations of a dataset's control points.
 

--- a/rasterio/rio/helpers.py
+++ b/rasterio/rio/helpers.py
@@ -2,10 +2,8 @@
 Helper objects used by multiple CLI commands.
 """
 
-from functools import wraps
 import json
 import os
-import sys
 
 import click
 
@@ -120,27 +118,3 @@ def resolve_inout(
 def to_lower(ctx, param, value):
     """Click callback, converts values to lowercase."""
     return value.lower()
-
-
-def hushpipe(func):
-    """Handle and silence broken pipe exceptions
-
-    See https://docs.python.org/3/library/signal.html#note-on-sigpipeef
-
-    """
-
-    @wraps(func)
-    def wrapper(*args, **kwargs):
-        try:
-            func(*args, **kwargs)
-        except click.ClickException:
-            raise
-        except BrokenPipeError:
-            # Python flushes standard streams on exit; redirect remaining output
-            # to devnull to avoid another BrokenPipeError at shutdown
-            devnull = os.open(os.devnull, os.O_WRONLY)
-            os.dup2(devnull, sys.stdout.fileno())
-        except Exception as exc:
-            raise click.ClickException(exc)
-
-    return wrapper

--- a/rasterio/rio/helpers.py
+++ b/rasterio/rio/helpers.py
@@ -2,8 +2,10 @@
 Helper objects used by multiple CLI commands.
 """
 
+from functools import wraps
 import json
 import os
+import sys
 
 import click
 
@@ -118,3 +120,27 @@ def resolve_inout(
 def to_lower(ctx, param, value):
     """Click callback, converts values to lowercase."""
     return value.lower()
+
+
+def hushpipe(func):
+    """Handle and silence broken pipe exceptions
+
+    See https://docs.python.org/3/library/signal.html#note-on-sigpipeef
+
+    """
+
+    @wraps(func)
+    def wrapper(*args, **kwargs):
+        try:
+            func(*args, **kwargs)
+        except click.ClickException:
+            raise
+        except BrokenPipeError:
+            # Python flushes standard streams on exit; redirect remaining output
+            # to devnull to avoid another BrokenPipeError at shutdown
+            devnull = os.open(os.devnull, os.O_WRONLY)
+            os.dup2(devnull, sys.stdout.fileno())
+        except Exception as exc:
+            raise click.ClickException(exc)
+
+    return wrapper

--- a/rasterio/rio/sample.py
+++ b/rasterio/rio/sample.py
@@ -3,14 +3,12 @@ import json
 import click
 
 import rasterio
-from rasterio.rio.helpers import hushpipe
 
 
 @click.command(short_help="Sample a dataset.")
 @click.argument('files', nargs=-1, required=True, metavar='FILE "[x, y]"')
 @click.option('-b', '--bidx', default=None, help="Indexes of input file bands.")
 @click.pass_context
-@hushpipe
 def sample(ctx, files, bidx):
     """Sample a dataset at one or more points
 

--- a/rasterio/rio/shapes.py
+++ b/rasterio/rio/shapes.py
@@ -11,7 +11,7 @@ import rasterio
 
 from rasterio.rio import options
 from rasterio.features import dataset_features
-from rasterio.rio.helpers import hushpipe, write_features
+from rasterio.rio.helpers import write_features
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,6 @@ logger = logging.getLogger(__name__)
               help="Interpret a band as a mask and output only one class of "
                    "valid data shapes.")
 @click.pass_context
-@hushpipe
 def shapes(
         ctx, input, output, precision, indent, compact, projection, sequence,
         use_rs, geojson_type, band, bandidx, sampling, with_nodata, as_mask):

--- a/rasterio/rio/transform.py
+++ b/rasterio/rio/transform.py
@@ -1,11 +1,11 @@
 """Fetch and edit raster dataset metadata from the command line."""
 
 import json
-import logging
 
 import click
 from cligj import precision_opt
 
+from rasterio.rio.helpers import hushpipe
 import rasterio.shutil
 
 
@@ -17,10 +17,9 @@ import rasterio.shutil
               help="Destination CRS.")
 @precision_opt
 @click.pass_context
+@hushpipe
 def transform(ctx, input, src_crs, dst_crs, precision):
     import rasterio.warp
-
-    logger = logging.getLogger(__name__)
 
     # Handle the case of file, stream, or string input.
     try:
@@ -28,31 +27,31 @@ def transform(ctx, input, src_crs, dst_crs, precision):
     except OSError:
         src = [input]
 
-    try:
-        with ctx.obj['env']:
-            if src_crs.startswith('EPSG'):
-                src_crs = {'init': src_crs}
-            elif rasterio.shutil.exists(src_crs):
-                with rasterio.open(src_crs) as f:
-                    src_crs = f.crs
-            if dst_crs.startswith('EPSG'):
-                dst_crs = {'init': dst_crs}
-            elif rasterio.shutil.exists(dst_crs):
-                with rasterio.open(dst_crs) as f:
-                    dst_crs = f.crs
-            for line in src:
-                coords = json.loads(line)
-                xs = coords[::2]
-                ys = coords[1::2]
-                xs, ys = rasterio.warp.transform(src_crs, dst_crs, xs, ys)
-                if precision >= 0:
-                    xs = [round(v, precision) for v in xs]
-                    ys = [round(v, precision) for v in ys]
-                result = [0] * len(coords)
-                result[::2] = xs
-                result[1::2] = ys
-                print(json.dumps(result))
+    with ctx.obj["env"]:
 
-    except Exception:
-        logger.exception("Exception caught during processing")
-        raise click.Abort()
+        if src_crs.startswith("EPSG"):
+            src_crs = {"init": src_crs}
+        elif rasterio.shutil.exists(src_crs):
+            with rasterio.open(src_crs) as f:
+                src_crs = f.crs
+
+        if dst_crs.startswith("EPSG"):
+            dst_crs = {"init": dst_crs}
+        elif rasterio.shutil.exists(dst_crs):
+            with rasterio.open(dst_crs) as f:
+                dst_crs = f.crs
+
+        for line in src:
+            coords = json.loads(line)
+            xs = coords[::2]
+            ys = coords[1::2]
+            xs, ys = rasterio.warp.transform(src_crs, dst_crs, xs, ys)
+
+            if precision >= 0:
+                xs = [round(v, precision) for v in xs]
+                ys = [round(v, precision) for v in ys]
+
+            result = [0] * len(coords)
+            result[::2] = xs
+            result[1::2] = ys
+            click.echo(json.dumps(result))

--- a/rasterio/rio/transform.py
+++ b/rasterio/rio/transform.py
@@ -5,7 +5,6 @@ import json
 import click
 from cligj import precision_opt
 
-from rasterio.rio.helpers import hushpipe
 import rasterio.shutil
 
 
@@ -17,7 +16,6 @@ import rasterio.shutil
               help="Destination CRS.")
 @precision_opt
 @click.pass_context
-@hushpipe
 def transform(ctx, input, src_crs, dst_crs, precision):
     import rasterio.warp
 


### PR DESCRIPTION
Resolves #818. I've learned some things about Python!

Python ignores SIGPIPE by default. By never catching BrokenPipeError via `except Exception` when, for example, piping the output of rio-shapes to  the Unix head program, we avoid getting an unhandled BrokenPipeError message when the interpreter shuts down (#2689).

I also did a little linting, caught a case of using print instead of click.echo, and reformatted a few blocks that look gross to my black-adjusted eyes.