### PR TITLE
Dodge empty sequences when computing bounds.

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changes
 1.3.6 (TBD)
 -----------
 
+- When computing the bounds of a sequence of feature or geometry objects, we
+  dodge empty "features" and "geometries" sequences that could be provided by,
+  e.g., Fiona 1.9.0 (#2745).
 - Decouple our Affine transformer from GDAL environments, fixing a performance
   regression introduced in 1.3.0 (#2754).
 - StatisticsError is raised when dataset statistics cannot be computed (#2760).

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -397,35 +397,17 @@ def _bounds(geometry, north_up=True, transform=None):
     TODO: add to Fiona.
     """
 
-    if 'features' in geometry:
-        # Input is a FeatureCollection
-        xmins = []
-        ymins = []
-        xmaxs = []
-        ymaxs = []
-        for feature in geometry['features']:
-            xmin, ymin, xmax, ymax = _bounds(feature['geometry'])
-            xmins.append(xmin)
-            ymins.append(ymin)
-            xmaxs.append(xmax)
-            ymaxs.append(ymax)
+    if 'features' in geometry and geometry["features"]:
+        xmins, ymins, xmaxs, ymaxs = zip(
+            *[_bounds(feat["geometry"]) for feat in geometry["features"]]
+        )
         if north_up:
             return min(xmins), min(ymins), max(xmaxs), max(ymaxs)
         else:
             return min(xmins), max(ymaxs), max(xmaxs), min(ymins)
 
-    elif 'geometries' in geometry:
-        # Input is a geometry collection
-        xmins = []
-        ymins = []
-        xmaxs = []
-        ymaxs = []
-        for geometry in geometry['geometries']:
-            xmin, ymin, xmax, ymax = _bounds(geometry)
-            xmins.append(xmin)
-            ymins.append(ymin)
-            xmaxs.append(xmax)
-            ymaxs.append(ymax)
+    elif 'geometries' in geometry and geometry['geometries']:
+        xmins, ymins, xmaxs, ymaxs = zip(*[_bounds(geom) for geom in geometry["geometries"]])
         if north_up:
             return min(xmins), min(ymins), max(xmaxs), max(ymaxs)
         else:


### PR DESCRIPTION
Plus a 30-40% speed gain by using zip.

Resolves #2745.