### PR TITLE
Additional info for offset parameter in transform.xy

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -404,7 +404,8 @@ class TransformerBase():
             transformations. Default: 0.
         offset : str, optional
             Determines if the returned coordinates are for the center of the
-            pixel or for a corner.
+            pixel or for a corner. Available options include center, ul, ur, ll,
+            lr.
         Raises
         ------
         ValueError


### PR DESCRIPTION
I found a need to use other than the default offset setting transform.xy, and didn't readily know the nomenclature for the additional options. This simply adds the available options to the docstring.