### PR TITLE
Python file opener VSI plugin

### DIFF
--- a/docs/topics/vsi.rst
+++ b/docs/topics/vsi.rst
@@ -1,16 +1,16 @@
-Virtual Files
-=============
+Virtual Filesystems
+===================
 
 .. todo::
 
     Support for URIs describing zip, s3, https resources.
     Relationship to GDAL vsicurl, vsis3 et al.
 
+Rasterio relies on GDAL's virtual filesystem interface to access datasets
+on the web, in cloud storage, in archive files, and in Python objects.
+
 AWS S3
 ------
-
-.. note::
-    Requires GDAL 2.1.0
 
 This is an extra feature that must be installed by executing
 
@@ -50,3 +50,34 @@ your code.
    make at least 3 GET requests to fetch a TIFF's `profile` as shown above
    and likely many more to fetch all the imagery from the TIFF. Consult the
    AWS S3 pricing guidelines before deciding if `aws.Session` is for you.
+
+Python file openers
+-------------------
+
+Datasets stored in proprietary systems or addressable only through protocols
+not directly supported by GDAL can be accessed using the ``opener`` keyword
+argument of ``rasterio.open``. Here is an example of using ``fs_s3fs`` to
+access the dataset in
+``sentinel-s2-l2a-cogs/45/C/VQ/2022/11/S2B_45CVQ_20221102_0_L2A/B01.tif`` from
+the ``sentinel-cogs`` AWS S3 bucket. Rasterio can access this without using the
+``opener`` argument, but it makes a good usage example. Other custom openers
+would work in the same way.
+
+.. code-block::
+
+    import rasterio
+    from fs_s3fs import S3FS
+
+    fs = S3FS(
+        bucket_name="sentinel-cogs",
+        dir_path="sentinel-s2-l2a-cogs/45/C/VQ/2022/11/S2B_45CVQ_20221102_0_L2A",
+        aws_access_key_id=AWS_ACCESS_KEY_ID,
+        aws_secret_access_key=AWS_SECRET_ACCESS_KEY,
+    )
+
+    with rasterio.open("B01.tif", opener=fs.openbin) as src:
+        print(src.profile)
+
+
+Where AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY are placeholders for the
+appropriate credentials.

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -202,14 +202,14 @@ def open(
     Examples
     --------
 
-    To open a GeoTIFF for reading using standard driver discovery and
-    no directives:
+    To open a local GeoTIFF dataset for reading using standard driver
+    discovery and no directives:
 
     >>> import rasterio
     >>> with rasterio.open('example.tif') as dataset:
     ...     print(dataset.profile)
 
-    To open a JPEG2000 using only the JP2OpenJPEG driver:
+    To open a local JPEG2000 dataset using only the JP2OpenJPEG driver:
 
     >>> with rasterio.open(
     ...         'example.jp2', driver='JP2OpenJPEG') as dataset:

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -186,9 +186,9 @@ def open(
         A custom dataset opener which can serve GDAL's virtual
         filesystem machinery via Python file-like objects. The
         underlying file-like object is obtained by calling *opener* with
-        *fp* as the sole positional argument. *opener* must return
-        a Python file-like object that provides read, seek, tell, and
-        close methods.
+        (*fp*, *mode*) or (*fp*, *mode* + "b") depending on the format
+        driver's native mode. *opener* must return a Python file-like
+        object that provides read, seek, tell, and close methods.
     kwargs : optional
         These are passed to format drivers as directives for creating or
         interpreting datasets. For example: in 'w' or 'w+' modes

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -185,6 +185,8 @@ cdef GDALDatasetH open_dataset(
     cdef char **drivers = NULL
     cdef char **options = NULL
 
+    log.debug("Args: filename=%r, flags=%r", filename, flags)
+
     filename = filename.encode('utf-8')
     fname = filename
 

--- a/rasterio/_env.pyx
+++ b/rasterio/_env.pyx
@@ -19,7 +19,8 @@ import threading
 
 from rasterio._err import CPLE_BaseError
 from rasterio._err cimport exc_wrap_ogrerr, exc_wrap_int
-from rasterio._filepath cimport install_filepath_plugin, uninstall_filepath_plugin
+from rasterio._filepath cimport install_filepath_plugin
+from rasterio._vsiopener cimport install_pyopener_plugin
 from rasterio._version import gdal_version
 
 from libc.stdio cimport stderr
@@ -65,6 +66,7 @@ except ImportError:
 cdef bint is_64bit = sys.maxsize > 2 ** 32
 
 cdef VSIFilesystemPluginCallbacksStruct* filepath_plugin = NULL
+cdef VSIFilesystemPluginCallbacksStruct* pyopener_plugin = NULL
 
 
 cdef void log_error(CPLErr err_class, int err_no, const char* msg) with gil:
@@ -364,6 +366,7 @@ cdef class GDALEnv(ConfigEnv):
                     GDALAllRegister()
                     OGRRegisterAll()
                     install_filepath_plugin(filepath_plugin)
+                    install_pyopener_plugin(pyopener_plugin)
 
                     if 'GDAL_DATA' in os.environ:
                         log.debug("GDAL_DATA found in environment.")

--- a/rasterio/_vsiopener.pxd
+++ b/rasterio/_vsiopener.pxd
@@ -1,0 +1,6 @@
+include "gdal.pxi"
+
+cdef int install_pyopener_plugin(VSIFilesystemPluginCallbacksStruct *callbacks_struct)
+cdef void uninstall_pyopener_plugin(VSIFilesystemPluginCallbacksStruct *callbacks_struct)
+
+

--- a/rasterio/_vsiopener.pyx
+++ b/rasterio/_vsiopener.pyx
@@ -1,0 +1,146 @@
+# cython: language_level=3, boundscheck=False
+# distutils: language = c++
+"""Bridge between Python file openers and GDAL VSI.
+
+Based on _filepath.pyx.
+"""
+
+include "gdal.pxi"
+
+import contextlib
+import logging
+from uuid import uuid4
+
+from libc.string cimport memcpy
+
+log = logging.getLogger(__name__)
+
+gdal33_version_checked = False
+gdal33_version_met = False
+
+
+# NOTE: This has to be defined outside of gdal.pxi or other C extensions will
+# try to compile C++ only code included in this header.
+cdef extern from "cpl_vsi_virtual.h":
+    cdef cppclass VSIFileManager:
+        @staticmethod
+        void* GetHandler(const char*)
+
+
+# Prefix for all in-memory paths used by GDAL's VSI system
+# Except for errors and log messages this shouldn't really be seen by the user
+cdef str FILESYSTEM_PREFIX = "/vsipyopener/"
+cdef bytes FILESYSTEM_PREFIX_BYTES = FILESYSTEM_PREFIX.encode("ascii")
+
+# This is global state for the Python filesystem plugin. It currently only
+# contains path -> PyOpenerBase (or subclass) instances. This is used by
+# the plugin to determine what "files" exist on "disk".
+# Currently the only way to "create" a file in the filesystem is to add
+# an entry to this dictionary. GDAL will then Open the path later.
+cdef _OPENER_REGISTRY = {}
+cdef _OPEN_FILE_OBJS = set()
+
+
+cdef int install_pyopener_plugin(VSIFilesystemPluginCallbacksStruct *callbacks_struct):
+    """Install handlers for python file openers if it isn't already installed."""
+    callbacks_struct = VSIAllocFilesystemPluginCallbacksStruct()
+    callbacks_struct.open = <VSIFilesystemPluginOpenCallback>pyopener_open
+    callbacks_struct.tell = <VSIFilesystemPluginTellCallback>pyopener_tell
+    callbacks_struct.seek = <VSIFilesystemPluginSeekCallback>pyopener_seek
+    callbacks_struct.read = <VSIFilesystemPluginReadCallback>pyopener_read
+    callbacks_struct.close = <VSIFilesystemPluginCloseCallback>pyopener_close
+    callbacks_struct.pUserData = <void*>_OPENER_REGISTRY
+
+    if VSIFileManager.GetHandler("") == VSIFileManager.GetHandler(FILESYSTEM_PREFIX_BYTES):
+        log.debug("Installing PyOpener filesystem handler plugin...")
+        return VSIInstallPluginHandler(FILESYSTEM_PREFIX_BYTES, callbacks_struct)
+    else:
+        return 0
+
+
+cdef void uninstall_pyopener_plugin(VSIFilesystemPluginCallbacksStruct *callbacks_struct):
+    if callbacks_struct is not NULL:
+        callbacks_struct.pUserData = NULL
+        VSIFreeFilesystemPluginCallbacksStruct(callbacks_struct)
+    callbacks_struct = NULL
+
+
+cdef void* pyopener_open(void *pUserData, const char *pszFilename, const char *pszAccess) with gil:
+    """Access files in the virtual filesystem.
+
+    This function is mandatory in the GDAL Filesystem Plugin API.
+    GDAL may call this function multiple times per filename and each
+    result must be seperately seekable.
+    """
+    cdef object file_opener
+    cdef object file_obj
+
+    if pszAccess != b"r" and pszAccess != b"rb":
+        log.error("PyOpener is currently a read-only interface.")
+        return NULL
+
+    if pUserData is NULL:
+        log.error("PyOpener filesystem accessed with uninitialized filesystem info.")
+        return NULL
+
+    cdef dict filesystem_info = <object>pUserData
+
+    try:
+        file_opener = filesystem_info[pszFilename]
+    except KeyError:
+        log.info("Object not found in virtual filesystem: filename=%r", pszFilename)
+        return NULL
+
+    # Extract the opener's argument from the vsi filename.
+    path = pszFilename
+    if path.startswith(FILESYSTEM_PREFIX_BYTES):
+        path = path[len(FILESYSTEM_PREFIX_BYTES):]
+
+    file_obj = file_opener(path, "rb")
+    return <void *>file_obj
+
+    # Open file wrappers are kept in this set and removed when closed.
+    # _OPEN_FILE_OBJS.add(file_obj)
+
+
+cdef vsi_l_offset pyopener_tell(void *pFile) with gil:
+    cdef object file_obj = <object>pFile
+    cdef long pos = file_obj.tell()
+    return <vsi_l_offset>pos
+
+
+cdef int pyopener_seek(void *pFile, vsi_l_offset nOffset, int nWhence) except -1 with gil:
+    cdef object file_obj = <object>pFile
+    # TODO: Add "seekable" check?
+    file_obj.seek(nOffset, nWhence)
+    return 0
+
+
+cdef size_t pyopener_read(void *pFile, void *pBuffer, size_t nSize, size_t nCount) with gil:
+    cdef object file_obj = <object>pFile
+    cdef bytes python_data = file_obj.read(nSize * nCount)
+    cdef int num_bytes = len(python_data)
+    # NOTE: We have to cast to char* first, otherwise Cython doesn't do the conversion properly
+    memcpy(pBuffer, <void*><char*>python_data, num_bytes)
+    return <size_t>(num_bytes / nSize)
+
+
+cdef int pyopener_close(void *pFile) except -1 with gil:
+    cdef object file_obj = <object>pFile
+    try:
+        file_obj.close()
+    except AttributeError:
+        pass
+
+    # _OPEN_FILE_OBJS.remove(file_obj)
+    return 0
+
+
+@contextlib.contextmanager
+def _opener_registration(urlpath, opener):
+    _OPENER_REGISTRY[urlpath] = opener
+    try:
+        yield opener
+    finally:
+        _ = _OPENER_REGISTRY.pop(urlpath)
+

--- a/rasterio/_vsiopener.pyx
+++ b/rasterio/_vsiopener.pyx
@@ -100,10 +100,10 @@ cdef void* pyopener_open(void *pUserData, const char *pszFilename, const char *p
 
     try:
         file_obj = file_opener(filename, mode)
-    # ZipFile.open doesn't take a mode argument and will raise
-    # ValueError if given one.
+    # ZipFile.open doesn't accept binary modes like "rb" and will raise
+    # ValueError if given one. We strip the mode in this case.
     except ValueError as err:
-        file_obj = file_opener(filename)
+        file_obj = file_opener(filename, mode.rstrip("b"))
 
     log.debug("Opened file object: file_obj=%r, mode=%r", file_obj, mode)
 

--- a/rasterio/_vsiopener.pyx
+++ b/rasterio/_vsiopener.pyx
@@ -90,7 +90,13 @@ cdef void* pyopener_open(void *pUserData, const char *pszFilename, const char *p
         log.info("Object not found: registry=%r, filename=%r", registry, filename)
         return NULL
 
-    cdef object file_obj = file_opener(filename, "rb")
+    cdef object file_obj
+
+    try:
+        file_obj = file_opener(filename, "rb")
+    except ValueError:
+        file_obj = file_opener(filename)
+
     if hasattr(file_obj, "open"):
         file_obj = file_obj.open()
 

--- a/rasterio/_vsiopener.pyx
+++ b/rasterio/_vsiopener.pyx
@@ -38,6 +38,7 @@ cdef bytes PREFIX_BYTES = PREFIX.encode("utf-8")
 # Currently the only way to "create" a file in the filesystem is to add
 # an entry to this dictionary. GDAL will then Open the path later.
 cdef _OPENER_REGISTRY = {}
+cdef _OPEN_FILE_OBJS = set()
 
 
 cdef int install_pyopener_plugin(VSIFilesystemPluginCallbacksStruct *callbacks_struct):
@@ -50,8 +51,11 @@ cdef int install_pyopener_plugin(VSIFilesystemPluginCallbacksStruct *callbacks_s
     callbacks_struct.close = <VSIFilesystemPluginCloseCallback>pyopener_close
     callbacks_struct.pUserData = <void*>_OPENER_REGISTRY
 
-    log.debug("Installing PyOpener filesystem handler plugin...")
-    return VSIInstallPluginHandler(PREFIX_BYTES, callbacks_struct)
+    if VSIFileManager.GetHandler("") == VSIFileManager.GetHandler(PREFIX_BYTES):
+        log.debug("Installing Python opener handler plugin...")
+        return VSIInstallPluginHandler(PREFIX_BYTES, callbacks_struct)
+    else:
+        return 0
 
 
 cdef void uninstall_pyopener_plugin(VSIFilesystemPluginCallbacksStruct *callbacks_struct):
@@ -68,14 +72,12 @@ cdef void* pyopener_open(void *pUserData, const char *pszFilename, const char *p
     GDAL may call this function multiple times per filename and each
     result must be seperately seekable.
     """
-    cdef object file_obj
-
     if pszAccess != b"r" and pszAccess != b"rb":
-        log.error("PyOpener is currently a read-only interface.")
+        log.error("Python opener is currently a read-only interface.")
         return NULL
 
     if pUserData is NULL:
-        log.error("PyOpener filesystem accessed with uninitialized filesystem info.")
+        log.error("Python opener registry is not initialized.")
         return NULL
 
     cdef dict registry = <object>pUserData
@@ -88,15 +90,16 @@ cdef void* pyopener_open(void *pUserData, const char *pszFilename, const char *p
         log.info("Object not found: registry=%r, filename=%r", registry, filename)
         return NULL
 
-    file_obj = file_opener(filename, "rb")
+    cdef object file_obj = file_opener(filename, "rb")
     if hasattr(file_obj, "open"):
         file_obj = file_obj.open()
 
     log.debug("Opened file object: file_obj=%r", file_obj)
+    _OPEN_FILE_OBJS.add(file_obj)
     return <void *>file_obj
 
 
-cdef vsi_l_offset pyopener_tell(void *pFile) with gil:
+cdef vsi_l_offset pyopener_tell(void *pFile) except -1 with gil:
     cdef object file_obj = <object>pFile
     cdef long pos = file_obj.tell()
     return <vsi_l_offset>pos
@@ -109,34 +112,34 @@ cdef int pyopener_seek(void *pFile, vsi_l_offset nOffset, int nWhence) except -1
     return 0
 
 
-cdef size_t pyopener_read(void *pFile, void *pBuffer, size_t nSize, size_t nCount) with gil:
+cdef size_t pyopener_read(void *pFile, void *pBuffer, size_t nSize, size_t nCount) except -1 with gil:
     cdef object file_obj = <object>pFile
-    log.debug("Reading Python file: file_obj=%r, nSize=%r, nCount=%r", file_obj, nSize, nCount)
     cdef bytes python_data = file_obj.read(nSize * nCount)
-    log.debug("Data check: python_data=%r", python_data)
-    log.debug("Data check: len=%r", len(python_data))
     cdef int num_bytes = len(python_data)
     # NOTE: We have to cast to char* first, otherwise Cython doesn't do the conversion properly
     memcpy(pBuffer, <void*><char*>python_data, num_bytes)
-    log.debug("Read Python file: num_bytes=%r", num_bytes)
     return <size_t>(num_bytes / nSize)
 
 
 cdef int pyopener_close(void *pFile) except -1 with gil:
     cdef object file_obj = <object>pFile
+    log.debug("Closing: file_obj=%r", file_obj)
     try:
         file_obj.close()
     except AttributeError:
+        log.exception()
         pass
+    except Exception:
+        log.exception()
+        raise
 
-    # _OPEN_FILE_OBJS.remove(file_obj)
+    _OPEN_FILE_OBJS.remove(file_obj)
     return 0
 
 
 @contextlib.contextmanager
 def _opener_registration(urlpath, opener):
     filename = urlpath
-    log.debug("Registering opener: filename=%r, opener=%r", filename, opener)
     _OPENER_REGISTRY[filename] = opener
     try:
         yield f"{PREFIX}{filename}"

--- a/rasterio/_vsiopener.pyx
+++ b/rasterio/_vsiopener.pyx
@@ -98,11 +98,13 @@ cdef void* pyopener_open(void *pUserData, const char *pszFilename, const char *p
     cdef object file_obj
 
     try:
-        file_obj = file_opener(filename, "rb")
+        file_obj = file_opener(filename, mode="rb")
     except ValueError:
-        file_obj = file_opener(filename)
+        file_obj = file_opener(filename, mode="r")
 
-    if hasattr(file_obj, "open"):
+    # If the opener returned an OpenFile, we open it.
+    if not hasattr(file_obj, "f") and hasattr(file_obj, "fs") and hasattr(file_obj, "path"):
+        log.debug("Detected an OpenFile: file_obj=%r", file_obj)
         file_obj = file_obj.open()
 
     log.debug("Opened file object: file_obj=%r", file_obj)

--- a/rasterio/_vsiopener.pyx
+++ b/rasterio/_vsiopener.pyx
@@ -114,7 +114,7 @@ cdef void* pyopener_open(void *pUserData, const char *pszFilename, const char *p
     try:
         file_obj = stack.enter_context(file_obj)
     except (AttributeError, TypeError):
-        log.info("File object is not a context manager: file_obj=%r", file_obj)
+        log.debug("File object is not a context manager: file_obj=%r", file_obj)
 
     _OPEN_FILE_EXIT_STACKS[file_obj] = stack
     return <void *>file_obj

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -50,6 +50,7 @@ cdef extern from "cpl_string.h" nogil:
                            const char *pszValue)
     char **CSLDuplicate(char **papszStrList)
     int CSLFindName(char **papszStrList, const char *pszName)
+    int CSLFindString(char **papszStrList, const char *pszString)
     int CSLFetchBoolean(char **papszStrList, const char *pszName, int default)
     const char *CSLFetchNameValue(char **papszStrList, const char *pszName)
     char **CSLSetNameValue(char **list, char *name, char *val)
@@ -121,6 +122,7 @@ cdef extern from "cpl_vsi.h" nogil:
     int VSIInstallPluginHandler(const char*, const VSIFilesystemPluginCallbacksStruct*)
     VSIFilesystemPluginCallbacksStruct* VSIAllocFilesystemPluginCallbacksStruct()
     void VSIFreeFilesystemPluginCallbacksStruct(VSIFilesystemPluginCallbacksStruct*)
+    char** VSIGetFileSystemsPrefixes()
 
     unsigned char *VSIGetMemFileBuffer(const char *path,
                                        vsi_l_offset *data_len,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -3,6 +3,7 @@
 # development specific requirements
 cython>=3
 delocate
+fsspec
 hypothesis
 mypy
 numpydoc

--- a/setup.py
+++ b/setup.py
@@ -253,6 +253,9 @@ if "clean" not in sys.argv:
         extensions.append(
             Extension(
                 'rasterio._filepath', ['rasterio/_filepath.pyx'], **cpp_ext_options))
+        extensions.append(
+            Extension(
+                'rasterio._vsiopener', ['rasterio/_vsiopener.pyx'], **cpp_ext_options))
     ext_modules = cythonize(
         extensions, quiet=True, compile_time_env=compile_time_env, **cythonize_options)
 

--- a/tests/test_filepath.py
+++ b/tests/test_filepath.py
@@ -224,3 +224,11 @@ def test_quieter_vsi_plugin_notifications(caplog, path_rgb_byte_tif):
                 _ = src.profile
 
         assert "not found in virtual filesystem" not in caplog.text
+
+import io
+
+
+def test_opener(path_rgb_byte_tif):
+    """First test of vsi python plugin opener."""
+    with rasterio.open(path_rgb_byte_tif, opener=io.open) as src:
+        _ = src.profile

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -7,11 +7,13 @@ import rasterio
 def test_opener_builtin(path_rgb_byte_tif):
     """First test of vsi python plugin opener."""
     with rasterio.open(path_rgb_byte_tif, opener=io.open) as src:
-        _ = src.profile
-
+        profile = src.profile
+        assert profile["driver"] == "GTiff"
+        assert profile["count"] == 3
 
 def test_opener_fsspec():
     """First test of vsi python plugin opener."""
     with rasterio.open("zip://*.tif::tests/data/files.zip", opener=fsspec.open) as src:
-        _ = src.profile
-        print(_)
+        profile = src.profile
+        assert profile["driver"] == "GTiff"
+        assert profile["count"] == 3

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -1,0 +1,8 @@
+import io
+
+import rasterio
+
+def test_opener(path_rgb_byte_tif):
+    """First test of vsi python plugin opener."""
+    with rasterio.open(path_rgb_byte_tif, opener=io.open) as src:
+        _ = src.profile

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -1,8 +1,17 @@
 import io
 
+import fsspec
+
 import rasterio
 
-def test_opener(path_rgb_byte_tif):
+def test_opener_builtin(path_rgb_byte_tif):
     """First test of vsi python plugin opener."""
     with rasterio.open(path_rgb_byte_tif, opener=io.open) as src:
         _ = src.profile
+
+
+def test_opener_fsspec():
+    """First test of vsi python plugin opener."""
+    with rasterio.open("zip://*.tif::tests/data/files.zip", opener=fsspec.open) as src:
+        _ = src.profile
+        print(_)

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -1,19 +1,44 @@
+"""Tests of the Python opener VSI plugin."""
+
+import zipfile
 import io
 
 import fsspec
+import pytest
 
 import rasterio
 
-def test_opener_builtin(path_rgb_byte_tif):
-    """First test of vsi python plugin opener."""
-    with rasterio.open(path_rgb_byte_tif, opener=io.open) as src:
+
+def test_opener_io_open():
+    """Use io.open as opener."""
+    with rasterio.open("tests/data/RGB.byte.tif", opener=io.open) as src:
         profile = src.profile
         assert profile["driver"] == "GTiff"
         assert profile["count"] == 3
 
-def test_opener_fsspec():
-    """First test of vsi python plugin opener."""
-    with rasterio.open("zip://*.tif::tests/data/files.zip", opener=fsspec.open) as src:
+
+@pytest.mark.parametrize("urlpath", ["file://tests/data/RGB.byte.tif", "zip://*.tif::tests/data/files.zip"])
+def test_opener_fsspec_open(urlpath):
+    """Use fsspec.open as opener."""
+    with rasterio.open(urlpath, opener=fsspec.open) as src:
         profile = src.profile
         assert profile["driver"] == "GTiff"
         assert profile["count"] == 3
+
+
+def test_opener_fsspec_fs():
+    """Use fsspec filesystem as opener."""
+    fs = fsspec.filesystem("file")
+    with rasterio.open("tests/data/RGB.byte.tif", opener=fs.open) as src:
+        profile = src.profile
+        assert profile["driver"] == "GTiff"
+        assert profile["count"] == 3
+
+
+def test_opener_zipfile_open():
+    """Use zipfile as opener."""
+    with zipfile.ZipFile("tests/data/files.zip") as zf:
+        with rasterio.open("RGB.byte.tif", opener=zf.open) as src:
+            profile = src.profile
+            assert profile["driver"] == "GTiff"
+            assert profile["count"] == 3


### PR DESCRIPTION
Resolves #2888 ~maybe~ definitely.

This PR adds a new `opener` keyword argument to `rasterio.open()`, making an analogy to the `opener` kwarg of Python's builtin `open()`.

The `opener` keyword argument must be a callable which takes a string as its one positional argument and returns a read-only Python file-like object with `read`, `seek`, `tell`, and `close` methods. The `opener` is called by GDAL's virtual filesystem machinery and thus its file-like object serves GDAL's format drivers.

Example usage:

```python
with rasterio.open("zip://*.tif::tests/data/files.zip", opener=fsspec.open) as src:
    print(src.profile)
```

When the opener needs extra arguments, one can use `functools.partial`.

```python
from functools import partial
with rasterio.open("dask::s3://bucket/key", opener=partial(fsspec.open, s3={"anon": True})) as src:
    print(src.profile)
```

Applications of this include:

* Opening datasets stored in proprietary systems
* Integration with auth systems or protocols not supported by GDAL

Currently we're testing with `io.open`, `zipfile.ZipFile.open`, and `fsspec.open`. I expect this to extend to `gzip` and `fs_s3fs` openers in the same way.