### PR TITLE
Convert test with latest GDAL into a reusable workflow

### DIFF
--- a/.github/workflows/test_gdal_build.yaml
+++ b/.github/workflows/test_gdal_build.yaml
@@ -1,0 +1,78 @@
+name: Test against GDAL build from source
+
+on:
+  workflow_call:
+    inputs:
+      branch:
+        required: true
+        type: string
+    secrets: inherit
+
+jobs:
+  test_gdal:
+    name: Test with GDAL
+    runs-on: ubuntu-latest
+    container: ghcr.io/osgeo/proj:9.2.0
+    env:
+      GDAL_DIR: ${{ github.workspace }}/gdal_install
+      GDAL_DATA: ${{ github.workspace }}/gdal_install/share/gdal
+      LD_LIBRARY_PATH: "${{ github.workspace }}/gdal_install/lib/:${LD_LIBRARY_PATH}"
+    steps:
+      - uses: actions/checkout@v3
+      - name: Update
+        run: |
+          apt-get update
+          apt-get -y install software-properties-common
+          add-apt-repository -y ppa:deadsnakes/ppa
+          apt-get update
+
+      - name: Set up Python
+        run: |
+          apt-get install -y --no-install-recommends \
+            python3.10 \
+            python3.10-dev \
+            python3.10-venv \
+            python3-pip \
+            g++
+
+      - name: Install GDAL
+        shell: bash
+        run: |
+          apt-get update
+          apt-get install -qq \
+            libcurl4-openssl-dev \
+            libtiff-dev \
+            libgeos-dev \
+            libjpeg-dev \
+            libnetcdf-dev \
+            libhdf4-alt-dev \
+            libhdf5-serial-dev \
+            libssl-dev \
+            libsqlite3-dev \
+            libexpat-dev \
+            libxerces-c-dev \
+            libpng-dev \
+            libopenjp2-7-dev \
+            libzstd-dev \
+            libwebp-dev \
+            cmake \
+            curl \
+            git
+          bash ci/gdal-compile.sh git ${{ inputs.branch }}
+
+      - name: Install dependencies
+        run: |
+          export PATH="${GDAL_DIR}/bin/:${PATH}"
+          python3.10 -m venv testenv
+          . testenv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip wheel -r requirements-dev.txt
+          python -m pip install -r requirements-dev.txt
+          python -m pip install --no-deps --force-reinstall -e .[test]
+
+      - name: Test
+        shell: bash
+        run: |
+          export PATH="${GDAL_DIR}/bin/:${PATH}"
+          . testenv/bin/activate
+          python -m pytest -v -m "not wheel" -rxXs --cov rasterio --cov-report term-missing

--- a/.github/workflows/test_gdal_build.yaml
+++ b/.github/workflows/test_gdal_build.yaml
@@ -1,5 +1,3 @@
-name: Test against GDAL build from source
-
 on:
   workflow_call:
     inputs:
@@ -8,8 +6,8 @@ on:
         type: string
 
 jobs:
-  test_gdal:
-    name: Test with GDAL
+  test_rasterio:
+    name: Test rasterio in PROJ container with GDAL ${{ inputs.branch }}
     runs-on: ubuntu-latest
     container: ghcr.io/osgeo/proj:9.2.0
     env:

--- a/.github/workflows/test_gdal_build.yaml
+++ b/.github/workflows/test_gdal_build.yaml
@@ -6,7 +6,6 @@ on:
       branch:
         required: true
         type: string
-    secrets: inherit
 
 jobs:
   test_gdal:

--- a/.github/workflows/test_gdal_build.yaml
+++ b/.github/workflows/test_gdal_build.yaml
@@ -1,13 +1,16 @@
 on:
   workflow_call:
     inputs:
-      branch:
+      gdal_ref:
+        required: true
+        type: string
+      rasterio_ref:
         required: true
         type: string
 
 jobs:
   test_rasterio:
-    name: Test rasterio in PROJ container with GDAL ${{ inputs.branch }}
+    name: Test rasterio ${{ inputs.rasterio_ref }} in PROJ container with GDAL ${{ inputs.gdal_ref }}
     runs-on: ubuntu-latest
     container: ghcr.io/osgeo/proj:9.2.0
     env:
@@ -15,7 +18,9 @@ jobs:
       GDAL_DATA: ${{ github.workspace }}/gdal_install/share/gdal
       LD_LIBRARY_PATH: "${{ github.workspace }}/gdal_install/lib/:${LD_LIBRARY_PATH}"
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.rasterio_ref }}
       - name: Update
         run: |
           apt-get update
@@ -55,7 +60,7 @@ jobs:
             cmake \
             curl \
             git
-          bash ci/gdal-compile.sh git ${{ inputs.branch }}
+          bash ci/gdal-compile.sh git ${{ inputs.gdal_ref }}
 
       - name: Install dependencies
         run: |

--- a/.github/workflows/test_gdal_dispatch.yaml
+++ b/.github/workflows/test_gdal_dispatch.yaml
@@ -1,4 +1,4 @@
-name: Test GDAL on demand
+name: Test on signal from GDAL
 
 on:
   repository_dispatch:

--- a/.github/workflows/test_gdal_dispatch.yaml
+++ b/.github/workflows/test_gdal_dispatch.yaml
@@ -17,4 +17,9 @@ jobs:
   test_gdal_branch:
     uses: ./.github/workflows/test_gdal_build.yaml
     with:
-      branch: ${{ github.event.client_payload.tag || 'master' }}
+      gdal_ref: ${{ github.event.client_payload.tag || 'master' }}
+      rasterio_ref: ${{ matrix.branch }}
+    strategy:
+      fail-fast: false
+      matrix:
+        branch: ['main', 'maint-1.3']

