### PR TITLE
CI: increment GDAL test matrix per #2771

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -37,12 +37,12 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10']
-        gdal-version: ['3.5.2', '3.4.3']
+        gdal-version: ['3.6.2', '3.5.2']
         include:
+          - python-version: '3.9'
+            gdal-version: '3.4.3'
           - python-version: '3.8'
             gdal-version: '3.3.3'
-          - python-version: '3.8'
-            gdal-version: '3.2.3'
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
I took liberties with dropping GDAL 3.2 when adding GDAL 3.6.