### PR TITLE
BUG: Fix calculation of bounds in transform.array_bounds

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -196,9 +196,19 @@ def array_bounds(height, width, transform):
     its height, width, and an affine transform.
 
     """
-    w, n = transform.xoff, transform.yoff
-    e, s = transform * (width, height)
-    return w, s, e, n
+    a, b, c, d, e, f, _, _, _ = transform
+    if b == d == 0:
+        west, south, east, north = c, f + e * height, c + a * width, f
+    else:
+        c0x, c0y = c, f
+        c1x, c1y = transform * (0, height)
+        c2x, c2y = transform * (width, height)
+        c3x, c3y = transform * (width, 0)
+        xs = (c0x, c1x, c2x, c3x)
+        ys = (c0y, c1y, c2y, c3y)
+        west, south, east, north = min(xs), min(ys), max(xs), max(ys)
+
+    return west, south, east, north
 
 
 def xy(transform, rows, cols, zs=None, offset='center', **rpc_options):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,15 +11,17 @@ import zipfile
 
 import affine
 import boto3
-from click.testing import CliRunner
-import pytest
 import numpy as np
+import pytest
+from click.testing import CliRunner
 
 import rasterio
+import rasterio.env
+from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
 from rasterio.enums import ColorInterp
 from rasterio.env import GDALVersion
-
+from affine import Affine
 
 DEFAULT_SHAPE = (10, 10)
 
@@ -384,10 +386,6 @@ def basic_image_file(tmpdir, basic_image):
     string
         Filename of test raster file
     """
-
-    from affine import Affine
-    import rasterio
-
     image = basic_image
 
     outfilename = str(tmpdir.join('basic_image.tif'))
@@ -419,10 +417,6 @@ def pixelated_image_file(tmpdir, pixelated_image):
     string
         Filename of test raster file
     """
-
-    from affine import Affine
-    import rasterio
-
     image = pixelated_image
 
     outfilename = str(tmpdir.join('pixelated_image.tif'))
@@ -454,10 +448,6 @@ def rotated_image_file(tmpdir, pixelated_image):
     string
         Filename of test raster file
     """
-
-    from affine import Affine
-    import rasterio
-
     image = 128 * np.ones((1000, 2000), dtype=np.uint8)
 
     rotated_transform = Affine(-0.05, 0.07, 481060,
@@ -481,10 +471,42 @@ def rotated_image_file(tmpdir, pixelated_image):
     return outfilename
 
 
+@pytest.fixture()
+def image_file_with_custom_size_and_transform(tmpdir):
+    """
+    A basic raster file with a 10x10 array containing a
+    caller supplied transform.
+
+    Returns
+    -------
+
+    string
+        Filename of test raster file
+    """
+    def inner(width, height, transform):
+        image = np.zeros((height, width))
+
+        outfilename = str(tmpdir.join('basic_image.tif'))
+        kwargs = {
+            "crs": CRS({'init': 'epsg:4326'}),
+            "transform": transform,
+            "count": 1,
+            "dtype": rasterio.uint8,
+            "driver": "GTiff",
+            "width": image.shape[1],
+            "height": image.shape[0],
+            "nodata": None
+        }
+        with rasterio.open(outfilename, 'w', **kwargs) as out:
+            out.write(image, indexes=1)
+
+        return outfilename
+
+    return inner
+
+
 @pytest.fixture(scope='function')
 def gdalenv(request):
-    import rasterio.env
-
     def fin():
         if rasterio.env.local._env:
             rasterio.env.delenv()
@@ -650,3 +672,17 @@ requires_gdal_lt_35 = pytest.mark.skipif(
     gdal_version.at_least('3.5'),
     reason="Requires GDAL before 3.5",
 )
+
+
+def assert_bounding_box_equal(expected, actual, tolerance=1e-4):
+    if isinstance(expected, tuple):
+        expected = BoundingBox(*expected)
+    if isinstance(actual, tuple):
+        actual = BoundingBox(*actual)
+
+    left = abs(expected.left - actual.left)
+    bottom = abs(expected.bottom - actual.bottom)
+    right = abs(expected.right - actual.right)
+    top = abs(expected.top - actual.top)
+
+    assert all(diff < tolerance for diff in [left, bottom, right, top]), f"{expected} differs from {actual}"


### PR DESCRIPTION
Fixes #2787.

The method of computing raster bounds in `rasterio.transform.array_bounds` assumes a standard GIS orientation of the image - north down, east right when just viewing the array. If the image is rotated in any way, the returned bounds may be in the wrong order (e.g. `east` is west of `west`), or may be entirely incorrect.

Replace the current implementation with the more general calculation used in DatasetBase.bounds. Add an array of tests to both implementations, passing in various transforms.