### PR TITLE
Return true minimum dtype when np.inf/nan present

### DIFF
--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -150,10 +150,14 @@ def get_minimum_dtype(values):
     rasterio dtype string
     """
     if is_ndarray(values):
+        if values.size == 0:
+            return bool_
         min_value = values.min()
         max_value = values.max()
         dtype = values.dtype
     else:
+        if not values:
+            return bool_
         min_value = min(values)
         max_value = max(values)
         dtype = np.result_type(min_value, max_value)

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -183,6 +183,20 @@ def get_minimum_dtype(values):
             raise ValueError("Values out of range for supported dtypes")
         return int64
     else:
+        # Check finite values range
+        if is_ndarray(values):
+            fvals = values[np.isfinite(values)]
+            if fvals.size == 0:
+                return float32
+            min_value = fvals.min()
+            max_value = fvals.max()
+        else:
+            fvals = tuple(filter(np.math.isfinite, values))
+            if not fvals:
+                return float32
+            min_value = min(fvals)
+            max_value = max(fvals)
+
         if min_value >= -3.4028235e+38 and max_value <= 3.4028235e+38:
             return float32
         return float64

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -5,6 +5,7 @@ from .conftest import gdal_version
 
 import rasterio
 from rasterio import (
+    bool_,
     ubyte,
     uint8,
     uint16,
@@ -66,6 +67,7 @@ def test_gdal_name(dtype, name):
 
 
 def test_get_minimum_dtype():
+    assert get_minimum_dtype([]) == bool_
     assert get_minimum_dtype([0, 1]) == uint8
     assert get_minimum_dtype([0, 1000]) == uint16
     assert get_minimum_dtype([0, 100000]) == uint32
@@ -75,6 +77,7 @@ def test_get_minimum_dtype():
     assert get_minimum_dtype([-1.5, 0, 1.5]) == float32
     assert get_minimum_dtype([-1.5e+100, 0, 1.5e+100]) == float64
 
+    assert get_minimum_dtype(np.array([], dtype=np.uint)) == bool_
     assert get_minimum_dtype(np.array([0, 1], dtype=np.uint)) == uint8
     assert get_minimum_dtype(np.array([0, 1000], dtype=np.uint)) == uint16
     assert get_minimum_dtype(np.array([0, 100000], dtype=np.uint)) == uint32

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -76,6 +76,9 @@ def test_get_minimum_dtype():
     assert get_minimum_dtype([-1, 0, 100000]) == int32
     assert get_minimum_dtype([-1.5, 0, 1.5]) == float32
     assert get_minimum_dtype([-1.5e+100, 0, 1.5e+100]) == float64
+    assert get_minimum_dtype([-1.5, np.nan, np.inf, -np.inf]) == float32
+    assert get_minimum_dtype([np.nan, np.inf]) == float32
+
 
     assert get_minimum_dtype(np.array([], dtype=np.uint)) == bool_
     assert get_minimum_dtype(np.array([0, 1], dtype=np.uint)) == uint8
@@ -85,6 +88,8 @@ def test_get_minimum_dtype():
     assert get_minimum_dtype(np.array([-1, 0, 128], dtype=int)) == int16
     assert get_minimum_dtype(np.array([-1, 0, 100000], dtype=int)) == int32
     assert get_minimum_dtype(np.array([-1.5, 0, 1.5], dtype=np.float64)) == float32
+    assert get_minimum_dtype(np.array([-1.5, np.nan, np.inf, -np.inf])) == float32
+    assert get_minimum_dtype(np.array([np.nan, np.inf])) == float32
 
 
 def test_get_minimum_dtype__int64():


### PR DESCRIPTION
When get_minimum_dtype was called with np.inf or np.nan, it would return float64. This PR fixes it to only do the range check on the finite values.

Additionally, I return the smallest dtype when the containers are empty, though, it could be argued to let the exceptions bubble up. Another approach would be to return None (ie GDT_Unknown). What would be preferred approach? My opinion is that either the smallest dtype (bool) or None should be returned.

ping @sgillies 