### PR TITLE
ENH: Add support for merging tiffs with different CRS

### DIFF
--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -8,7 +8,7 @@ import pytest
 
 import affine
 import rasterio
-from rasterio.merge import merge
+from rasterio.merge import merge, merge_with_crs
 
 # Non-coincident datasets test fixture.
 # Three overlapping GeoTIFFs, two to the NW and one to the SE.
@@ -102,6 +102,73 @@ def test_issue2202(dx, dy):
             ]
         ]
         aux_array, aux_transform = rasterio.merge.merge(datasets=ds, bounds=aoi.bounds)
+        from rasterio.plot import show
+
+        show(aux_array)
+
+# Test with CRS consideration
+@pytest.mark.parametrize(
+    "method,value",
+    [("first", 1), ("last", 2), ("min", 1), ("max", 3), ("sum", 6), ("count", 3)],
+)
+def test_merge_with_crs_method(test_data_dir_overlapping, method, value):
+    """Merge method with CRS produces expected values in intersection"""
+    inputs = sorted(list(test_data_dir_overlapping.iterdir()))  # nw is first.
+    datasets = [rasterio.open(x) for x in inputs]
+    output_count = 1
+    arr, _ = merge_with_crs(
+        datasets, output_count=output_count, method=method, dtype=numpy.uint64
+    )
+    numpy.testing.assert_array_equal(arr[:, 5:10, 5:10], value)
+
+
+def test_issue2163_with_crs():
+    """Demonstrate fix for issue 2163"""
+    with rasterio.open("tests/data/float_raster_with_nodata.tif") as src:
+        data = src.read()
+        result, transform = merge_with_crs([src])
+        assert numpy.allclose(
+            data, result[:, : data.shape[1], : data.shape[2]])
+
+
+def test_unsafe_casting_with_crs():
+    """Demonstrate fix for issue 2179"""
+    with rasterio.open("tests/data/float_raster_with_nodata.tif") as src:
+        result, transform = merge_with_crs([src], dtype="uint8", nodata=0.0)
+        assert not result.any()  # this is why it's called "unsafe".
+
+
+@pytest.mark.skipif(
+    not (boto3.Session().get_credentials()),
+    reason="S3 raster access requires credentials",
+)
+@pytest.mark.network
+@pytest.mark.slow
+@settings(deadline=None, max_examples=5)
+@given(
+    dx=floats(min_value=-0.05, max_value=0.05),
+    dy=floats(min_value=-0.05, max_value=0.05),
+)
+def test_issue2202_with_crs(dx, dy):
+    import rasterio.merge
+    from shapely import wkt
+    from shapely.affinity import translate
+
+    aoi = wkt.loads(
+        r"POLYGON((11.09 47.94, 11.06 48.01, 11.12 48.11, 11.18 48.11, 11.18 47.94, 11.09 47.94))"
+    )
+    aoi = translate(aoi, dx, dy)
+
+    with rasterio.Env(AWS_NO_SIGN_REQUEST=True,):
+        ds = [
+            rasterio.open(i)
+            for i in [
+                "/vsis3/copernicus-dem-30m/Copernicus_DSM_COG_10_N47_00_E011_00_DEM/Copernicus_DSM_COG_10_N47_00_E011_00_DEM.tif",
+                "/vsis3/copernicus-dem-30m/Copernicus_DSM_COG_10_N48_00_E011_00_DEM/Copernicus_DSM_COG_10_N48_00_E011_00_DEM.tif",
+            ]
+        ]
+        aux_array, aux_transform = rasterio.merge.merge_with_crs(
+            datasets=ds, bounds=aoi.bounds)
         from rasterio.plot import show
 
         show(aux_array)


### PR DESCRIPTION
(Following https://github.com/rasterio/rasterio/issues/2696)

I have been looking into the implementation of [rasterio.merge.merge](https://github.com/rasterio/rasterio/blob/main/rasterio/merge.py) to "prefetch" common bounds from a group of rasters. Once working on my implementation (since the function isn't currently too modular) I realized that I was getting errors when calculating common bounds of tiffs.

After some investigation, it turns out this was because the CRS of each tif was different, resulting in bounds given in different units. Before implementing my own solution, I looked at the merge implementation again but found no consideration for this. In the end, I implemented a solution based on [rasterio.warp.transform_bounds](https://rasterio.readthedocs.io/en/latest/api/rasterio.warp.html#rasterio.warp.transform_bounds).

I currently implemented this solution with a separate function since it may be a backward breaking change and I'm not sure whether that is something that would be appreciated. I replicated all existing tests for the new merge function (with support for multiple CRSs) but still need to add tests to check the feature specifically (i.e. actively try to merge tiffs with different CRSs).