### PR TITLE
PERF: Speedup validate_dtype

### DIFF
--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -178,10 +178,14 @@ def get_minimum_dtype(values):
         # check finite values range
         if is_ndarray(values):
             fvals = values[np.isfinite(values)]
+            if fvals.size == 0:
+                return float32
             min_value = fvals.min()
             max_value = fvals.max()
         else:
             fvals = tuple(filter(np.math.isfinite, values))
+            if not fvals:
+                return float32
             min_value = min(fvals)
             max_value = max(fvals)
 

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -227,8 +227,7 @@ def validate_dtype(values, valid_dtypes):
     """
     if is_ndarray(values) and values.dtype.name in valid_dtypes:
         return True
-    else:
-        return get_minimum_dtype(values) in valid_dtypes
+    return get_minimum_dtype(values) in valid_dtypes
 
 
 def _is_complex_int(dtype):

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -146,10 +146,14 @@ def get_minimum_dtype(values):
     rasterio dtype string
     """
     if is_ndarray(values):
+        if values.size == 0:
+            return bool_
         min_value = values.min()
         max_value = values.max()
         dtype = values.dtype
     else:
+        if not values:
+            return bool_
         min_value = min(values)
         max_value = max(values)
         dtype = np.result_type(min_value, max_value)

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -175,6 +175,16 @@ def get_minimum_dtype(values):
             raise ValueError("Values out of range for supported dtypes")
         return int64
     else:
+        # check finite values range
+        if is_ndarray(values):
+            fvals = values[np.isfinite(values)]
+            min_value = fvals.min()
+            max_value = fvals.max()
+        else:
+            fvals = tuple(map(np.math.isfinite, values))
+            min_value = min(fvals)
+            max_value = max(fvals)
+            
         if min_value >= -3.4028235e+38 and max_value <= 3.4028235e+38:
             return float32
         return float64

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -181,7 +181,7 @@ def get_minimum_dtype(values):
             min_value = fvals.min()
             max_value = fvals.max()
         else:
-            fvals = tuple(map(np.math.isfinite, values))
+            fvals = tuple(filter(np.math.isfinite, values))
             min_value = min(fvals)
             max_value = max(fvals)
 

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -1,9 +1,5 @@
 """Mapping of GDAL to Numpy data types.
 
-Since 0.13 we are not importing numpy here and data types are strings.
-Happily strings can be used throughout Numpy and so existing code will
-not break.
-
 """
 import numpy as np
 

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -184,7 +184,7 @@ def get_minimum_dtype(values):
             fvals = tuple(map(np.math.isfinite, values))
             min_value = min(fvals)
             max_value = max(fvals)
-            
+
         if min_value >= -3.4028235e+38 and max_value <= 3.4028235e+38:
             return float32
         return float64
@@ -209,16 +209,12 @@ def can_cast_dtype(values, dtype):
     boolean
         True if values can be cast to data type.
     """
-    values = np.asarray(values)
-
-    if values.dtype.name == _getnpdtype(dtype).name:
+    dtype_name = _getnpdtype(dtype).name
+    if is_ndarray(values) and values.dtype.name == dtype_name:
         return True
 
-    elif values.dtype.kind == 'f':
-        return np.allclose(values, values.astype(dtype), equal_nan=True)
-
-    else:
-        return np.array_equal(values, values.astype(dtype))
+    min_dtype = get_minimum_dtype(values)
+    return np.can_cast(min_dtype, dtype_name, casting='safe')
 
 
 def validate_dtype(values, valid_dtypes):

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -229,10 +229,10 @@ def validate_dtype(values, valid_dtypes):
     boolean:
         True if dtype of values is one of valid_dtypes
     """
-    values = np.asarray(values)
-
-    return (values.dtype.name in valid_dtypes or
-            get_minimum_dtype(values) in valid_dtypes)
+    if is_ndarray(values) and values.dtype.name in valid_dtypes:
+        return True
+    else:
+        return get_minimum_dtype(values) in valid_dtypes
 
 
 def _is_complex_int(dtype):

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -5,6 +5,7 @@ from .conftest import gdal_version
 
 import rasterio
 from rasterio import (
+    bool_,
     ubyte,
     uint8,
     uint16,
@@ -82,6 +83,12 @@ def test_get_minimum_dtype():
     assert get_minimum_dtype(np.array([-1, 0, 128], dtype=int)) == int16
     assert get_minimum_dtype(np.array([-1, 0, 100000], dtype=int)) == int32
     assert get_minimum_dtype(np.array([-1.5, 0, 1.5], dtype=np.float64)) == float32
+
+    assert get_minimum_dtype([-1.5, np.nan, np.inf, -np.inf]) == float32
+    assert get_minimum_dtype(np.array([-1.5, np.nan, np.inf, -np.inf], dtype=np.float64)) == float32
+    assert get_minimum_dtype([-np.inf, np.inf]) == float32
+    assert get_minimum_dtype([]) == bool_
+    assert get_minimum_dtype(np.array([], dtype=int)) == bool_
 
 
 def test_get_minimum_dtype__int64():


### PR DESCRIPTION
Continuing from #2716, we can also avoid creating an array in validate_dtype.

```python
# Fast path (numpy array is exactly the dtype we want) is roughly the same
In [49]: %timeit validate_dtype(nvals, ['int32'])
1.82 µs ± 6.06 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

In [50]: %timeit validate_dtype2(nvals, ['int32'])
1.88 µs ± 33.3 ns per loop (mean ± std. dev. of 7 runs, 1,000,000 loops each)

# Array, but dtype is not valid (needing to call get_minimum_dtype) basically the same.
In [66]: %timeit validate_dtype(nvals, ['float32'])
4.77 µs ± 366 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [67]: %timeit validate_dtype2(nvals, ['float32'])
4.46 µs ± 56 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

# Slow path (non-array paths) are much faster
In [64]: %timeit validate_dtype(vals, ['int32'])
14.1 µs ± 43.8 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

In [65]: %timeit validate_dtype2(vals, ['int32'])
6.37 µs ± 44.2 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)
```

Question 1: There is a comment at the top of the module that talks about not importing numpy. Is that still relevant?
https://github.com/rasterio/rasterio/blob/main/rasterio/dtypes.py#L3

Question 2: Would it be desired for dtype objects or strings to be accepted as types? 
for example: `validate_dtype(arr, [np.uint8, 'int16'])`