### PR TITLE
Add rio-blocks documentation

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Changes
 1.3.7 (TBD)
 -----------
 
+- Missing documentation for rio-blocks has been added (#2835).
 - Ensure that the nodata mask value for all non-alpha bands is True in
   sample_gen() (#2832).
 - GDAL often searches for sidecar files that may or may not exist. For the

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,7 +4,7 @@ Changes
 1.3.7 (TBD)
 -----------
 
-- Missing documentation for rio-blocks has been added (#2835).
+- Missing documentation for rio-blocks has been added to the CLI docs (#2835).
 - Ensure that the nodata mask value for all non-alpha bands is True in
   sample_gen() (#2832).
 - GDAL often searches for sidecar files that may or may not exist. For the

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -75,10 +75,42 @@ To compress it using the LZW method, add
     --co compress=LZW
 
 
-bounds
+blocks
 ------
 
-Added in 0.10.
+This command prints features describing a raster's internal blocks, which are
+used directly for raster I/O.  These features can be used to visualize how a
+windowed operation would operate using those blocks.
+
+Output features have two JSON encoded properties: block and window. Block is a
+two element array like ``[0, 0]`` describing the window's position in the input
+band's window layout. Window is a JSON serialization of rasterio's Window class
+like ``{"col_off": 0, "height": 3, "row_off": 705, "width": 791}``.
+
+Block windows are extracted from the dataset (all bands must have matching
+block windows) by default, or from the band specified using the ``--bidx`` option:
+
+.. code-block:: console
+
+	rio shapes --bidx 3 tests/data/RGB.byte.tif
+
+By default a GeoJSON FeatureCollection is written. With the ``--sequence``
+option a GeoJSON feature stream is written instead.
+
+.. code-block:: console
+
+	rio shapes tests/data/RGB.byte.tif --sequence
+
+Output features are reprojected to OGC:CRS84 (WGS 84) unless the
+``--projected`` flag is provided, which causes the output to be kept in the
+input datasource's coordinate reference system.
+
+For more information on exactly what blocks and windows represent, see
+:func:`rasterio._base.DatasetBase.block_windows`.
+
+
+bounds
+------
 
 The ``bounds`` command writes the bounding boxes of raster datasets to GeoJSON for
 use with, e.g., `geojsonio-cli <https://github.com/mapbox/geojsonio-cli>`__.
@@ -133,8 +165,6 @@ Shoot the GeoJSON into a Leaflet map using geojsonio-cli by typing
 calc
 ----
 
-Added in 0.19
-
 The ``calc`` command reads files as arrays, evaluates lisp-like expressions in
 their context, and writes the result as a new file. Members of the numpy
 module and arithmetic and logical operators are available builtin functions
@@ -175,8 +205,6 @@ efficiently in Python.
 clip
 ----
 
-Added in 0.27
-
 The ``clip`` command clips a raster using bounds input directly or from a
 template raster.
 
@@ -195,12 +223,8 @@ It can also be combined to read bounds of a feature dataset using Fiona:
 
     $ rio clip input.tif output.tif --bounds $(fio info features.shp --bounds)
 
-
-
 convert
 -------
-
-Added in 0.25
 
 The ``convert`` command copies and converts raster datasets to other data types
 and formats (similar to ``gdal_translate``).
@@ -224,8 +248,6 @@ You can use `--rgb` as shorthand for `--co photometric=rgb`.
 
 edit-info
 ---------
-
-Added in 0.24
 
 The ``edit-info`` command allows you edit a raster dataset's metadata, namely
 
@@ -272,11 +294,8 @@ which can also be expressed as:
 See :class:`rasterio.enums.ColorInterp` for a full list of supported color
 interpretations and the color docs for more information.
 
-
 info
 ----
-
-Added in 0.13
 
 The ``info`` command prints structured information about a dataset.
 
@@ -383,8 +402,6 @@ The ``insp`` command opens a dataset and an interpreter.
 mask
 ----
 
-Added in 0.21
-
 The ``mask`` command masks in pixels from all bands of a raster using features
 (masking out all areas not covered by features) and optionally crops the output
 raster to the extent of the features.  Features are assumed to be in the same
@@ -414,8 +431,6 @@ keep pixels not covered by features.
 merge
 -----
 
-Added in 0.12.1
-
 The ``merge`` command can be used to flatten a stack of identically structured
 datasets.
 
@@ -426,8 +441,6 @@ datasets.
 
 overview
 --------
-
-New in 0.25
 
 The ``overview`` command creates overviews stored in the dataset, which can
 improve performance in some applications.
@@ -466,8 +479,6 @@ default value is 128.
 
 rasterize
 ---------
-
-New in 0.18.
 
 The ``rasterize`` command rasterizes GeoJSON features into a new or existing
 raster.
@@ -514,8 +525,6 @@ Other options are available, see:
 rm
 --
 
-New in 1.0
-
 Invoking the shell's ``$ rm <path>`` on a dataset can be used to
 delete a dataset referenced by a file path, but it won't handle
 deleting side car files.  This command is aware of datasets and
@@ -524,8 +533,6 @@ their sidecar files.
 
 sample
 ------
-
-New in 0.18.
 
 The sample command reads ``x, y`` positions from stdin and writes the dataset
 values at that position to stdout.
@@ -542,8 +549,6 @@ The output of the transform command (see below) makes good input for sample.
 
 shapes
 ------
-
-New in 0.11.
 
 The ``shapes`` command extracts and writes features of a specified dataset band
 out as GeoJSON.
@@ -567,8 +572,6 @@ Note: ``rio shapes`` returns line-delimited GeoJSONs by default. Use the ``--col
 
 stack
 -----
-
-New in 0.15.
 
 The ``stack`` command stacks a number of bands from one or more input files
 into a multiband dataset. Input datasets must be of a kind: same data type,
@@ -598,8 +601,6 @@ You can use `--rgb` as shorthand for `--co photometric=rgb`.
 transform
 ---------
 
-New in 0.10.
-
 The ``transform`` command reads a JSON array of coordinates, interleaved, and
 writes another array of transformed coordinates to stdout.
 
@@ -625,8 +626,6 @@ a raster dataset, do the following.
 
 warp
 ----
-
-New in 0.25
 
 The ``warp`` command warps (reprojects) a raster based on parameters that can be
 obtained from a template raster, or input directly.  The output is always

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -92,14 +92,14 @@ block windows) by default, or from the band specified using the ``--bidx`` optio
 
 .. code-block:: console
 
-	rio shapes --bidx 3 tests/data/RGB.byte.tif
+	rio blocks --bidx 3 tests/data/RGB.byte.tif
 
 By default a GeoJSON FeatureCollection is written. With the ``--sequence``
 option a GeoJSON feature stream is written instead.
 
 .. code-block:: console
 
-	rio shapes tests/data/RGB.byte.tif --sequence
+	rio blocks tests/data/RGB.byte.tif --sequence
 
 Output features are reprojected to OGC:CRS84 (WGS 84) unless the
 ``--projected`` flag is provided, which causes the output to be kept in the

--- a/rasterio/rio/blocks.py
+++ b/rasterio/rio/blocks.py
@@ -116,13 +116,13 @@ def blocks(
     the --bidx option:
     \b
 
-        rio shapes --bidx 3 tests/data/RGB.byte.tif
+        rio blocks --bidx 3 tests/data/RGB.byte.tif
 
     By default a GeoJSON FeatureCollection is written, but the
     --sequence option produces a GeoJSON feature stream instead.
     \b
 
-        rio shapes tests/data/RGB.byte.tif --sequence
+        rio blocks tests/data/RGB.byte.tif --sequence
 
     Output features are reprojected to OGC:CRS84 (WGS 84) unless the
     --projected flag is provided, which causes the output to be kept in

--- a/rasterio/rio/blocks.py
+++ b/rasterio/rio/blocks.py
@@ -100,36 +100,36 @@ def blocks(
 ):
     """Write dataset blocks as GeoJSON features.
 
-    This command writes features describing a raster's internal blocks, which
-    are used directly for raster I/O.  These features can be used to visualize
-    how a windowed operation would operate using those blocks.
+    This command prints features describing a raster's internal blocks,
+    which are used directly for raster I/O.  These features can be used
+    to visualize how a windowed operation would operate using those
+    blocks.
 
-    Output features have two JSON encoded properties: block and window.  Block
-    is a two element array like '[0, 0]' describing the window's position
-    in the input band's window layout.  Window is a two element array
-    containing two more two element arrays like '[[0, 256], [0, 256]' and
-    describes the range of pixels the window covers in the input band.  Values
-    are JSON encoded for better interoperability.
+    Output features have two JSON encoded properties: block and window.
+    Block is a two element array like [0, 0] describing the window's
+    position in the input band's window layout. Window is a JSON
+    serialization of rasterio's Window class like {"col_off": 0,
+    "height": 3, "row_off": 705, "width": 791}.
 
-    Block windows are extracted from the dataset (all bands must have matching
-    block windows) by default, or from the band specified using the '--bidx
-    option:
+    Block windows are extracted from the dataset (all bands must have
+    matching block windows) by default, or from the band specified using
+    the --bidx option:
     \b
 
-        $ rio shapes --bidx 3 tests/data/RGB.byte.tif
+        rio shapes --bidx 3 tests/data/RGB.byte.tif
 
-    By default a GeoJSON 'FeatureCollection' is written, but the --sequence'
-    option produces a GeoJSON feature stream instead.
+    By default a GeoJSON FeatureCollection is written, but the
+    --sequence option produces a GeoJSON feature stream instead.
     \b
 
-        $ rio shapes tests/data/RGB.byte.tif --sequence
+        rio shapes tests/data/RGB.byte.tif --sequence
 
-    Output features are reprojected to 'WGS84' unless the '--projected' flag is
-    provided, which causes the output to be kept in the input datasource's
-    coordinate reference system.
+    Output features are reprojected to OGC:CRS84 (WGS 84) unless the
+    --projected flag is provided, which causes the output to be kept in
+    the input datasource's coordinate reference system.
 
-    For more information on exactly what blocks and windows represent, see
-    'dataset.block_windows()'.
+    For more information on exactly what blocks and windows represent,
+    see block_windows().
 
     """
     dump_kwds = {'sort_keys': True}


### PR DESCRIPTION
Remove notes about additions before 1.0.

Resolves #2570