### PR TITLE
BUG: Revert get_minimum_dtype change to avoid numpy array

### DIFF
--- a/rasterio/dtypes.py
+++ b/rasterio/dtypes.py
@@ -149,16 +149,13 @@ def get_minimum_dtype(values):
     -------
     rasterio dtype string
     """
-    if is_ndarray(values):
-        min_value = values.min()
-        max_value = values.max()
-        dtype = values.dtype
-    else:
-        min_value = min(values)
-        max_value = max(values)
-        dtype = np.result_type(min_value, max_value)
+    if not is_ndarray(values):
+        values = np.asarray(values)
 
-    if dtype.kind in {'i', 'u'}:
+    min_value = values.min()
+    max_value = values.max()
+
+    if values.dtype.kind in {'i', 'u'}:
         if min_value >= 0:
             if max_value <= 255:
                 return uint8

--- a/tests/test_dtypes.py
+++ b/tests/test_dtypes.py
@@ -65,23 +65,26 @@ def test_gdal_name(dtype, name):
     assert _gdal_typename(dtype) == name
 
 
-def test_get_minimum_dtype():
-    assert get_minimum_dtype([0, 1]) == uint8
-    assert get_minimum_dtype([0, 1000]) == uint16
-    assert get_minimum_dtype([0, 100000]) == uint32
-    assert get_minimum_dtype([-1, 0, 1]) == int8
-    assert get_minimum_dtype([-1, 0, 128]) == int16
-    assert get_minimum_dtype([-1, 0, 100000]) == int32
-    assert get_minimum_dtype([-1.5, 0, 1.5]) == float32
-    assert get_minimum_dtype([-1.5e+100, 0, 1.5e+100]) == float64
-
-    assert get_minimum_dtype(np.array([0, 1], dtype=np.uint)) == uint8
-    assert get_minimum_dtype(np.array([0, 1000], dtype=np.uint)) == uint16
-    assert get_minimum_dtype(np.array([0, 100000], dtype=np.uint)) == uint32
-    assert get_minimum_dtype(np.array([-1, 0, 1], dtype=int)) == int8
-    assert get_minimum_dtype(np.array([-1, 0, 128], dtype=int)) == int16
-    assert get_minimum_dtype(np.array([-1, 0, 100000], dtype=int)) == int32
-    assert get_minimum_dtype(np.array([-1.5, 0, 1.5], dtype=np.float64)) == float32
+@pytest.mark.parametrize("values,dtype", [
+    ([0, 1], uint8),
+    ([0, 1000], uint16),
+    ([0, 100000], uint32),
+    ([-1, 0, 1], int8),
+    ([-1, 0, 128], int16),
+    ([-1, 0, 100000], int32),
+    ([-1.5, 0, 1.5], float32),
+    ([-1.5e+100, 0, 1.5e+100], float64),
+    ([-3, .01, 3], float32),
+    (np.array([0, 1], dtype=np.uint), uint8),
+    (np.array([0, 1000], dtype=np.uint), uint16),
+    (np.array([0, 100000], dtype=np.uint), uint32),
+    (np.array([-1, 0, 1], dtype=int), int8),
+    (np.array([-1, 0, 128], dtype=int), int16),
+    (np.array([-1, 0, 100000], dtype=int), int32),
+    (np.array([-1.5, 0, 1.5], dtype=np.float64), float32),
+])
+def test_get_minimum_dtype(values,dtype):
+    assert get_minimum_dtype(values) == dtype
 
 
 def test_get_minimum_dtype__int64():


### PR DESCRIPTION
This reverts commit e46cc0374b2b14ecfda547ec9b0b60b5bb7eb774.

https://github.com/rasterio/rasterio/pull/2716#issuecomment-1401010485

cc: @groutr 