### PR TITLE
Allow (float) windowed reads smaller than 1.0 to handle extreme zoom use case

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -145,8 +145,8 @@ cdef int io_multi_band(GDALDatasetH hds, int mode, double x0, double y0,
 
     cdef int xoff = <int>x0
     cdef int yoff = <int>y0
-    cdef int xsize = <int>width
-    cdef int ysize = <int>height
+    cdef int xsize = <int>max(1, width)
+    cdef int ysize = <int>max(1, height)
 
     cdef GDALRasterIOExtraArg extras
     extras.nVersion = 1
@@ -247,8 +247,8 @@ cdef int io_multi_mask(GDALDatasetH hds, int mode, double x0, double y0,
 
     cdef int xoff = <int>x0
     cdef int yoff = <int>y0
-    cdef int xsize = <int>width
-    cdef int ysize = <int>height
+    cdef int xsize = <int>max(1, width)
+    cdef int ysize = <int>max(1, height)
 
     cdef GDALRasterIOExtraArg extras
     extras.nVersion = 1
@@ -939,14 +939,8 @@ cdef class DatasetReaderBase(DatasetBase):
 
             yoff = window.row_off
             xoff = window.col_off
-
-            # Now that we have floating point windows it's easy for
-            # the number of pixels to read to slip below 1 due to
-            # loss of floating point precision. Here we ensure that
-            # we're reading at least one pixel.
-            height = max(1.0, window.height)
-            width = max(1.0, window.width)
-
+            width = window.width
+            height = window.height
         else:
             xoff = yoff = <int>0
             width = <int>self.width


### PR DESCRIPTION
For our use-case of rendering WMS / TMS images at high zoom levels, the clamping of the window read is happening too soon and causes corruption for lower resolution data. 

Here's a small demonstration of the issue. Given this dummy data set, in which we zoom a couple of times to a select few subpixels:

(data_g.png)
![data_g](https://github.com/rasterio/rasterio/assets/1843382/b92c47d6-d945-4455-93dd-a18c2867930c)
```
import rasterio
from rasterio.transform import Affine

with rasterio.open('data_g.png') as src:
    box = (72, 90, 74, 88)
    for zoom in range(3):
        box = (box[0] + 0.25, box[1] - 0.25, box[2] - 0.25, box[3] + 0.25)
        src_window = src.window(*box)
        print(src_window)
        data = src.read(boundless=True, window=src_window, out_shape=(256, 256), resampling=rasterio.enums.Resampling.nearest)
        with rasterio.open(f'out{zoom}.png', 'w', width=256, height=256, count=src.count, dtype=src.dtypes[0], transform=Affine.identity()) as dst:
            for i in range(1, src.count + 1):
                dst.write(data[i-1], indexes=i)
```
We end up with the following output:

> Window(col_off=72.25, row_off=88.25, width=1.5, height=1.5)
![out0](https://github.com/rasterio/rasterio/assets/1843382/96747b39-17a5-4a98-959f-8bb750214903)

> Window(col_off=72.5, row_off=88.5, width=1.0, height=1.0)
![out1](https://github.com/rasterio/rasterio/assets/1843382/cbcf920d-d310-42f6-a672-cd2a930b7e42)

> Window(col_off=72.75, row_off=88.75, width=0.5, height=0.5)
![out2](https://github.com/rasterio/rasterio/assets/1843382/a915c9d6-b18b-48cb-a6ae-e992f4c02038)

As you can see, the last one is messed up due to the premature clamping of the window width/height. Instead, that clamping should be delayed, so we can pass in the original float values in the extras parameter to the gdal io function.

Once you apply this patch, the last image will be fixed

> Window(col_off=72.75, row_off=88.75, width=0.5, height=0.5)
![out2_fixed](https://github.com/rasterio/rasterio/assets/1843382/c2b4153c-1bdc-4769-b9ac-f55b1b8eecc2)


