### PR TITLE
Close #2976; merge raster transformation issue

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -348,10 +348,6 @@ def merge(
             int_e = src_e if src_e < dst_e else dst_e
             int_n = src_n if src_n < dst_n else dst_n
 
-            # If the output transform.e is negative, we need to change it to the positive
-            if output_transform.e < 0:
-                output_transform = output_transform * Affine.scale(1, -1)
-
             # 2. Compute the source window
             src_window = windows.from_bounds(int_w, int_s, int_e, int_n, src.transform)
 

--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -348,6 +348,10 @@ def merge(
             int_e = src_e if src_e < dst_e else dst_e
             int_n = src_n if src_n < dst_n else dst_n
 
+            # If the output transform.e is negative, we need to change it to the positive
+            if output_transform.e < 0:
+                output_transform = output_transform * Affine.scale(1, -1)
+
             # 2. Compute the source window
             src_window = windows.from_bounds(int_w, int_s, int_e, int_n, src.transform)
 

--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -318,10 +318,6 @@ def from_bounds(
 
     if not isinstance(transform, Affine):  # TODO: RPCs?
         raise WindowError("A transform object is required to calculate the window")
-    if (right - left) / transform.a < 0:
-        raise WindowError("Bounds and transform are inconsistent")
-    if (bottom - top) / transform.e < 0:
-        raise WindowError("Bounds and transform are inconsistent")
 
     rows, cols = rowcol(
         transform,


### PR DESCRIPTION
I don't know, what is the purpose of the below code in `from_bounds` function in `windows.py` file is.

```python
if (right - left) / transform.a < 0:
    raise WindowError("Bounds and transform are inconsistent")
if (bottom - top) / transform.e < 0:
    raise WindowError("Bounds and transform are inconsistent")
```

When I tried to debug, I found that this condition was generating an issue for merging the file (#2976). When I tried to remove it and run my test, it passed successfully. Please kindly review and fix the `#2976` issue. 