--- a/.github/workflows/test_gdal_dispatch.yaml
+++ b/.github/workflows/test_gdal_dispatch.yaml
@@ -1,0 +1,20 @@
+name: Test GDAL on demand
+
+on:
+  repository_dispatch:
+    types: [upstream_tag]
+  pull_request:  # also build on PRs touching this file
+    paths:
+      - ".github/workflows/test_gdal_dispatch.yaml"
+      - ".github/workflows/test_gdal_build.yaml"
+      - "ci/gdal-compile.sh"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test_gdal_branch:
+    uses: ./.github/workflows/test_gdal_build.yaml
+    with:
+      branch: ${{ github.event.client_payload.tag || 'master' }}

--- a/.github/workflows/test_gdal_latest.yaml
+++ b/.github/workflows/test_gdal_latest.yaml
@@ -1,4 +1,4 @@
-name: Test GDAL Latest
+name: Weekly tests against latest GDAL
 
 on:
   schedule:

--- a/.github/workflows/test_gdal_latest.yaml
+++ b/.github/workflows/test_gdal_latest.yaml
@@ -17,8 +17,9 @@ jobs:
   test_gdal_latest:
     uses: ./.github/workflows/test_gdal_build.yaml
     with:
-      branch: ${{ matrix.gdal-branch }}
+      gdal_ref: ${{ matrix.branch }}
+      rasterio_ref: ${{ github.ref }}
     strategy:
       fail-fast: false
       matrix:
-        gdal-branch: ['master', 'release/3.7']
+        branch: ['master', 'release/3.7']

--- a/.github/workflows/test_gdal_latest.yaml
+++ b/.github/workflows/test_gdal_latest.yaml
@@ -6,6 +6,7 @@ on:
   pull_request:  # also build on PRs touching this file
     paths:
       - ".github/workflows/test_gdal_latest.yaml"
+      - ".github/workflows/test_gdal_build.yaml"
       - "ci/gdal-compile.sh"
 
 concurrency:
@@ -14,73 +15,10 @@ concurrency:
 
 jobs:
   test_gdal_latest:
-    name: GDAL Latest
-    runs-on: ubuntu-latest
-    container: ghcr.io/osgeo/proj:9.2.0
-    env:
-      GDAL_DIR: ${{ github.workspace }}/gdal_install
-      GDAL_DATA: ${{ github.workspace }}/gdal_install/share/gdal
-      LD_LIBRARY_PATH: "${{ github.workspace }}/gdal_install/lib/:${LD_LIBRARY_PATH}"
+    uses: .github/workflows/test_gdal_build.yaml
+    with:
+      branch: ${{ matrix.gdal-branch }}
     strategy:
       fail-fast: false
       matrix:
         gdal-branch: ['master', 'release/3.7']
-    steps:
-      - uses: actions/checkout@v3
-      - name: Update
-        run: |
-          apt-get update
-          apt-get -y install software-properties-common
-          add-apt-repository -y ppa:deadsnakes/ppa
-          apt-get update
-
-      - name: Set up Python
-        run: |
-          apt-get install -y --no-install-recommends \
-            python3.10 \
-            python3.10-dev \
-            python3.10-venv \
-            python3-pip \
-            g++
-
-      - name: Install GDAL
-        shell: bash
-        run: |
-          apt-get update
-          apt-get install -qq \
-            libcurl4-openssl-dev \
-            libtiff-dev \
-            libgeos-dev \
-            libjpeg-dev \
-            libnetcdf-dev \
-            libhdf4-alt-dev \
-            libhdf5-serial-dev \
-            libssl-dev \
-            libsqlite3-dev \
-            libexpat-dev \
-            libxerces-c-dev \
-            libpng-dev \
-            libopenjp2-7-dev \
-            libzstd-dev \
-            libwebp-dev \
-            cmake \
-            curl \
-            git
-          bash ci/gdal-compile.sh git ${{ matrix.gdal-branch }}
-
-      - name: Install dependencies
-        run: |
-          export PATH="${GDAL_DIR}/bin/:${PATH}"
-          python3.10 -m venv testenv
-          . testenv/bin/activate
-          python -m pip install --upgrade pip
-          python -m pip wheel -r requirements-dev.txt
-          python -m pip install -r requirements-dev.txt
-          python -m pip install --no-deps --force-reinstall -e .[test]
-
-      - name: Test
-        shell: bash
-        run: |
-          export PATH="${GDAL_DIR}/bin/:${PATH}"
-          . testenv/bin/activate
-          python -m pytest -v -m "not wheel" -rxXs --cov rasterio --cov-report term-missing

--- a/.github/workflows/test_gdal_latest.yaml
+++ b/.github/workflows/test_gdal_latest.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   test_gdal_latest:
-    uses: .github/workflows/test_gdal_build.yaml
+    uses: ./.github/workflows/test_gdal_build.yaml
     with:
       branch: ${{ matrix.gdal-branch }}
     strategy:


### PR DESCRIPTION
Resolves #2960.

Summary:

* A weekly test against latest GDAL and an on-demand test against the latest GDAL tag (to test pre-releases) share a new reusable workflow (based on previous workflow).
* The on-demand workflow only can only be triggered by the GitHub API if it's in our default branch. Its matrix spans rasterio main and current maint branches.

Thus this PR is aimed at main. We can backport to maint-1.3 after this is merged.

Work on the GDAL side of things is here: https://github.com/OSGeo/gdal/pull/8692.

Any questions @snowman2 @vincentsarago ? 