### PR TITLE
Fix for issue #2582

### DIFF
--- a/docs/quickstart.rst
+++ b/docs/quickstart.rst
@@ -113,8 +113,8 @@ from a more fundamental attribute: the dataset's geospatial transform.
 
 A dataset's :attr:`.DatasetReader.transform` is an affine
 transformation matrix that maps pixel locations in (col, row) coordinates to
-(x, y) spatial positions. The product of this matrix and ``(0, 0)``, the row
-and column coordinates of the upper left corner of the dataset, is the spatial
+(x, y) spatial positions. The product of this matrix and ``(0, 0)``, the column
+and row coordinates of the upper left corner of the dataset, is the spatial
 position of the upper left corner.
 
 .. code-block:: pycon


### PR DESCRIPTION
Fix quickstart documentation mixing up column and row position of matrix. Fixes #2582 