### PR TITLE
DOC: improve doc for window.round_lengths and round_offsets

### DIFF
--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -709,8 +709,7 @@ class Window:
     def round_lengths(self, **kwds):
         """Return a copy with width and height rounded.
 
-        Lengths are rounded to the preceding (floor) or succeeding (ceil)
-        whole number. The offsets are not changed.
+        Lengths are rounded to the nearest whole number. The offsets are not changed.
 
         Parameters
         ----------
@@ -737,8 +736,7 @@ class Window:
     def round_offsets(self, **kwds):
         """Return a copy with column and row offsets rounded.
 
-        Offsets are rounded to the preceding (floor) or succeeding (ceil)
-        whole number. The lengths are not changed.
+        Offsets are rounded to the preceding whole number. The lengths are not changed.
 
         Parameters
         ----------


### PR DESCRIPTION
Doc is outdated, from before the parameters were removed.