### PR TITLE
PERF: Optimize can_cast_dtype.

### DIFF
--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -204,7 +204,7 @@ def can_cast_dtype(values, dtype):
         True if values can be cast to data type.
     """
     dtype_name = _getnpdtype(dtype).name
-    if values.dtype.name == _getnpdtype(dtype).name:
+    if is_ndarray(values) and values.dtype.name == dtype_name:
         return True
     min_dtype = get_minimum_dtype(values)
     return np.can_cast(min_dtype, dtype_name, casting='safe')

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -70,6 +70,8 @@ _kind_stem = {
 def _dtype_name(dtype):
     # Workaround to avoid a lot of overhead in Numpy to get typenames like float32
     dtype = np.dtype(dtype)
+    if dtype.kind == 'b':
+        return _kind_stem[dtype.kind]
     return f"{_kind_stem[dtype.kind]}{dtype.itemsize * 8}"
 
 

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -203,16 +203,11 @@ def can_cast_dtype(values, dtype):
     boolean
         True if values can be cast to data type.
     """
-    values = np.asarray(values)
-
+    dtype_name = _getnpdtype(dtype).name
     if values.dtype.name == _getnpdtype(dtype).name:
         return True
-
-    elif values.dtype.kind == 'f':
-        return np.allclose(values, values.astype(dtype), equal_nan=True)
-
-    else:
-        return np.array_equal(values, values.astype(dtype))
+    min_dtype = get_minimum_dtype(values)
+    return np.can_cast(min_dtype, dtype_name, casting='safe')
 
 
 def validate_dtype(values, valid_dtypes):

--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -60,6 +60,18 @@ if not _GDAL_AT_LEAST_37:
 dtype_rev["complex"] = 11
 dtype_rev["complex_int16"] = 8
 
+_kind_stem = {
+    'f': 'float',
+    'c': 'complex',
+    'i': 'int', 
+    'u': 'uint',
+    'b': 'bool'}
+
+def _dtype_name(dtype):
+    # Workaround to avoid a lot of overhead in Numpy to get typenames like float32
+    dtype = np.dtype(dtype)
+    return f"{_kind_stem[dtype.kind]}{dtype.itemsize * 8}"
+
 
 def _get_gdal_dtype(type_name):
     try:
@@ -203,8 +215,8 @@ def can_cast_dtype(values, dtype):
     boolean
         True if values can be cast to data type.
     """
-    dtype_name = _getnpdtype(dtype).name
-    if is_ndarray(values) and values.dtype.name == dtype_name:
+    dtype_name = _dtype_name(_getnpdtype(dtype))
+    if is_ndarray(values) and _dtype_name(values.dtype) == dtype_name:
         return True
     min_dtype = get_minimum_dtype(values)
     return np.can_cast(min_dtype, dtype_name, casting='safe')

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -29,7 +29,19 @@ from rasterio.dtypes import (
     _is_complex_int,
     _getnpdtype,
     _get_gdal_dtype,
+    _dtype_name
 )
+
+
+def test_dtype_name():
+    from rasterio.dtypes import dtype_rev
+    for dt in dtype_rev:
+        if dt is None:
+            continue
+        elif dt.startswith('complex_int'):
+            continue
+        dt = np.dtype(dt)
+        assert _dtype_name(dt) == dt.name
 
 
 def test_is_ndarray():


### PR DESCRIPTION
1. Don't cast to array
2. Avoid trial casting and comparing. Use numpy type hierarchy to determine safety.

These two changes make `can_cast_array` smarter for larger datasets or quick checks.