### PR TITLE
Python file opener VSI plugin: `read-multi-range`support

### DIFF
--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -1,5 +1,6 @@
 """Tests of the Python opener VSI plugin."""
 
+import warnings
 import zipfile
 import io
 
@@ -42,3 +43,32 @@ def test_opener_zipfile_open():
             profile = src.profile
             assert profile["driver"] == "GTiff"
             assert profile["count"] == 3
+
+
+def test_opener_multi_range_read():
+    """Test with Opener having multi-range reader."""
+
+    class Opener(io.FileIO):
+        def read_multi_range(
+            self,
+            nranges,
+            offsets,
+            sizes,
+        ):
+            """Read multiple ranges."""
+            warnings.warn("Using MultiRange Reads", UserWarning)
+            return [
+                self._read_range(offset, size) for (offset, size) in zip(offsets, sizes)
+            ]
+
+        def _read_range(self, offset, size):
+            _ = self.seek(offset)
+            return self.read(size)
+
+    # Make sure GDAL uses `read_multi_range`
+    with pytest.warns(UserWarning, match="Using MultiRange Reads"):
+        with rasterio.open("tests/data/RGB.byte.tif", opener=Opener) as src:
+            profile = src.profile
+            assert profile["driver"] == "GTiff"
+            assert profile["count"] == 3
+            assert src.read(out_shape=(src.count, round(src.height/2), round(src.width/2))).any()

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -16,6 +16,7 @@ def test_opener_io_open():
         profile = src.profile
         assert profile["driver"] == "GTiff"
         assert profile["count"] == 3
+        assert src.read(out_shape=(src.count, round(src.height/2), round(src.width/2))).any()
 
 
 @pytest.mark.parametrize("urlpath", ["file://tests/data/RGB.byte.tif", "zip://*.tif::tests/data/files.zip"])


### PR DESCRIPTION
From exploratory work described in https://github.com/rasterio/rasterio/pull/2898#issuecomment-1800035599

For now VSI Opener has to implement simple `read` but GDAL can use *smarter* `multi-range` read IF `read_multi_range` is available in the *opener*

Sadly we defined the callback_struct without `analyzing` the opener so this PR will fail for opener which doesn't define the `read_multi_range` 😬 

https://github.com/rasterio/rasterio/blob/2482d52142f15bbd9b6965bcb463d3a86f81f002/rasterio/_vsiopener.pyx#L52-L60

This PR is a WIP an a careful analysis of the cython code needs to be done! 