### PR TITLE
Fix ImportError with unreachable http_proxy.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,8 +27,13 @@ DEFAULT_SHAPE = (10, 10)
 if sys.version_info > (3,):
     reduce = functools.reduce
 
+try:
+    have_credentials = boto3.Session().get_credentials()
+except Exception:
+    have_credentials = False
+
 credentials = pytest.mark.skipif(
-    not(boto3.Session().get_credentials()),
+    not(have_credentials),
     reason="S3 raster access requires credentials")
 
 


### PR DESCRIPTION
The Debian package build failed because pytest fails with an ImportError:

```python
ImportError while loading conftest '/build/rasterio-1.3.5/.pybuild/cpython3_3.10_rasterio/build/tests/conftest.py'.
tests/conftest.py:31: in <module>
    not(boto3.Session().get_credentials()),
/usr/lib/python3/dist-packages/boto3/session.py:203: in get_credentials
    return self._session.get_credentials()
/usr/lib/python3/dist-packages/botocore/session.py:509: in get_credentials
    ).load_credentials()
/usr/lib/python3/dist-packages/botocore/credentials.py:2035: in load_credentials
    creds = provider.load()
/usr/lib/python3/dist-packages/botocore/credentials.py:1045: in load
    metadata = fetcher.retrieve_iam_role_credentials()
/usr/lib/python3/dist-packages/botocore/utils.py:570: in retrieve_iam_role_credentials
    token = self._fetch_metadata_token()
/usr/lib/python3/dist-packages/botocore/utils.py:457: in _fetch_metadata_token
    response = self._session.send(request.prepare())
/usr/lib/python3/dist-packages/botocore/httpsession.py:486: in send
    raise ProxyConnectionError(
E   botocore.exceptions.ProxyConnectionError: Failed to connect to proxy URL: "http://127.0.0.1:9/"
```

The package build environment has no networking, the http_proxy is therefore not reachable.

You can reproduce such an environment with:
```python
$ http_proxy="http://127.0.0.1:9/" python3
Python 3.11.1 (main, Dec 31 2022, 10:23:59) [GCC 12.2.0] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto3
>>> boto3.Session().get_credentials()
Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 174, in _new_conn
    conn = connection.create_connection(
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/util/connection.py", line 96, in create_connection
    raise err
  File "/usr/lib/python3/dist-packages/urllib3/util/connection.py", line 86, in create_connection
    sock.connect(sa)
ConnectionRefusedError: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 704, in urlopen
    httplib_response = self._make_request(
                       ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 399, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 239, in request
    super(HTTPConnection, self).request(method, url, body=body, headers=headers)
  File "/usr/lib/python3.11/http/client.py", line 1282, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3/dist-packages/botocore/awsrequest.py", line 94, in _send_request
    rval = super()._send_request(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/http/client.py", line 1328, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.11/http/client.py", line 1277, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3/dist-packages/botocore/awsrequest.py", line 123, in _send_output
    self.send(msg)
  File "/usr/lib/python3/dist-packages/botocore/awsrequest.py", line 218, in send
    return super().send(str)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/http/client.py", line 975, in send
    self.connect()
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 205, in connect
    conn = self._new_conn()
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 186, in _new_conn
    raise NewConnectionError(
urllib3.exceptions.NewConnectionError: <botocore.awsrequest.AWSHTTPConnection object at 0x7fa6f6de9e10>: Failed to establish a new connection: [Errno 111] Connection refused

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/lib/python3/dist-packages/botocore/httpsession.py", line 455, in send
    urllib_response = conn.urlopen(
                      ^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 788, in urlopen
    retries = retries.increment(
              ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/util/retry.py", line 525, in increment
    raise six.reraise(type(error), error, _stacktrace)
          ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/six.py", line 718, in reraise
    raise value.with_traceback(tb)
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 704, in urlopen
    httplib_response = self._make_request(
                       ^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/connectionpool.py", line 399, in _make_request
    conn.request(method, url, **httplib_request_kw)
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 239, in request
    super(HTTPConnection, self).request(method, url, body=body, headers=headers)
  File "/usr/lib/python3.11/http/client.py", line 1282, in request
    self._send_request(method, url, body, headers, encode_chunked)
  File "/usr/lib/python3/dist-packages/botocore/awsrequest.py", line 94, in _send_request
    rval = super()._send_request(
           ^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/http/client.py", line 1328, in _send_request
    self.endheaders(body, encode_chunked=encode_chunked)
  File "/usr/lib/python3.11/http/client.py", line 1277, in endheaders
    self._send_output(message_body, encode_chunked=encode_chunked)
  File "/usr/lib/python3/dist-packages/botocore/awsrequest.py", line 123, in _send_output
    self.send(msg)
  File "/usr/lib/python3/dist-packages/botocore/awsrequest.py", line 218, in send
    return super().send(str)
           ^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3.11/http/client.py", line 975, in send
    self.connect()
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 205, in connect
    conn = self._new_conn()
           ^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/urllib3/connection.py", line 186, in _new_conn
    raise NewConnectionError(
urllib3.exceptions.ProxyError: ('Cannot connect to proxy.', NewConnectionError('<botocore.awsrequest.AWSHTTPConnection object at 0x7fa6f6de9e10>: Failed to establish a new connection: [Errno 111] Connection refused'))

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "/usr/lib/python3/dist-packages/boto3/session.py", line 203, in get_credentials
    return self._session.get_credentials()
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/botocore/session.py", line 509, in get_credentials
    ).load_credentials()
      ^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/botocore/credentials.py", line 2035, in load_credentials
    creds = provider.load()
            ^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/botocore/credentials.py", line 1045, in load
    metadata = fetcher.retrieve_iam_role_credentials()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/botocore/utils.py", line 570, in retrieve_iam_role_credentials
    token = self._fetch_metadata_token()
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/botocore/utils.py", line 457, in _fetch_metadata_token
    response = self._session.send(request.prepare())
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/usr/lib/python3/dist-packages/botocore/httpsession.py", line 486, in send
    raise ProxyConnectionError(
botocore.exceptions.ProxyConnectionError: Failed to connect to proxy URL: "http://127.0.0.1:9/"
```

Wrapping the `boto3.Session().get_credentials()` call in a `try` block resolves the issue.