### PR TITLE
Implemented bulk affine transformations with numpy

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -435,24 +435,20 @@ class TransformerBase:
         else:
             raise TransformError("Invalid offset")
 
-        # shift input coordinates according to offset
-        T = IDENTITY.translation(coff, roff)
-        offset_rows = []
-        offset_cols = []
         try:
-            for colrow in zip(cols, rows):
-                offset_col, offset_row = T * colrow
-                offset_rows.append(offset_row)
-                offset_cols.append(offset_col)
-
+            # shift input coordinates according to offset
+            T = IDENTITY.translation(coff, roff)
+            identity_transformer = AffineTransformer(T)
+            offset_cols, offset_rows = identity_transformer._transform(
+                cols, rows, zs, transform_direction=TransformDirection.forward
+            )
             new_xs, new_ys = self._transform(
                 offset_cols, offset_rows, zs, transform_direction=TransformDirection.forward
             )
-
             if len(new_xs) == 1 and not AS_ARR:
                 return (new_xs[0], new_ys[0])
             else:
-                return (new_xs, new_ys)
+                return (list(new_xs), list(new_ys))
         except TypeError:
             raise TransformError("Invalid inputs")
 
@@ -486,20 +482,21 @@ class AffineTransformer(TransformerBase):
         self._transformer = affine_transform
 
     def _transform(self, xs, ys, zs, transform_direction):
-        resxs = []
-        resys = []
-
         if transform_direction is TransformDirection.forward:
             transform = self._transformer
         elif transform_direction is TransformDirection.reverse:
             transform = ~self._transformer
 
-        for x, y in zip(xs, ys):
-            resx, resy = transform * (x, y)
-            resxs.append(resx)
-            resys.append(resy)
+        is_arr = True if type(xs) in [list, tuple] else False
+        if is_arr:
+            a, b, c, d, e, f, _, _, _ = transform
+            transform_matrix = np.array([[a, b, c], [d, e, f]])
+            input_matrix = np.array([xs, ys, np.ones(len(xs))])
+            output_matrix = np.dot(transform_matrix, input_matrix)
+            return (list(output_matrix[0]), list(output_matrix[1]))
+        else:
+            return transform * (xs, ys)
 
-        return (resxs, resys)
 
     def __repr__(self):
         return "<AffineTransformer>"


### PR DESCRIPTION
Related to the discussion: https://github.com/rasterio/rasterio/discussions/2935 

* Reason of this change is to gain speed in bulk transforms.
* Replaced the for loop in AffineTransformer._transform  with numpy matrix multiplication
* Reimplemented TransformerBase.xy to take advantage of the above change.
* All tests are running correctly (except S3-related)
* Total test time is reduced by 40%.

Test summary before the changes: (failed tests are due to S3)

    6 failed, 2109 passed, 8 skipped, 11 xfailed, 7 xpassed, 298 warnings in 138.78s (0:02:18) 

Test summary after the changes:

    6 failed, 2109 passed, 8 skipped, 11 xfailed, 7 xpassed, 298 warnings in 85.06s (0:01:25)