### PR TITLE
Operations on closed MemoryFile and ZipMemoryFile raise ValueError

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -29,6 +29,8 @@ New Features:
 
 Bug fixes:
 
+- Operations on closed MemoryFile and ZipMemoryFile objects now raise
+  ValueError as with other Python file objects (#2870, #).
 - Delay clamping of I/O windows until just before GDAL methods calls to improve
   accuracy of sub-pixel reads (#2864).
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1269,13 +1269,13 @@ cdef class MemoryFileBase:
 
     def seek(self, offset, whence=0):
         if self.closed:
-            raise OSError("I/O operation on closed MemoryFile")
+            raise ValueError("I/O operation on closed MemoryFile")
         else:
             return VSIFSeekL(self._vsif, offset, whence)
 
     def tell(self):
         if self.closed:
-            raise OSError("I/O operation on closed MemoryFile")
+            raise ValueError("I/O operation on closed MemoryFile")
         else:
             return VSIFTellL(self._vsif)
 
@@ -1298,7 +1298,7 @@ cdef class MemoryFileBase:
         cdef vsi_l_offset buffer_len = 0
 
         if self.closed:
-            raise OSError("I/O operation on closed MemoryFile")
+            raise ValueError("I/O operation on closed MemoryFile")
 
         if size < 0:
             buffer = VSIGetMemFileBuffer(self._path, &buffer_len, 0)
@@ -1329,7 +1329,7 @@ cdef class MemoryFileBase:
 
         """
         if self.closed:
-            raise OSError("I/O operation on closed MemoryFile")
+            raise ValueError("I/O operation on closed MemoryFile")
         cdef const unsigned char *view = <bytes>data
         n = len(data)
         result = VSIFWriteL(view, 1, n, self._vsif)

--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -134,7 +134,7 @@ class MemoryFile(MemoryFileBase):
         mempath = _UnparsedPath(self.name)
 
         if self.closed:
-            raise OSError("I/O operation on closed file.")
+            raise ValueError("I/O operation on closed file.")
         if len(self) > 0:
             log.debug("VSI path: {}".format(mempath.path))
             rd = DatasetReader(mempath, driver=driver, sharing=sharing, **kwargs)
@@ -271,7 +271,7 @@ class ZipMemoryFile(MemoryFile):
         zippath = _UnparsedPath('/vsizip{0}/{1}'.format(self.name, path.lstrip('/')))
 
         if self.closed:
-            raise OSError("I/O operation on closed file.")
+            raise ValueError("I/O operation on closed file.")
         return DatasetReader(zippath, driver=driver, sharing=sharing, **kwargs)
 
 

--- a/tests/test_memoryfile.py
+++ b/tests/test_memoryfile.py
@@ -88,7 +88,7 @@ def test_closed():
     """A closed MemoryFile can not be opened"""
     with MemoryFile() as memfile:
         pass
-    with pytest.raises(OSError):
+    with pytest.raises(ValueError):
         memfile.open()
 
 
@@ -96,7 +96,7 @@ def test_closed_seek():
     """A closed MemoryFile cannot be seeked"""
     with MemoryFile() as memfile:
         pass
-    with pytest.raises(OSError):
+    with pytest.raises(ValueError):
         memfile.seek(0)
 
 
@@ -104,7 +104,7 @@ def test_closed_read():
     """A closed MemoryFile cannot be read"""
     with MemoryFile() as memfile:
         pass
-    with pytest.raises(OSError):
+    with pytest.raises(ValueError):
         memfile.read()
 
 
@@ -112,7 +112,7 @@ def test_closed_write():
     """Cannot write to a closed MemoryFile"""
     with MemoryFile() as memfile:
         pass
-    with pytest.raises(OSError):
+    with pytest.raises(ValueError):
         memfile.write([0])
 
 
@@ -120,7 +120,7 @@ def test_closed_tell():
     """Cannot tell on a closed MemoryFile"""
     with MemoryFile() as memfile:
         pass
-    with pytest.raises(OSError):
+    with pytest.raises(ValueError):
         memfile.tell()
 
 
@@ -281,7 +281,7 @@ def test_zip_closed():
     """A closed ZipMemoryFile can not be opened"""
     with ZipMemoryFile() as zipmemfile:
         pass
-    with pytest.raises(OSError):
+    with pytest.raises(ValueError):
         zipmemfile.open('foo')
 
 


### PR DESCRIPTION
To be like standard Python files. Follow up on #2870.