### PR TITLE
Add hist_range arg to rasterio.plot.show_hist

### DIFF
--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -228,7 +228,7 @@ def reshape_as_raster(arr):
     return im
 
 
-def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, label=None, **kwargs):
+def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, label=None, hist_range=None, **kwargs):
     """Easily display a histogram with matplotlib.
 
     Parameters
@@ -246,9 +246,12 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, label=No
         Title for the figure.
     ax : matplotlib.axes.Axes, optional
         The raster will be added to this axes if passed.
-    label : matplotlib labels (opt)
-        If passed, matplotlib will use this label list.
+    label : str, optional
+        String, or list of strings. If passed, matplotlib will use this label list.
         Otherwise, a default label list will be automatically created
+    hist_range : list, optional
+        List of `[min, max]` values. If passed, matplotlib will use this range.
+        Otherwise, a default range will be automatically created
     **kwargs : optional keyword arguments
         These will be passed to the :meth:`matplotlib.axes.Axes.hist` method.
     """
@@ -261,9 +264,14 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, label=No
     else:
         arr = source
 
-    # The histogram is computed individually for each 'band' in the array
-    # so we need the overall min/max to constrain the plot
-    rng = np.nanmin(arr), np.nanmax(arr)
+    if "range" in kwargs:
+        # Avoid TypeError: matplotlib.axes._axes.Axes.hist() got multiple values for keyword argument 'range'
+        hist_range = kwargs.pop("range")
+
+    if hist_range is None:
+        # The histogram is computed individually for each 'band' in the array
+        # so we need the overall min/max to constrain the plot
+        hist_range = np.nanmin(arr), np.nanmax(arr)
 
     if len(arr.shape) == 2:
         arr = np.expand_dims(arr.flatten(), 0).T
@@ -291,7 +299,7 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, label=No
         if isinstance(source, (tuple, rasterio.Band)):
             labels = [str(source[1])]
         else:
-            labels = (str(i + 1) for i in range(len(arr)))
+            labels = [str(i + 1) for i in range(len(arr))]
 
     if ax:
         show = False
@@ -305,7 +313,7 @@ def show_hist(source, bins=10, masked=True, title='Histogram', ax=None, label=No
             bins=bins,
             color=colors,
             label=labels,
-            range=rng,
+            range=hist_range,
             **kwargs)
 
     ax.legend(loc="upper right")

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -202,6 +202,22 @@ def test_show_hist():
         except ImportError:
             pass
 
+        try:
+            show_hist(src.read(), hist_range=[0, 255])
+            fig = plt.gcf()
+            plt.close(fig)
+        except ImportError:
+            pass
+
+        try:
+            show_hist(src)
+            fig = plt.gcf()
+            ax = plt.gca()
+            assert ax.get_legend_handles_labels()[1] == ["1", "2", "3"]
+            plt.close(fig)
+        except ImportError:
+            pass
+
 
 def test_show_hist_mplargs():
     """
@@ -211,7 +227,8 @@ def test_show_hist_mplargs():
     with rasterio.open('tests/data/RGB.byte.tif') as src:
         try:
             show_hist(src, bins=50, lw=0.0, stacked=False, alpha=0.3,
-               histtype='stepfilled', title="World Histogram overlaid")
+               histtype='stepfilled', title="World Histogram overlaid",
+               range=[0, 255])
             fig = plt.gcf()
             plt.close(fig)
         except ImportError:


### PR DESCRIPTION
As per this [GIS Stack question](https://gis.stackexchange.com/questions/457467/control-the-range-with-show-hist-of-rasterio), it could be useful to allow the caller to supply a `hist_range` argument to `rasterio.plot.show_hist` which would be passed to matplotlib instead of the internally generated range ([plot.py#L266](https://github.com/rasterio/rasterio/blob/main/rasterio/plot.py#L266)).  

The way I've implemented it also avoids `TypeError: matplotlib.axes._axes.Axes.hist() got multiple values for keyword argument 'range'` if a user passes a `range` kwarg to `show_hist`.  The docs were a bit confusing in regards to this as it sounded like all additional kwargs would be passed to the matplotlib Axes.hist method, however range could not.

While putting together a PR for this, I also made a minor fix to `show_hist` to fix a repr of a generator object being used as the label,  but it didn't seem worthy of a separate PR.

Changes:

- Add hist_range argument
- Handle range kwarg
- Avoid seeing a repr(<generator etc...>) label
- Make label doc string the same format as other args 
- Add tests for hist_range, range and label