### PR TITLE
Coordinate contains check

### DIFF
--- a/rasterio/coords.py
+++ b/rasterio/coords.py
@@ -22,6 +22,31 @@ BoundingBox.__doc__ = \
         Top coordinate
     """
 
+
+def contains_coord(bounds, coord):
+    """Test if coord is contained in bounds.
+    Coordinate and bounds are assumed to be relative to the same CRS.
+
+    Parameters
+    ----------
+    bounds: BoundingBox
+    coord: Sequence
+        xy coordinate
+
+    Returns
+    -------
+    boolean
+    ``True`` if coord is contained in bounding box
+    ``False`` otherwise
+    """
+    x, y = coord
+    # if we are dealing with a possibly south-up bounding box
+    bottom, top = sorted((bounds.bottom, bounds.top))
+    return (bottom <= y <= top
+            and
+            bounds.left <= x <= bounds.right)
+
+
 def disjoint_bounds(bounds1, bounds2):
     """Compare two bounds and determine if they are disjoint.
 

--- a/tests/test_coords.py
+++ b/tests/test_coords.py
@@ -1,7 +1,7 @@
 import numpy as np
 
 import rasterio
-from rasterio.coords import BoundingBox, disjoint_bounds
+from rasterio.coords import BoundingBox, disjoint_bounds, contains_coord
 
 
 def test_bounds():
@@ -39,3 +39,19 @@ def test_disjoint_bounds_issue1459_south_up():
     a = BoundingBox(left=0.0, bottom=1.0, right=1.0, top=0.0)
     b = BoundingBox(left=0.0, bottom=2.0, right=1.0, top=1.01)
     assert disjoint_bounds(a, b)
+
+
+def test_contains_coord():
+    bounds = BoundingBox(left=0.0, bottom=0.0, right=1.0, top=1.0)
+    assert contains_coord(bounds, (.5, .5))
+    assert contains_coord(bounds, (0, 0))
+    assert not contains_coord(bounds, (-.01, .5))
+    assert not contains_coord(bounds, (0, 2))
+
+
+def test_contains_coord_south_up():
+    bounds = BoundingBox(left=0.0, bottom=1.0, right=1.0, top=0.0)
+    assert contains_coord(bounds, (.5, .5))
+    assert contains_coord(bounds, (0, 0))
+    assert not contains_coord(bounds, (-.01, .5))
+    assert not contains_coord(bounds, (0, 2))


### PR DESCRIPTION
Implements a useful utility function for checking of a coordinate is contained within the bounding box of a raster. The use case that prompted this was testing to see which rasters covered a specific location(s). Testing this before reading seemed a much simpler route than checking to see if the read pixel was a nodata value.

It's a small utility function designed to make life a little more simple and the coord module seemed like the perfect place for this to live.