### PR TITLE
TST: Update test_transform_bounds_densify to match GDAL

### DIFF
--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -290,20 +290,22 @@ def test_transform_bounds__esri_wkt():
 @pytest.mark.parametrize(
     "density,expected",
     [
-        (0, (-1688721.99764, -350040.36880, 1688799.61159, 2236495.86829)),
-        (100, (-1688721.99764, -555239.84875, 1688799.61159, 2236495.86829)),
+        (0, (-1684649.41338, -350356.81377, 1684649.41338, 2234551.18559)),
+        (100, (-1684649.41338, -555777.79210, 1684649.41338, 2234551.18559)),
     ],
 )
 def test_transform_bounds_densify(density, expected):
     # This transform is non-linear along the edges, so densification produces
     # a different result than otherwise
     src_crs = CRS.from_epsg(4326)
-    dst_crs = CRS.from_epsg(2163)
-    with rasterio.Env(OSR_USE_NON_DEPRECATED="NO"):
-        assert np.allclose(
-            expected,
-            transform_bounds(src_crs, dst_crs, -120, 40, -80, 64, densify_pts=density),
-        )
+    dst_crs = CRS.from_proj4(
+        "+proj=laea +lat_0=45 +lon_0=-100 +x_0=0 +y_0=0 "
+        "+a=6370997 +b=6370997 +units=m +no_defs"
+    )
+    assert np.allclose(
+        expected,
+        transform_bounds(src_crs, dst_crs, -120, 40, -80, 64, densify_pts=density),
+    )
 
 
 def test_transform_bounds_no_change():


### PR DESCRIPTION
Closes #2789

Differences are related to transform differences, not errors in transform_bounds. Updating to match GDAL/pyproj so tests pass.