### PR TITLE
MNT: Update warp tests for GDAL 3.6 &  Update GDAL versions in test matrix

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -33,12 +33,16 @@ jobs:
     runs-on: ubuntu-latest
     name: Docker | GDAL=${{ matrix.gdal-version }} | python=${{ matrix.python-version }}
     container: osgeo/gdal:ubuntu-small-${{ matrix.gdal-version }}
+    env:
+        DEBIAN_FRONTEND: noninteractive
     strategy:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10']
-        gdal-version: ['3.5.2', '3.4.3']
+        gdal-version: ['3.5.3', '3.6.1']
         include:
+          - python-version: '3.8'
+            gdal-version: '3.4.3'
           - python-version: '3.8'
             gdal-version: '3.3.3'
           - python-version: '3.8'

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -54,7 +54,7 @@ def flatten_coords(coordinates):
                 yield x
 
 
-if gdal_version.at_least("3.7"):
+if gdal_version.at_least("3.6"):
     # GH2662
     reproj_expected = (
         ({"CHECK_WITH_INVERT_PROJ": False}, 6646),
@@ -537,7 +537,7 @@ def test_reproject_view():
     )
 
     expected_sum = 299199
-    if gdal_version.at_least("3.7"):
+    if gdal_version.at_least("3.6"):
         # GH2662
         expected_sum = 299231
     assert (out > 0).sum() == expected_sum


### PR DESCRIPTION
Related: #2772

Backport of:
- https://github.com/rasterio/rasterio/pull/2680
- https://github.com/rasterio/rasterio/pull/2679