### PR TITLE
Migrate to RTD v2

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,8 +1,20 @@
 version: 2
 
 build:
-  os: ubuntu-22.04
+  os: "ubuntu-22.04"
   tools:
-    python: "3.11"
+    python: "mambaforge-4.10"
+
+sphinx:
+  configuration: docs/conf.py
+  fail_on_warning: false
+
+formats: all
+
 conda:
-  environment: environment.yml
+  environment: docs/environment.yml
+
+python:
+  install:
+    - method: setuptools
+      path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,8 @@
+version: 2
+
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.11"
+conda:
+  environment: environment.yml

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -3,6 +3,6 @@ channels:
 - conda-forge
 - defaults
 dependencies:
-- python=3.9.*
-- libgdal=3.4.*
+- python=3.11.*
+- libgdal=3.6.*
 - sphinx-click

--- a/docs/environment.yml
+++ b/docs/environment.yml
@@ -5,4 +5,6 @@ channels:
 dependencies:
 - python=3.11.*
 - libgdal=3.6.*
+- cython=3.0.*
+- numpy=1.25.*
 - sphinx-click

--- a/readthedocs.yml
+++ b/readthedocs.yml
@@ -1,5 +1,0 @@
-python:
-  version: 3
-  pip_install: true
-conda:
-  file: environment.yml


### PR DESCRIPTION
Based on shapely's config, which has already been migrated.