### PR TITLE
Raise warning when rasterize encounters empty shapes list

### DIFF
--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -70,6 +70,10 @@ class ShapeSkipWarning(UserWarning):
     """Warn that an invalid or empty shape in a collection has been skipped"""
 
 
+class RasterioWarning(UserWarning):
+    """General warning from Rasterio"""
+
+
 class GDALBehaviorChangeException(RuntimeError):
     """Raised when GDAL's behavior differs from the given arguments.  For
     example, antimeridian cutting is always on as of GDAL 2.2.0.  Users

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -141,11 +141,11 @@ class WarpOperationError(RasterioError):
 #----------------------------------------
 
 
-class RasterioWarning(UserWarning):
+class RasterioWarning(Warning):
     """General warning from Rasterio"""
 
 
-class NodataShadowWarning(UserWarning):
+class NodataShadowWarning(RasterioWarning):
     """Warn that a dataset's nodata attribute is shadowing its alpha band."""
 
     def __str__(self):
@@ -154,15 +154,15 @@ class NodataShadowWarning(UserWarning):
                 "by the nodata attribute")
 
 
-class NotGeoreferencedWarning(UserWarning):
+class NotGeoreferencedWarning(RasterioWarning):
     """Warn that a dataset isn't georeferenced."""
 
 
-class TransformWarning(UserWarning):
+class TransformWarning(RasterioWarning):
     """Warn that coordinate transformations may behave unexpectedly"""
 
 
-class ShapeSkipWarning(UserWarning):
+class ShapeSkipWarning(RasterioWarning):
     """Warn that an invalid or empty shape in a collection has been skipped"""
 
 

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -145,6 +145,10 @@ class RasterioWarning(Warning):
     """General warning from Rasterio"""
 
 
+class RasterioUserWarning(RasterioWarning, UserWarning):
+    """Rasterio UserWarning. Use instead of UserWarning."""
+
+
 class NodataShadowWarning(RasterioWarning):
     """Warn that a dataset's nodata attribute is shadowing its alpha band."""
 

--- a/rasterio/errors.py
+++ b/rasterio/errors.py
@@ -3,6 +3,10 @@
 from click import FileError
 
 
+#----------------------------------------
+#  Rasterio Errors
+#----------------------------------------
+
 class RasterioError(Exception):
     """Root exception class"""
 
@@ -46,32 +50,8 @@ class RasterioIOError(OSError):
     registered format drivers."""
 
 
-class NodataShadowWarning(UserWarning):
-    """Warn that a dataset's nodata attribute is shadowing its alpha band."""
-
-    def __str__(self):
-        return ("The dataset's nodata attribute is shadowing "
-                "the alpha band. All masks will be determined "
-                "by the nodata attribute")
-
-
-class NotGeoreferencedWarning(UserWarning):
-    """Warn that a dataset isn't georeferenced."""
-
-
-class TransformWarning(UserWarning):
-    """Warn that coordinate transformations may behave unexpectedly"""
-
 class RPCError(ValueError):
     """Raised when RPC transformation is invalid"""
-
-
-class ShapeSkipWarning(UserWarning):
-    """Warn that an invalid or empty shape in a collection has been skipped"""
-
-
-class RasterioWarning(UserWarning):
-    """General warning from Rasterio"""
 
 
 class GDALBehaviorChangeException(RuntimeError):
@@ -106,14 +86,6 @@ class GDALVersionError(RasterioError):
 
 class WindowEvaluationError(ValueError):
     """Raised when window evaluation fails"""
-
-
-class RasterioDeprecationWarning(FutureWarning):
-    """Rasterio module deprecations
-
-    Following https://www.python.org/dev/peps/pep-0565/#additional-use-case-for-futurewarning
-    we base this on FutureWarning while continuing to support Python < 3.7.
-    """
 
 
 class RasterBlockError(RasterioError):
@@ -162,3 +134,41 @@ class DatasetIOShapeError(RasterioError):
 
 class WarpOperationError(RasterioError):
     """Raised when a warp operation fails."""
