### PR TITLE
Backport 2851

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,11 @@
 Changes
 =======
 
+1.3.8 (TBD)
+-----------
+
+- Add a workaround for a GDAL multithreading bug introduced in 3.6.0 (#2851).
+
 1.3.7 (2023-05-22)
 ------------------
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -166,6 +166,43 @@ cdef int io_multi_band(GDALDatasetH hds, int mode, double x0, double y0,
     for i in range(count):
         bandmap[i] = <int>indexes[i]
 
+    IF (CTE_GDAL_MAJOR_VERSION, CTE_GDAL_MINOR_VERSION, CTE_GDAL_PATCH_VERSION) >= (3, 6, 0) and (CTE_GDAL_MAJOR_VERSION, CTE_GDAL_MINOR_VERSION, CTE_GDAL_PATCH_VERSION) < (3, 7, 1):
+        # Workaround for https://github.com/rasterio/rasterio/issues/2847
+        # (bug when reading TIFF PlanarConfiguration=Separate images with
+        # multi-threading)
+        # To be removed when GDAL >= 3.7.1 is required
+        cdef const char* interleave = NULL
+        cdef GDALDriverH driver = NULL
+        cdef const char* driver_name = NULL
+        cdef GDALRasterBandH band = NULL
+        if CPLGetConfigOption("GDAL_NUM_THREADS", NULL):
+            interleave = GDALGetMetadataItem(hds, "INTERLEAVE", "IMAGE_STRUCTURE")
+            if interleave and interleave == b"BAND":
+                driver = GDALGetDatasetDriver(hds)
+                if driver:
+                    driver_name = GDALGetDescription(driver)
+                    if driver_name and driver_name == b"GTiff":
+                        try:
+                            for i in range(count):
+                                band = GDALGetRasterBand(hds, bandmap[i])
+                                if band == NULL:
+                                    raise ValueError("Null band")
+                                with nogil:
+                                    retval = GDALRasterIOEx(
+                                        band,
+                                        <GDALRWFlag>mode, xoff, yoff, xsize, ysize,
+                                        buf + i * bufbandspace,
+                                        bufxsize, bufysize, buftype,
+                                        bufpixelspace, buflinespace, &extras)
+
+                                if retval != CE_None:
+                                    return exc_wrap_int(retval)
+
+                            return exc_wrap_int(CE_None)
+
+                        finally:
+                            CPLFree(bandmap)
+
     try:
         with nogil:
             retval = GDALDatasetRasterIOEx(

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -226,6 +226,20 @@ class ReaderContextTest(unittest.TestCase):
             self.assertIsNone(s.meta['nodata'])
             self.assertRaises(ValueError, s.read)
 
+    def test_read_gtiff_band_interleave_multithread(self):
+        """Test workaround for https://github.com/rasterio/rasterio/issues/2847."""
+
+        with rasterio.Env(GDAL_NUM_THREADS='2'), rasterio.open('tests/data/rgb_deflate.tif') as s:
+            s.read(1)
+            a = s.read(2)
+            self.assertEqual(a.sum(), 25282412)
+
+        with rasterio.Env(GDAL_NUM_THREADS='2'), rasterio.open('tests/data/rgb_deflate.tif') as s:
+            a = s.read(indexes=[3,2,1])
+            self.assertEqual(a[0].sum(), 27325233)
+            self.assertEqual(a[1].sum(), 25282412)
+            self.assertEqual(a[2].sum(), 17008452)
+
 
 @pytest.mark.parametrize("shape,indexes", [
     ((72, 80), 1),          # Single band

--- a/tests/test_rio_calc.py
+++ b/tests/test_rio_calc.py
@@ -6,10 +6,10 @@ from rasterio.rio.main import main_group
 
 
 def test_err(tmpdir, runner):
-    outfile = str(tmpdir.join('out.tif'))
-    result = runner.invoke(main_group, ['calc'] + [
-        '($ 0.1 (read 1))', 'tests/data/shade.tif', outfile],
-        catch_exceptions=False)
+    outfile = str(tmpdir.join("out.tif"))
+    result = runner.invoke(
+        main_group, ["calc"] + ["($ 0.1 (read 1))", "tests/data/shade.tif", outfile]
+    )
     assert result.exit_code == 1
 
 


### PR DESCRIPTION
Backport of the workaround in #2851