### PR TITLE
Robustness improvements for workflow that watches GDAL's tags

### DIFF
--- a/.github/workflows/test_gdal_tags.yaml
+++ b/.github/workflows/test_gdal_tags.yaml
@@ -15,7 +15,7 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  get-tags:
+  get_tags:
     name: Find recent tags and generate test job matrix
     runs-on: ubuntu-latest
     outputs:
@@ -53,24 +53,25 @@ jobs:
         run: |
           curl -O https://github.com/osgeo/gdal/tags.atom
           python3 ci/get-new-tags.py tags.atom 12 > tags.json
+          echo "tags=$(cat failed-gdal-refs.json tags.json | jq -s -c 'add | unique')"
           echo "tags=$(cat failed-gdal-refs.json tags.json | jq -s -c 'add | unique')" >> "$GITHUB_OUTPUT"
 
-  test-gdal-tags:
+  test_gdal_tags:
     uses: ./.github/workflows/test_gdal_build.yaml
     with:
       gdal_ref: ${{ matrix.gdal || 'master' }}
       rasterio_ref: ${{ github.ref }}
-    if: needs.get-tags.outputs.tags != '[]'
-    needs: [get-tags]
+    if: needs.get_tags.outputs.tags != '[]'
+    needs: [get_tags]
     strategy:
       fail-fast: false
       max-parallel: 6
       matrix:
         gdal: ${{ fromJSON(needs.get-tags.outputs.tags) }}
 
-  collect-failures:
+  collect_failures:
     runs-on: ubuntu-latest
-    needs: [test-gdal-tags]
+    needs: [test_gdal_tags]
     steps:
       - uses: actions/download-artifact@v3
       - run: |

--- a/.github/workflows/test_gdal_tags.yaml
+++ b/.github/workflows/test_gdal_tags.yaml
@@ -76,6 +76,7 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
       - run: |
+          touch failure-default.json
           cat failure-*.json | jq -s -c '[.[]gdal_ref]' > failed-gdal-refs.json
           cat failed-gdal-refs.json
       - uses: actions/upload-artifact@v3

--- a/.github/workflows/test_gdal_tags.yaml
+++ b/.github/workflows/test_gdal_tags.yaml
@@ -77,7 +77,7 @@ jobs:
       - uses: actions/download-artifact@v3
       - run: |
           touch failure-default.json
-          cat failure-*.json | jq -s -c '[.[]gdal_ref]' > failed-gdal-refs.json
+          cat failure-*.json | jq -s -c '[.[].gdal_ref] | unique' > failed-gdal-refs.json
           cat failed-gdal-refs.json
       - uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/test_gdal_tags.yaml
+++ b/.github/workflows/test_gdal_tags.yaml
@@ -28,7 +28,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Get artifacts of last workflow run
-	continue-on-error: true
+        continue-on-error: true
         run: |
           gh api \
             -H "Accept: application/vnd.github+json" \

--- a/.github/workflows/test_gdal_tags.yaml
+++ b/.github/workflows/test_gdal_tags.yaml
@@ -28,6 +28,7 @@ jobs:
         with:
           python-version: '3.11'
       - name: Get artifacts of last workflow run
+	continue-on-error: true
         run: |
           gh api \
             -H "Accept: application/vnd.github+json" \
@@ -40,7 +41,6 @@ jobs:
             /repos/rasterio/rasterio/actions/runs/$(jq '.id' last-run.json)/artifacts > artifacts.json
           jq '.' artifacts.json
       - name: Get failed GDAL refs from last workflow run
-        if: always()
         continue-on-error: true
         run: |
           jq '.artifacts[] | select(.name == "failures")' artifacts.json > artifact.json
@@ -50,9 +50,7 @@ jobs:
           ls -l *.json*
           cat failed-gdal-refs.json
       - run: test -f failed-gdal-refs.json || echo '[]' > failed-gdal-refs.json
-        if: always()
       - id: fetch-tags
-        if: always()
         run: |
           curl -O https://github.com/osgeo/gdal/tags.atom
           python3 ci/get-new-tags.py tags.atom 12 > tags.json

--- a/.github/workflows/test_gdal_tags.yaml
+++ b/.github/workflows/test_gdal_tags.yaml
@@ -68,7 +68,7 @@ jobs:
       fail-fast: false
       max-parallel: 6
       matrix:
-        gdal: ${{ fromJSON(needs.get-tags.outputs.tags) }}
+        gdal: ${{ fromJSON(needs.get_tags.outputs.tags) }}
 
   collect_failures:
     runs-on: ubuntu-latest

--- a/.github/workflows/test_gdal_tags.yaml
+++ b/.github/workflows/test_gdal_tags.yaml
@@ -40,6 +40,7 @@ jobs:
             /repos/rasterio/rasterio/actions/runs/$(jq '.id' last-run.json)/artifacts > artifacts.json
           jq '.' artifacts.json
       - name: Get failed GDAL refs from last workflow run
+        if: always()
         continue-on-error: true
         run: |
           jq '.artifacts[] | select(.name == "failures")' artifacts.json > artifact.json
@@ -49,6 +50,7 @@ jobs:
           ls -l *.json*
           cat failed-gdal-refs.json
       - run: test -f failed-gdal-refs.json || echo '[]' > failed-gdal-refs.json
+        if: always()
       - id: fetch-tags
         run: |
           curl -O https://github.com/osgeo/gdal/tags.atom

--- a/.github/workflows/test_gdal_tags.yaml
+++ b/.github/workflows/test_gdal_tags.yaml
@@ -52,6 +52,7 @@ jobs:
       - run: test -f failed-gdal-refs.json || echo '[]' > failed-gdal-refs.json
         if: always()
       - id: fetch-tags
+        if: always()
         run: |
           curl -O https://github.com/osgeo/gdal/tags.atom
           python3 ci/get-new-tags.py tags.atom 12 > tags.json

--- a/.github/workflows/test_gdal_tags.yaml
+++ b/.github/workflows/test_gdal_tags.yaml
@@ -76,9 +76,8 @@ jobs:
     steps:
       - uses: actions/download-artifact@v3
       - run: |
-          ls -l *.json
-          cat failed-gdal-refs.json
           cat failure-*.json | jq -s -c '[.[]gdal_ref]' > failed-gdal-refs.json
+          cat failed-gdal-refs.json
       - uses: actions/upload-artifact@v3
         with:
           name: failed-gdal-refs


### PR DESCRIPTION
In a nutshell: we ignore non-critical errors and prevent other errors that are entailed by them.