### PR TITLE
PERF: Minor performance improvements to dtypes

### DIFF
--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -140,11 +140,16 @@ def get_minimum_dtype(values):
     -------
     rasterio dtype string
     """
-    values = np.asarray(values)
-    min_value = values.min()
-    max_value = values.max()
+    if is_ndarray(values):
+        min_value = values.min()
+        max_value = values.max()
+        dtype = values.dtype
+    else:
+        min_value = min(values)
+        max_value = max(values)
+        dtype = np.result_type(min_value, max_value)
 
-    if values.dtype.kind in ('i', 'u'):
+    if dtype.kind in {'i', 'u'}:
         if min_value >= 0:
             if max_value <= 255:
                 return uint8
@@ -162,7 +167,6 @@ def get_minimum_dtype(values):
         if not _GDAL_AT_LEAST_35:
             raise ValueError("Values out of range for supported dtypes")
         return int64
-
     else:
         if min_value >= -3.4028235e+38 and max_value <= 3.4028235e+38:
             return float32

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -103,7 +103,7 @@ def in_dtype_range(value, dtype):
     """
     Check if the value is within the dtype range
     """
-    if np.dtype(dtype).kind == "f" and (np.isinf(value) or np.isnan(value)):
+    if np.dtype(dtype).kind == "f" and (np.math.isinf(value) or np.math.isnan(value)):
         return True
     range_min, range_max = dtype_ranges[dtype]
     return range_min <= value <= range_max

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -140,10 +140,7 @@ def get_minimum_dtype(values):
     -------
     rasterio dtype string
     """
-
-    if not is_ndarray(values):
-        values = np.array(values)
-
+    values = np.asarray(values)
     min_value = values.min()
     max_value = values.max()
 
@@ -191,9 +188,7 @@ def can_cast_dtype(values, dtype):
     boolean
         True if values can be cast to data type.
     """
-
-    if not is_ndarray(values):
-        values = np.array(values)
+    values = np.asarray(values)
 
     if values.dtype.name == _getnpdtype(dtype).name:
         return True
@@ -219,9 +214,7 @@ def validate_dtype(values, valid_dtypes):
     boolean:
         True if dtype of values is one of valid_dtypes
     """
-
-    if not is_ndarray(values):
-        values = np.array(values)
+    values = np.asarray(values)
 
     return (values.dtype.name in valid_dtypes or
             get_minimum_dtype(values) in valid_dtypes)

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -5,7 +5,7 @@ Happily strings can be used throughout Numpy and so existing code will
 not break.
 
 """
-import numpy
+import numpy as np
 
 from rasterio.env import GDALVersion
 
@@ -103,7 +103,7 @@ def in_dtype_range(value, dtype):
     """
     Check if the value is within the dtype range
     """
-    if numpy.dtype(dtype).kind == "f" and (numpy.isinf(value) or numpy.isnan(value)):
+    if np.dtype(dtype).kind == "f" and (np.isinf(value) or np.isnan(value)):
         return True
     range_min, range_max = dtype_ranges[dtype]
     return range_min <= value <= range_max
@@ -140,7 +140,6 @@ def get_minimum_dtype(values):
     -------
     rasterio dtype string
     """
-    import numpy as np
 
     if not is_ndarray(values):
         values = np.array(values)
@@ -175,7 +174,6 @@ def get_minimum_dtype(values):
 
 def is_ndarray(array):
     """Check if array is a ndarray."""
-    import numpy as np
 
     return isinstance(array, np.ndarray) or hasattr(array, '__array__')
 
@@ -193,7 +191,6 @@ def can_cast_dtype(values, dtype):
     boolean
         True if values can be cast to data type.
     """
-    import numpy as np
 
     if not is_ndarray(values):
         values = np.array(values)
@@ -222,7 +219,6 @@ def validate_dtype(values, valid_dtypes):
     boolean:
         True if dtype of values is one of valid_dtypes
     """
-    import numpy as np
 
     if not is_ndarray(values):
         values = np.array(values)
@@ -236,7 +232,6 @@ def _is_complex_int(dtype):
 
 
 def _getnpdtype(dtype):
-    import numpy as np
     if _is_complex_int(dtype):
         return np.dtype("complex64")
     else:


### PR DESCRIPTION
A few minor performance enhancements in dtypes modules
1. Use scalar variants of isinf/isnan in `in_dtype_range`. The scalar versions of these functions are much faster than the ufunc (140ns for scalar vs 950ns for ufunc).
2. Avoid creating array in `get_minimum_dtype`. If passed a non-array, use the builtin min/max to avoid the extra memory/cpu overhead of traversing values 3 times.
```
In [66]: %timeit dtypes.get_minimum_dtype(range(266))
35.3 µs ± 651 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

In [67]: %timeit get_minimum_dtype(range(266))
13.3 µs ± 172 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```
3. Use `np.asarray` where possible. Benchmarking on my system showed that calling `np.asarray` was much faster when called with an array (90ns vs 336ns) and about the same when called with non-arrays (~870us) compared to existing approach.