### PR TITLE
Update write_mask to accept Numpy booleans, to enable writing optimized masked array (mask == mp.ma.nomask)

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1923,9 +1923,9 @@ cdef class DatasetWriterBase(DatasetReaderBase):
             height = self.height
 
         try:
-            if mask_array is True:
+            if mask_array is True or mask_array is np.True_:
                 GDALFillRaster(mask, 255, 0)
-            elif mask_array is False:
+            elif mask_array is False or mask_array is np.False_:
                 GDALFillRaster(mask, 0, 0)
             elif mask_array.dtype == bool:
                 array = 255 * mask_array.astype(np.uint8)

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -511,6 +511,28 @@ def test_write_masked_true(tmp_path):
         assert list(arr.flatten()) == [np.ma.masked, np.ma.masked, 2]
 
 
+def test_write_masked_nomask(tmp_path):
+    """Verify that a mask is written when we write an optimized masked array (mask == np.ma.nomask)."""
+    data = np.ma.masked_array([[0, 1, 2]], dtype="uint8")
+
+    with rasterio.open(
+        tmp_path / "test.tif",
+        "w",
+        driver="GTiff",
+        count=1,
+        width=3,
+        height=1,
+        dtype="uint8",
+    ) as dst:
+        dst.write(data, indexes=1, masked=True)
+
+    # Expect no masked values.
+    with rasterio.open(tmp_path / "test.tif") as src:
+        assert src.mask_flag_enums == ([MaskFlags.per_dataset],)
+        arr = src.read(masked=True)
+        assert list(arr.flatten()) == [0, 1, 2]
+
+
 @requires_gdal35
 def test_write_int64(tmp_path):
     test_file = tmp_path / "test.tif"


### PR DESCRIPTION
Fixes #2706