### PR TITLE
Allow color values greater than 256 in colormaps

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,7 @@ Changes
 1.3.7 (2023-05-22)
 ------------------
 
+- Allow color values greater than 256 in colormaps (#2769).
 - Fix the GDAL datatype mapping of Rasterio's uint64 and int64 data types. They
   were reversed in previous versions.
 - Special characters, specifically "!", in an HTTP(S) URI's userinfo


### PR DESCRIPTION
Also improve the docstring of write_colormap and write_mask.

Resolves #2769