### PR TITLE
Update tests.yaml

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -52,7 +52,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11', '3.12']
         gdal-version: ['3.6.4', '3.7.0']
         include:
           - python-version: '3.9'


### PR DESCRIPTION
I'm curious about testing on 3.12, but that will require building numpy and matplotlib (optionally) from source. The matplotlib sub-build fails for this PR.