### PR TITLE
Int8 related backports from main

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -89,3 +89,5 @@ MANIFEST
 .pytest_cache
 *.ipynb
 mprofile*.dat
+memray-*
+issue????.py

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Changes
 1.3.7 (TBD)
 -----------
 
+- Ensure that the nodata mask value for all non-alpha bands is True in
+  sample_gen() (#2832).
 - GDAL often searches for sidecar files that may or may not exist. For the
   Python file VSI plugin in _filepath.pyx, we have turned the logging level for
   these events down from ERROR to INFO (#2827).

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -161,9 +161,10 @@ cdef _band_dtype(GDALRasterBandH band):
     """Resolve dtype of a given band, deals with signed/unsigned byte ambiguity."""
     cdef const char * ptype
     cdef int gdal_dtype = GDALGetRasterDataType(band)
-
-    if gdal_dtype == GDT_Byte:
-        # Can be uint8 or int8, need to check PIXELTYPE property
+    if gdal_dtype == GDT_Byte and dtypes.dtype_rev["int8"] == 1:
+        # Before GDAL 3.7, int8 was dealt by GDAL as a GDT_Byte (1)
+        # with PIXELTYPE=SIGNEDBYTE metadata item in IMAGE_STRUCTURE
+        # metadata domain.
         ptype = GDALGetMetadataItem(band, 'PIXELTYPE', 'IMAGE_STRUCTURE')
 
         if ptype and strncmp(ptype, 'SIGNEDBYTE', 10) == 0:

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1442,7 +1442,9 @@ cdef class DatasetWriterBase(DatasetReaderBase):
             # if we can crosswalk those.
             gdal_dtype = _get_gdal_dtype(self._init_dtype)
 
-            if _getnpdtype(self._init_dtype) == _getnpdtype('int8'):
+            # Before GDAL 3.7, int8 was dealt by GDAL as a GDT_Byte (1)
+            # with PIXELTYPE=SIGNEDBYTE creation option.
+            if _getnpdtype(self._init_dtype) == _getnpdtype('int8') and gdal_dtype == 1:
                 options = CSLSetNameValue(options, 'PIXELTYPE', 'SIGNEDBYTE')
 
             # Create a GDAL dataset handle.

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -256,7 +256,9 @@ def rasterize(
         'int16', 'int32', 'uint8', 'uint16', 'uint32', 'float32', 'float64'
     )
     if GDALVersion.runtime().at_least("3.5"):
-        valid_dtypes = valid_dtypes + ("int64", "uint64")
+        valid_dtypes += ("int64", "uint64")
+    if GDALVersion.runtime().at_least("3.7"):
+        valid_dtypes += ("int8",)
 
     def format_invalid_dtype(param):
         return '{0} dtype must be one of: {1}'.format(

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -223,6 +223,7 @@ cdef extern from "gdal.h" nogil:
     ctypedef enum GDALDataType:
         GDT_Unknown
         GDT_Byte
+        GDT_Int8
         GDT_UInt16
         GDT_Int16
         GDT_UInt32

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -750,6 +750,14 @@ def test_rasterize_invalid_value(basic_geometry):
                 gdal_version.at_least("3.5"), reason="GDAL regression? Works with 3.4.3"
             ),
         ),
+        pytest.param(
+            "int8",
+            -128,
+            marks=pytest.mark.skipif(
+                not gdal_version.at_least("3.7"),
+                reason="int8 support added in GDAL 3.7",
+            ),
+        ),
         ("uint8", 255),
         ("uint16", 65535),
         ("float32", 1.434532),
@@ -781,11 +789,12 @@ def test_rasterize_supported_dtype(dtype, default_value, basic_geometry):
 def test_rasterize_unsupported_dtype(basic_geometry):
     """Unsupported types should all raise exceptions."""
     unsupported_types = (
-        ('int8', -127),
-        ('float16', -9343.232)
+        ('float16', -9343.232),
     )
     if not gdal_version.at_least("3.5"):
         unsupported_types += (('int64', 20439845334323),)
+    if not gdal_version.at_least("3.7"):
+        unsupported_types += (('int8', -127),)
 
     for dtype, default_value in unsupported_types:
         with pytest.raises(ValueError):

--- a/tests/test_int8.py
+++ b/tests/test_int8.py
@@ -3,9 +3,12 @@ import numpy
 import pytest
 
 import rasterio
+from rasterio.env import GDALVersion
+
+gdal_version = GDALVersion.runtime()
 
 
-@pytest.mark.xfail(reason="Likely upstream bug")
+@pytest.mark.xfail(gdal_version < GDALVersion(3, 7), reason="GDAL < 3.7 doesn't handle signed int8 correctly")
 @pytest.mark.parametrize("nodata", [-1, -128])
 def test_write_int8_mem(nodata):
     profile = {

--- a/tests/test_write.py
+++ b/tests/test_write.py
@@ -12,9 +12,8 @@ from .conftest import requires_gdal35, gdal_version
 import rasterio
 from rasterio.drivers import blacklist
 from rasterio.enums import MaskFlags, Resampling
-from rasterio.env import Env
+from rasterio.env import Env, GDALVersion
 from rasterio.errors import RasterioIOError
-
 
 def test_validate_dtype_None(tmpdir):
     """Raise TypeError if there is no dtype"""
@@ -118,6 +117,10 @@ def test_write_sbyte(tmpdir):
 
     info = subprocess.check_output(["gdalinfo", "-stats", name]).decode('utf-8')
     assert "Minimum=-33.000, Maximum=-33.000, Mean=-33.000, StdDev=0.000" in info
+    if GDALVersion.runtime() < GDALVersion(3, 7):
+        assert 'SIGNEDBYTE' in info
+    else:
+        assert 'Int8' in info
 
 
 @pytest.mark.gdalbin


### PR DESCRIPTION
Namely #2656 and #2780. No more unnecessary warnings with GDAL 3.7.0!