### PR TITLE
Allow crop and invert in raster_geometry_mask

### DIFF
--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -38,12 +38,14 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
         If False (default), include a pixel only if its center is within one of
         the shapes, or if it is selected by Bresenham's line algorithm.
     invert : bool (opt)
-        If False (default), mask will be `False` inside shapes and `True`
-        outside.  If True, mask will be `True` inside shapes and `False`
-        outside.
+        Determines whether to mask pixels outside or inside the shapes.
+        The default (False) is to mask pixels outside shapes.
+        When invert is used with crop, the area outside the cropping window is
+        considered selected and should be processed accordingly by the user.
     crop : bool (opt)
-        Whether to crop the dataset to the extent of the shapes. Defaults to
-        False.
+        Crop the dataset to the extent of the shapes. Useful for
+        processing rasters where shapes cover only a relatively small area.
+        Defaults to False.
     pad : bool (opt)
         If True, the features will be padded in each direction by
         one half of a pixel prior to cropping dataset. Defaults to False.
@@ -57,8 +59,9 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
 
         Three elements:
 
-            mask : numpy ndarray of type 'bool'
-                Mask that is `True` outside shapes, and `False` within shapes.
+            mask : np.ndarray of type 'bool'
+                Mask suitable for use in a MaskedArray where valid pixels are
+                marked `False` and invalid pixels are marked `True`.
 
             out_transform : affine.Affine()
                 Information for mapping pixel coordinates in `masked` to another

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -3,7 +3,7 @@
 import logging
 import warnings
 
-import numpy
+import numpy as np
 
 import rasterio._loading
 with rasterio._loading.add_gdal_dll_directories():
@@ -68,9 +68,6 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
                 Window within original raster covered by shapes.  None if crop
                 is False.
     """
-    if crop and invert:
-        raise ValueError("crop and invert cannot both be True.")
-
     if crop and pad:
         pad_x = pad_width
         pad_y = pad_width
@@ -91,7 +88,9 @@ def raster_geometry_mask(dataset, shapes, all_touched=False, invert=False,
                           'Are they in different coordinate reference systems?')
 
         # Return an entirely True mask (if invert is False)
-        mask = numpy.ones(shape=dataset.shape[-2:], dtype="bool") * (not invert)
+        mask = np.ones(shape=dataset.shape[-2:], dtype="bool")
+        if invert:
+            mask = ~mask
         return mask, dataset.transform, None
 
     if crop:

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -91,7 +91,7 @@ def test_raster_geometrymask_crop_invert(basic_image_2x2, basic_image_file,
         geometrymask, transform, window = raster_geometry_mask(src, geometries,
                                                             crop=True, invert=True)
 
-    image = basic_image_2x2[2:5, 2:5].astype(bool)
+    image = basic_image_2x2[2:5, 2:5] == 1
 
     assert geometrymask.shape == (3, 3)
     assert np.array_equal(geometrymask, image)

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -91,8 +91,10 @@ def test_raster_geometrymask_crop_invert(basic_image_2x2, basic_image_file,
         geometrymask, transform, window = raster_geometry_mask(src, geometries,
                                                             crop=True, invert=True)
 
+    image = basic_image_2x2[2:5, 2:5].astype(bool)
+
     assert geometrymask.shape == (3, 3)
-    assert np.array_equal(geometrymask, basic_image_2x2)
+    assert np.array_equal(geometrymask, image)
     assert transform == Affine(1, 0, 2, 0, 1, 2)
     assert window is not None and window.flatten() == (2, 2, 3, 3)
 

--- a/tests/test_mask.py
+++ b/tests/test_mask.py
@@ -81,14 +81,21 @@ def test_raster_geometrymask_crop(basic_image_2x2, basic_image_file,
     assert window is not None and window.flatten() == (2, 2, 3, 3)
 
 
-def test_raster_geometrymask_crop_invert(basic_image_file, basic_geometry):
-    """crop and invert cannot be combined"""
+def test_raster_geometrymask_crop_invert(basic_image_2x2, basic_image_file,
+                                        basic_geometry):
+    """ Test cropping and inverting """
 
     geometries = [basic_geometry]
 
     with rasterio.open(basic_image_file) as src:
-        with pytest.raises(ValueError):
-            raster_geometry_mask(src, geometries, crop=True, invert=True)
+        geometrymask, transform, window = raster_geometry_mask(src, geometries,
+                                                            crop=True, invert=True)
+
+    assert geometrymask.shape == (3, 3)
+    assert np.array_equal(geometrymask, basic_image_2x2)
+    assert transform == Affine(1, 0, 2, 0, 1, 2)
+    assert window is not None and window.flatten() == (2, 2, 3, 3)
+
 
 
 def test_raster_geometrymask_crop_all_touched(basic_image, basic_image_file,


### PR DESCRIPTION
This PR removes the check for `crop=True` and `invert=True` in `raster_geometry_mask`.  The enforced mutual exclusivity of crop and invert actually result a frustrating special case, and I think it is best to remove this check completely.

Here is each case considered and its meaning:
1. `crop=False, invert=False`: This is the default state. We get the full dataset where inside the shapes is unmasked (False) and outside the shapes is masked (True). This is used to process pixels inside shape boundaries.
2. `crop=True, invert=False`: This crops the dataset to the extent of the shapes, which is to say the bounding box of the union of the shapes.  Inside the shapes is still unmasked (False) and outside the shapes is masked (True). This is used to process pixels inside shape boundaries while only needing to consider the minimum possible part of the domain.
3. `crop=False, invert=True`: We get the full dataset, however inside the shapes is masked (True) and outside the shapes is unmasked (False). This case processes all pixels outside the shapes.
4. `crop=True, invert=True`: This case was excluded. In this PR, it means to mask all area inside the shapes (True) and unmask the area outside the shapes (False), but within the bounding box of the union of the shapes (cropping is done to the extent of the shapes).

I think the intent of the crop/invert check (as much as I can tell from the commits in the git history 7 years ago) was that invert meant invert the interior/exterior of the shape, so this would mask the inside of the shapes and select the full domain outside the shapes. However, if cropping were allowed, we could reap the benefits of reduced memory/processing overhead. _We know that the dataset outside of the cropped window is unmasked_ (False) because all shapes would exist within the cropping window with their interiors masked (True). Because of the crop/invert check, we are forced to use case 3 when selecting the area outside of a shape and surrender all the benefit of cropping. Crop and invert can coexist and there are cases where it is strongly preferred, such as processing larger-than-memory rasters.