### PR TITLE
Prevent interpreter segfaults with closed MemoryFile.

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1274,15 +1274,17 @@ cdef class MemoryFileBase:
         VSIRmdirRecursive("/vsimem/{}".format(self._dirname).encode("utf-8"))
 
     def seek(self, offset, whence=0):
-        if not self.closed:
+        if self.closed:
+            raise OSError("I/O operation on closed MemoryFile")
+        else:
             return VSIFSeekL(self._vsif, offset, whence)
 
     def tell(self):
         if self.closed:
-            return 0
+            raise OSError("I/O operation on closed MemoryFile")
         else:
             return VSIFTellL(self._vsif)
-        
+
     def read(self, size=-1):
         """Read bytes from MemoryFile.
 
@@ -1302,7 +1304,7 @@ cdef class MemoryFileBase:
         cdef vsi_l_offset buffer_len = 0
 
         if self.closed:
-            raise OSError("Cannot read from closed MemoryFile")
+            raise OSError("I/O operation on closed MemoryFile")
 
         if size < 0:
             buffer = VSIGetMemFileBuffer(self._path, &buffer_len, 0)
@@ -1333,7 +1335,7 @@ cdef class MemoryFileBase:
 
         """
         if self.closed:
-            raise OSError("Cannot write to closed MemoryFile")
+            raise OSError("I/O operation on closed MemoryFile")
         cdef const unsigned char *view = <bytes>data
         n = len(data)
         result = VSIFWriteL(view, 1, n, self._vsif)

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -92,6 +92,38 @@ def test_closed():
         memfile.open()
 
 
+def test_closed_seek():
+    """A closed MemoryFile cannot be seeked"""
+    with MemoryFile() as memfile:
+        pass
+    with pytest.raises(OSError):
+        memfile.seek(0)
+
+
+def test_closed_read():
+    """A closed MemoryFile cannot be read"""
+    with MemoryFile() as memfile:
+        pass
+    with pytest.raises(OSError):
+        memfile.read()
+
+
+def test_closed_write():
+    """Cannot write to a closed MemoryFile"""
+    with MemoryFile() as memfile:
+        pass
+    with pytest.raises(OSError):
+        memfile.write([0])
+
+
+def test_closed_tell():
+    """Cannot tell on a closed MemoryFile"""
+    with MemoryFile() as memfile:
+        pass
+    with pytest.raises(OSError):
+        memfile.tell()
+
+
 def test_non_initial_bytes(rgb_file_bytes):
     """MemoryFile contents can be read from bytes and opened."""
     with MemoryFile() as memfile:
@@ -380,4 +412,3 @@ def test_write_rpcs_to_memfile(path_rgb_byte_rpc_vrt):
                 assert dst.rpcs is None
                 dst.rpcs = src.rpcs
                 assert dst.rpcs
-


### PR DESCRIPTION
Calling file operations on null pointer crashes Python interpreter.

Discovered this when accidentally calling `.seek(0)` on a closed MemoryFile and the Python interpreter segfaulted.