### PR TITLE
In nested Env managers make interaction of Env.session consistent for a single thread

### DIFF
--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -254,8 +254,8 @@ class Env:
 
         # if self.context_options has "AWS_*" credentials from parent context then it should
         # always override what comes back from self.session.get_credential_options()
-        # b/c Session.from_environ might've created a session in __init__ from
-        # globally exported "AWS_*" os environ variables
+        # b/c Session.from_environ could've created a session from globally exported
+        # "AWS_*" os environ variables
         existing_creds = self.aws_creds_from_context_options()
         self.options.update(**existing_creds)
         setenv(**existing_creds)

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -252,12 +252,10 @@ class Env:
         self.options.update(**cred_opts)
         setenv(**cred_opts)
 
-        # https://github.com/rasterio/rasterio/issues/2866
-        # if self.context_options has "AWS_*" credentials then it should
+        # if self.context_options has "AWS_*" credentials from parent context then it should
         # always override what comes back from self.session.get_credential_options()
-        # b/c Session.from_environ might've created a session during __init__ from
-        # globally exported "AWS_*" os environ variables instead
-        # of those from existing single-threaded context
+        # b/c Session.from_environ might've created a session in __init__ from
+        # globally exported "AWS_*" os environ variables
         existing_creds = self.aws_creds_from_context_options()
         self.options.update(**existing_creds)
         setenv(**existing_creds)

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -261,6 +261,7 @@ class Env:
             # always override what comes back from self.session.get_credential_options()
             # b/c __init__ might have created a session from globally exported "AWS_*" os environ variables
             parent_context_creds = self.aws_creds_from_context_options()
+            if not parent_context_creds: return
             self.options.update(**parent_context_creds)
             # override resolution path to keep state accurate and trackable
             self.session_resolution_path = "session_from_parent_context_options"

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -191,6 +191,7 @@ class Env:
                 session = Session.aws_or_dummy(session=session)
 
             self.session = session
+            self.session_resolution_path = "session_kwarg"
 
         elif aws_access_key_id or profile_name or aws_unsigned:
             self.session = Session.aws_or_dummy(
@@ -200,12 +201,15 @@ class Env:
                 region_name=region_name,
                 profile_name=profile_name,
                 aws_unsigned=aws_unsigned)
+            self.session_resolution_path = "session_aws_or_dummy"
 
         elif 'AWS_ACCESS_KEY_ID' in os.environ and 'AWS_SECRET_ACCESS_KEY' in os.environ:
             self.session = Session.from_environ()
+            self.session_resolution_path = "session_from_environ"
 
         else:
             self.session = DummySession()
+            self.session_resolution_path = "session_dummy"
 
         self.options = options.copy()
         self.context_options = {}
@@ -252,13 +256,15 @@ class Env:
         self.options.update(**cred_opts)
         setenv(**cred_opts)
 
-        # if self.context_options has "AWS_*" credentials from parent context then it should
-        # always override what comes back from self.session.get_credential_options()
-        # b/c Session.from_environ could've created a session from globally exported
-        # "AWS_*" os environ variables
-        existing_creds = self.aws_creds_from_context_options()
-        self.options.update(**existing_creds)
-        setenv(**existing_creds)
+        if self.session_resolution_path == "session_from_environ":
+            # if self.context_options has "AWS_*" credentials from parent context then it should
+            # always override what comes back from self.session.get_credential_options()
+            # b/c __init__ might have created a session from globally exported "AWS_*" os environ variables
+            parent_context_creds = self.aws_creds_from_context_options()
+            self.options.update(**parent_context_creds)
+            # override resolution path to keep state accurate and trackable
+            self.session_resolution_path = "session_from_parent_context_options"
+            setenv(**parent_context_creds)
 
     def drivers(self):
         """Return a mapping of registered drivers."""

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -3,7 +3,6 @@
 
 import os
 import sys
-from collections import namedtuple
 from concurrent import futures
 from unittest import mock
 
@@ -405,7 +404,7 @@ def test_session_nested_env_with_global_multi_threaded(monkeypatch, gdalenv, cap
         for result_list in results:
             for result in result_list:
                 for k,v in result.items():
-                    assert global_expected[k] == v
+                    assert session_expected[k] == v
 
     monkeypatch.undo()
 

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -404,7 +404,7 @@ def test_session_nested_env_with_global_multi_threaded(monkeypatch, gdalenv, cap
         for result_list in results:
             for result in result_list:
                 for k,v in result.items():
-                    assert session_expected[k] == v
+                    assert global_expected[k] == v
 
     monkeypatch.undo()
 


### PR DESCRIPTION
Addresses #2866 for single-threaded context

### Additions

* adds simple `rasterio.Env.session_resolution_path` to track how `__init__` resolves sessions and help fix bug for single-threaded context

* adds override flow to `credentialize()` for nested context managers getting parent session context from `self.context_options`

* tests