+
+
+#----------------------------------------
+# Rasterio Warnings
+#----------------------------------------
+
+
+class RasterioWarning(UserWarning):
+    """General warning from Rasterio"""
+
+
+class NodataShadowWarning(UserWarning):
+    """Warn that a dataset's nodata attribute is shadowing its alpha band."""
+
+    def __str__(self):
+        return ("The dataset's nodata attribute is shadowing "
+                "the alpha band. All masks will be determined "
+                "by the nodata attribute")
+
+
+class NotGeoreferencedWarning(UserWarning):
+    """Warn that a dataset isn't georeferenced."""
+
+
+class TransformWarning(UserWarning):
+    """Warn that coordinate transformations may behave unexpectedly"""
+
+
+class ShapeSkipWarning(UserWarning):
+    """Warn that an invalid or empty shape in a collection has been skipped"""
+
+
+class RasterioDeprecationWarning(FutureWarning):
+    """Rasterio module deprecations
+
+    Following https://www.python.org/dev/peps/pep-0565/#additional-use-case-for-futurewarning
+    we base this on FutureWarning while continuing to support Python < 3.7.
+    """

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -350,11 +350,12 @@ def rasterize(
             raise ValueError('Invalid out_shape, must be 2D')
 
         out = np.empty(out_shape, dtype=dtype)
-        out.fill(fill)
 
     else:
         raise ValueError('Either an out_shape or image must be provided')
 
+    out.fill(fill)
+    
     if min(out.shape) == 0:
         raise ValueError("width and height must be > 0")
 

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -16,7 +16,7 @@ from rasterio.dtypes import (
 )
 from rasterio.enums import MergeAlg
 from rasterio.env import ensure_env, GDALVersion
-from rasterio.errors import ShapeSkipWarning, RasterioWarning
+from rasterio.errors import ShapeSkipWarning, RasterioUserWarning
 from rasterio._features import _shapes, _sieve, _rasterize, _bounds
 from rasterio import warp
 from rasterio.rio.helpers import coords
@@ -324,7 +324,7 @@ def rasterize(
             warnings.warn('Invalid or empty shape {} at index {} will not be rasterized.'.format(geom, index), ShapeSkipWarning)
 
     if not valid_shapes:
-        warnings.warn('No valid geometry objects found for rasterize', RasterioWarning)
+        warnings.warn('No valid geometry objects found for rasterize', RasterioUserWarning)
 
     shape_values = np.array(shape_values)
 

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -16,7 +16,7 @@ from rasterio.dtypes import (
 )
 from rasterio.enums import MergeAlg
 from rasterio.env import ensure_env, GDALVersion
-from rasterio.errors import ShapeSkipWarning
+from rasterio.errors import ShapeSkipWarning, RasterioWarning
 from rasterio._features import _shapes, _sieve, _rasterize, _bounds
 from rasterio import warp
 from rasterio.rio.helpers import coords
@@ -324,7 +324,7 @@ def rasterize(
             warnings.warn('Invalid or empty shape {} at index {} will not be rasterized.'.format(geom, index), ShapeSkipWarning)
 
     if not valid_shapes:
-        raise ValueError('No valid geometry objects found for rasterize')
+        warnings.warn('No valid geometry objects found for rasterize', RasterioWarning)
 
     shape_values = np.array(shape_values)
 

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -354,11 +354,10 @@ def rasterize(
     else:
         raise ValueError('Either an out_shape or image must be provided')
 
-    out.fill(fill)
-    
     if min(out.shape) == 0:
         raise ValueError("width and height must be > 0")
 
+    out.fill(fill)
     transform = guard_transform(transform)
     _rasterize(valid_shapes, out, transform, all_touched, merge_alg)
     return out

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -556,7 +556,6 @@ def test_rasterize_invalid_geom(input):
     _warn = record.pop(ShapeSkipWarning)
 
 
-
 def test_rasterize_skip_invalid_geom(geojson_polygon, basic_image_2x2):
     """Rasterize operation should succeed for at least one valid geometry
     and should skip any invalid or empty geometries with an error."""
@@ -598,9 +597,11 @@ def test_rasterize_missing_out(basic_geometry):
 
 
 def test_rasterize_missing_shapes():
-    """Shapes are required for this operation."""
+    """Shapes are recommended for this operation. If no shapes, empty array is returned."""
     with pytest.warns(RasterioWarning, match="No valid geometry objects"):
-        rasterize([], out_shape=DEFAULT_SHAPE)
+        rv = rasterize([], out_shape=DEFAULT_SHAPE)
+        assert rv.shape == DEFAULT_SHAPE
+        assert (rv == 0).all()
 
 
 def test_rasterize_invalid_shapes():

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -603,6 +603,8 @@ def test_rasterize_missing_shapes():
         assert rv.shape == DEFAULT_SHAPE
         assert (rv == 0).all()
 
+
+def test_rasterize_fill_out_array():
     with pytest.warns(RasterioWarning, match="No valid geometry objects"):
         out = np.empty((3, 3))
         rv = rasterize([], out=out)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -560,7 +560,7 @@ def test_rasterize_skip_invalid_geom(geojson_polygon, basic_image_2x2):
     """Rasterize operation should succeed for at least one valid geometry
     and should skip any invalid or empty geometries with an error."""
 
-    with pytest.warns(UserWarning, match="Invalid or empty shape"):
+    with pytest.warns(ShapeSkipWarning, match="Invalid or empty shape"):
         out = rasterize([geojson_polygon, {'type': 'Polygon', 'coordinates': []}], out_shape=DEFAULT_SHAPE)
 
     assert np.array_equal(out, basic_image_2x2)

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -603,6 +603,12 @@ def test_rasterize_missing_shapes():
         assert rv.shape == DEFAULT_SHAPE
         assert (rv == 0).all()
 
+    with pytest.warns(RasterioWarning, match="No valid geometry objects"):
+        out = np.empty((3, 3))
+        rv = rasterize([], out=out)
+        assert rv.shape == out.shape
+        assert (rv == 0).all()
+
 
 def test_rasterize_invalid_shapes():
     """Invalid shapes should raise an exception rather than be skipped."""

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -9,7 +9,7 @@ import shapely.geometry
 
 import rasterio
 from rasterio.enums import MergeAlg
-from rasterio.errors import WindowError, ShapeSkipWarning, RasterioWarning
+from rasterio.errors import WindowError, ShapeSkipWarning, RasterioUserWarning
 from rasterio.features import (
     bounds, geometry_mask, geometry_window, is_valid_geom, rasterize, sieve,
     shapes)
@@ -126,14 +126,14 @@ def test_geometry_mask_invert(basic_geometry, basic_image_2x2):
 @pytest.mark.parametrize("geom", [{'type': 'Invalid'}, {'type': 'Point'}, {'type': 'Point', 'coordinates': []}])
 def test_geometry_invalid_geom(geom):
     """An invalid geometry should fail"""
-    with pytest.warns((RasterioWarning, ShapeSkipWarning)) as record:
+    with pytest.warns((RasterioUserWarning, ShapeSkipWarning)) as record:
         geometry_mask(
             [geom],
             out_shape=DEFAULT_SHAPE,
             transform=Affine.identity())
 
     assert len(record) == 2
-    _warn = record.pop(RasterioWarning)
+    _warn = record.pop(RasterioUserWarning)
     assert "No valid geometry objects" in _warn.message.args[0]
     _warn = record.pop(ShapeSkipWarning)
 
@@ -547,11 +547,11 @@ def test_rasterize_multipolygon_no_hole():
     [{'type'}], [{'type': 'Invalid'}], [{'type': 'Point'}], [{'type': 'Point', 'coordinates': []}], [{'type': 'GeometryCollection', 'geometries': []}]])
 def test_rasterize_invalid_geom(input):
     """Invalid GeoJSON should fail with exception"""
-    with pytest.warns((RasterioWarning, ShapeSkipWarning)) as record:
+    with pytest.warns((RasterioUserWarning, ShapeSkipWarning)) as record:
         rasterize(input, out_shape=DEFAULT_SHAPE)
 
     assert len(record) == 2
-    _warn = record.pop(RasterioWarning)
+    _warn = record.pop(RasterioUserWarning)
     assert "No valid geometry objects" in _warn.message.args[0]
     _warn = record.pop(ShapeSkipWarning)
 
@@ -598,14 +598,14 @@ def test_rasterize_missing_out(basic_geometry):
 
 def test_rasterize_missing_shapes():
     """Shapes are recommended for this operation. If no shapes, empty array is returned."""
-    with pytest.warns(RasterioWarning, match="No valid geometry objects"):
+    with pytest.warns(RasterioUserWarning, match="No valid geometry objects"):
         rv = rasterize([], out_shape=DEFAULT_SHAPE)
         assert rv.shape == DEFAULT_SHAPE
         assert (rv == 0).all()
 
 
 def test_rasterize_fill_out_array():
-    with pytest.warns(RasterioWarning, match="No valid geometry objects"):
+    with pytest.warns(RasterioUserWarning, match="No valid geometry objects"):
         out = np.empty((3, 3))
         rv = rasterize([], out=out)
         assert rv.shape == out.shape
@@ -614,11 +614,11 @@ def test_rasterize_fill_out_array():
 
 def test_rasterize_invalid_shapes():
     """Invalid shapes should raise an exception rather than be skipped."""
-    with pytest.warns((RasterioWarning, ShapeSkipWarning)) as record:
+    with pytest.warns((RasterioUserWarning, ShapeSkipWarning)) as record:
         rasterize([{'foo': 'bar'}], out_shape=DEFAULT_SHAPE)
 
     assert len(record) == 2
-    _warn = record.pop(RasterioWarning)
+    _warn = record.pop(RasterioUserWarning)
     assert "No valid geometry objects" in _warn.message.args[0]
     _warn = record.pop(ShapeSkipWarning)
 


### PR DESCRIPTION
Address #2743.

I created a new RasterioWarning as an analogue to RasterioError for general issues in rasterio that don't warrant aborting the operation, but the user should be notified of the condition. It currently inherits from UserWarning, though it could be better to inherit from Warning directly and then make all other warnings inherit from RasterioWarning. Thoughts?

Also, if anyone knows of a nicer way to match multiple warnings, please advise a better way. Maybe we should define a helper function to match specific messages with specific warnings.
