### PR TITLE
Solutions for #2747

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,9 @@ Changes
 1.3.6 (TBD)
 -----------
 
+- Tests that use matplotlib have been cleaned up and the one in test_warp.py
+  which uses our vendored rangehttpserver has been marked as needing a network
+  (#).
 - When computing the bounds of a sequence of feature or geometry objects, we
   dodge empty "features" and "geometries" sequences that could be provided by,
   e.g., Fiona 1.9.0 (#2745).

--- a/tests/test_dataset_mask.py
+++ b/tests/test_dataset_mask.py
@@ -1,24 +1,13 @@
-import logging
-import sys
-
-import numpy as np
-import pytest
-
-try:
-    import matplotlib as mpl
-    mpl.use('agg')
-    import matplotlib.pyplot as plt
-except ImportError:
-    plt = None
+"""Dataset mask test."""
 
 from affine import Affine
+import numpy as np
+import pytest
 
 import rasterio
 from rasterio.enums import Resampling
 from rasterio.errors import NodataShadowWarning
 from rasterio.crs import CRS
-
-logging.basicConfig(stream=sys.stderr, level=logging.DEBUG)
 
 
 # Setup test arrays
@@ -131,7 +120,7 @@ def tiffs(tmpdir):
     # 6. RGB with msk (internal)
     prof = _profile.copy()
     prof['count'] = 3
-    with rasterio.Env(GDAL_TIFF_INTERNAL_MASK=True) as env:
+    with rasterio.Env(GDAL_TIFF_INTERNAL_MASK=True):
         with rasterio.open(str(tmpdir.join('rgb_msk_internal.tif')),
                            'w', **prof) as dst:
             dst.write(red, 1)
@@ -156,21 +145,25 @@ def test_no_ndv(tiffs):
     with rasterio.open(str(tiffs.join('rgb_no_ndv.tif'))) as src:
         assert np.array_equal(src.dataset_mask(), alldata)
 
+
 def test_rgb_ndv(tiffs):
     with rasterio.open(str(tiffs.join('rgb_ndv.tif'))) as src:
         res = src.dataset_mask()
         assert res.dtype.name == "uint8"
         assert np.array_equal(src.dataset_mask(), alp)
 
+
 def test_rgba_no_ndv(tiffs):
     with rasterio.open(str(tiffs.join('rgba_no_ndv.tif'))) as src:
         assert np.array_equal(src.dataset_mask(), alp)
+
 
 def test_rgba_ndv(tiffs):
     with rasterio.open(str(tiffs.join('rgba_ndv.tif'))) as src:
         with pytest.warns(NodataShadowWarning):
             res = src.dataset_mask()
         assert np.array_equal(res, alp)
+
 
 def test_rgb_msk(tiffs):
     with rasterio.open(str(tiffs.join('rgb_msk.tif'))) as src:
@@ -179,9 +172,11 @@ def test_rgb_msk(tiffs):
         for bmask in src.read_masks():
             assert np.array_equal(bmask, msk)
 
+
 def test_rgb_msk_int(tiffs):
     with rasterio.open(str(tiffs.join('rgb_msk_internal.tif'))) as src:
         assert np.array_equal(src.dataset_mask(), msk)
+
 
 def test_rgba_msk(tiffs):
     with rasterio.open(str(tiffs.join('rgba_msk.tif'))) as src:

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -1,50 +1,47 @@
 """Unittests for rasterio.plot"""
 
-
-import numpy as np
 import pytest
 
-try:
-    import matplotlib as mpl
-    mpl.use('agg')
-    import matplotlib.pyplot as plt
-    plt.show = lambda :None
-except ImportError:
-    plt = None
+plt = pytest.importorskip("matplotlib.pyplot")
+
+import matplotlib
+import numpy as np
 
 import rasterio
-from rasterio.plot import (show, show_hist, get_plt,
-                           plotting_extent, adjust_band)
+from rasterio.plot import show, show_hist, get_plt, plotting_extent, adjust_band
 from rasterio.enums import ColorInterp
+
+
+matplotlib.use("agg")
+plt.show = lambda: None
 
 
 def test_show_raster_band():
     """Test plotting a single raster band."""
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         show((src, 1))
         fig = plt.gcf()
         plt.close(fig)
 
+
 def test_show_raster_mult_bands():
     """Test multiple bands plotting."""
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         show((src, (1, 2, 3)))
         fig = plt.gcf()
         plt.close(fig)
 
+
 def test_show_raster_object():
     """Test plotting a raster object."""
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         show(src)
         fig = plt.gcf()
         plt.close(fig)
 
+
 def test_show_raster_float():
     """Test plotting a raster object with float data."""
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/float.tif') as src:
         show(src)
         fig = plt.gcf()
@@ -53,7 +50,6 @@ def test_show_raster_float():
 
 def test_show_cmyk_interp(tmpdir):
     """A CMYK TIFF has cyan, magenta, yellow, black bands."""
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         profile = src.profile
 
@@ -84,7 +80,6 @@ def test_show_raster_no_bounds():
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show((src, 1), with_bounds=False)
@@ -99,7 +94,6 @@ def test_show_raster_title():
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show((src, 1), title="insert title here")
@@ -108,12 +102,12 @@ def test_show_raster_title():
         except ImportError:
             pass
 
+
 def test_show_hist_large():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    matplotlib = pytest.importorskip('matplotlib')
     try:
         rand_arr = np.random.randn(10, 718, 791)
         show_hist(rand_arr)
@@ -122,12 +116,12 @@ def test_show_hist_large():
     except ImportError:
         pass
 
+
 def test_show_raster_cmap():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show((src, 1), cmap='jet')
@@ -136,12 +130,12 @@ def test_show_raster_cmap():
         except ImportError:
             pass
 
+
 def test_show_raster_ax():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             fig, ax = plt.subplots(1)
@@ -151,12 +145,12 @@ def test_show_raster_ax():
         except ImportError:
             pass
 
+
 def test_show_array():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show(src.read(1))
@@ -171,7 +165,6 @@ def test_show_array3D():
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show(src.read((1, 2, 3)))
@@ -180,12 +173,12 @@ def test_show_array3D():
         except ImportError:
             pass
 
+
 def test_show_hist():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show_hist((src, 1), bins=256)
@@ -209,12 +202,12 @@ def test_show_hist():
         except ImportError:
             pass
 
+
 def test_show_hist_mplargs():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show_hist(src, bins=50, lw=0.0, stacked=False, alpha=0.3,
@@ -224,12 +217,12 @@ def test_show_hist_mplargs():
         except ImportError:
             pass
 
+
 def test_show_contour():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show((src, 1), contour=True)
@@ -238,12 +231,12 @@ def test_show_contour():
         except ImportError:
             pass
 
+
 def test_show_contour_mplargs():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show((src, 1), contour=True,
@@ -254,23 +247,24 @@ def test_show_contour_mplargs():
         except ImportError:
             pass
 
+
 def test_get_plt():
     """
     This test only verifies that code up to the point of plotting with
     matplotlib works correctly.  Tests do not exercise matplotlib.
     """
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif'):
         try:
             assert plt == get_plt()
         except ImportError:
             pass
 
+
 def test_plt_transform():
-    matplotlib = pytest.importorskip('matplotlib')
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         show(src.read(), transform=src.transform)
         show(src.read(1), transform=src.transform)
+
 
 def test_plotting_extent():
     from rasterio.plot import reshape_as_image
@@ -284,6 +278,7 @@ def test_plotting_extent():
         # array requires a transform
         with pytest.raises(ValueError):
             plotting_extent(src.read(1))
+
 
 def test_plot_normalize():
     a = np.linspace(1, 6, 10)

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1959,6 +1959,7 @@ def test_reproject_rpcs_approx_transformer(caplog):
         assert "Created approximate transformer" in caplog.text
 
 
+@pytest.mark.network
 @pytest.fixture
 def http_error_server(data):
     """Serves files from the test data directory, poorly."""


### PR DESCRIPTION
In an attempt to make the tests run more cleanly in a situation like that of #2747, I've eliminated an unnecessary matplotlib import from one test module, switched test_plot.py over to skipping at the module level if matplotlib.pyplot can't be imported, and marked one test in test_warp.py as needing a network.