### PR TITLE
ENH: Added option to change merge strategy in CLI

### DIFF
--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -30,7 +30,7 @@ def deprecated_precision(*args):
               default='nearest', help="Resampling method.",
               show_default=True)
 @click.option('--method',
-              type=click.Choice([method for method in MERGE_METHODS.keys()]),
+              type=click.Choice(list(MERGE_METHODS)),
               default='first', help="Merging strategy.",
               show_default=True)
 @options.nodata_opt

--- a/rasterio/rio/merge.py
+++ b/rasterio/rio/merge.py
@@ -8,6 +8,7 @@ from rasterio.enums import Resampling
 from rasterio.errors import RasterioDeprecationWarning
 from rasterio.rio import options
 from rasterio.rio.helpers import resolve_inout
+from rasterio.merge import MERGE_METHODS
 
 
 def deprecated_precision(*args):
@@ -27,6 +28,10 @@ def deprecated_precision(*args):
 @click.option('--resampling',
               type=click.Choice([r.name for r in Resampling if r.value <= 7]),
               default='nearest', help="Resampling method.",
+              show_default=True)
+@click.option('--method',
+              type=click.Choice([method for method in MERGE_METHODS.keys()]),
+              default='first', help="Merging strategy.",
               show_default=True)
 @options.nodata_opt
 @options.dtype_opt
@@ -49,6 +54,7 @@ def merge(
     bounds,
     res,
     resampling,
+    method,
     nodata,
     dtype,
     bidx,
@@ -94,6 +100,7 @@ def merge(
             dtype=dtype,
             indexes=(bidx or None),
             resampling=resampling,
+            method=method,
             dst_path=output,
             dst_kwds=creation_options,
         )


### PR DESCRIPTION
This adds the possibility to switch the strategy used when merging rasters. The underlying functionality already exists in the underlying merge function but is not exposed by the CLI.

If you'd like to have a test for this, I would be happy to provide one, but I did not see any tests so far for the CLI.