### PR TITLE
BUG: Use numpy.asanyarray instead of numpy.array(..copy=False)

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1689,7 +1689,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                 arr = arr.filled(fill_value)
 
         else:
-            arr = np.array(arr, copy=False)
+            arr = np.asanyarray(arr)
 
         if indexes is None:
             indexes = self.indexes

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -356,7 +356,7 @@ def _reproject(
                 # source is a masked array
                 src_nodata = source.fill_value
             # ensure data converted to numpy array
-            source = np.array(source, copy=False)
+            source = np.asanyarray(source)
             # Convert 2D single-band arrays to 3D multi-band.
             if len(source.shape) == 2:
                 source = source.reshape(1, *source.shape)
@@ -398,7 +398,7 @@ def _reproject(
             if not dst_crs:
                 raise CRSError("Missing dst_crs.")
             # ensure data converted to numpy array
-            destination = np.array(destination, copy=False)
+            destination = np.asanyarray(destination)
             if len(destination.shape) == 2:
                 destination = destination.reshape(1, *destination.shape)
 


### PR DESCRIPTION
Related to #2575

Originally added in #1959. However, asanyarray is likely more appropriate so masked arrays not converted to regular arrays.
