### PR TITLE
expose GDALs TPS transformer as an option for GCPTransformer

### DIFF
--- a/rasterio/_transform.pyx
+++ b/rasterio/_transform.pyx
@@ -228,6 +228,7 @@ cdef class RPCTransformerBase:
 cdef class GCPTransformerBase:
     cdef void *_transformer
     cdef bint _closed
+    cdef bint _tps
 
     def __cinit__(self):
         self._transformer = NULL
@@ -236,7 +237,7 @@ cdef class GCPTransformerBase:
     def __dealloc__(self):
         self.close()
 
-    def __init__(self, gcps):
+    def __init__(self, gcps, tps=False):
         """
         Construct a new GCP transformer
 
@@ -249,12 +250,15 @@ cdef class GCPTransformerBase:
         ----------
         gcps : a sequence of GroundControlPoint
             Ground Control Points for a dataset.
+        tps : bool
+            If True, use GDALs thin plate spline transformer instead of polynomials.
         """
         super().__init__()
         cdef int bReversed = 1
         cdef int nReqOrder = 0  # let GDAL determine polynomial order
         cdef GDAL_GCP *gcplist = <GDAL_GCP *>CPLMalloc(len(gcps) * sizeof(GDAL_GCP))
         cdef int nGCPCount = len(gcps)
+        self._tps = tps
 
         try:
             for i, obj in enumerate(gcps):
@@ -267,7 +271,10 @@ cdef class GCPTransformerBase:
                 gcplist[i].dfGCPX = obj.x
                 gcplist[i].dfGCPY = obj.y
                 gcplist[i].dfGCPZ = obj.z or 0.0
-            self._transformer = exc_wrap_pointer(GDALCreateGCPTransformer(nGCPCount, gcplist, nReqOrder, bReversed))
+            if self._tps:
+                self._transformer = exc_wrap_pointer(GDALCreateTPSTransformer(nGCPCount, gcplist, bReversed))
+            else:
+                self._transformer = exc_wrap_pointer(GDALCreateGCPTransformer(nGCPCount, gcplist, nReqOrder, bReversed))
             self._closed = False
         finally:
             CPLFree(gcplist)
@@ -322,7 +329,10 @@ cdef class GCPTransformerBase:
             z[i] = zs[i]
 
         try:
-            err = GDALGCPTransform(self._transformer, bDstToSrc, n, x, y, z, panSuccess)
+            if self._tps:
+                err = GDALTPSTransform(self._transformer, bDstToSrc, n, x, y, z, panSuccess)
+            else:
+                err = GDALGCPTransform(self._transformer, bDstToSrc, n, x, y, z, panSuccess)
             if err == GDALError.failure:
                 warnings.warn(
                 "Could not transform points using GCPs.",
@@ -332,7 +342,7 @@ cdef class GCPTransformerBase:
             res_zs = [0] * n
             checked = False
             for i in range(n):
-                # GDALGCPTransformer may return a success overall despite individual points failing. Warn once.
+                # GDALGCPTransformer or GDALTPSTransformer may return a success overall despite individual points failing. Warn once.
                 if not panSuccess[i] and not checked:
                     warnings.warn(
                     "One or more points could not be transformed using GCPs.",
@@ -354,7 +364,10 @@ cdef class GCPTransformerBase:
         Destroy transformer
         """
         if self._transformer != NULL:
-            GDALDestroyGCPTransformer(self._transformer)
+            if self._tps:
+                GDALDestroyTPSTransformer(self._transformer)
+            else:
+                GDALDestroyGCPTransformer(self._transformer)
         self._transformer = NULL
         self._closed = True
 

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -645,6 +645,11 @@ cdef extern from "gdal_alg.h" nogil:
     void *GDALDestroyGCPTransformer( void *pTransformArg)
     int GDALGCPTransform( void *pTransformArg, int bDstToSrc, int nPointCount,
                           double *x, double *y, double *z, int *panSuccess)
+    void *GDALCreateTPSTransformer( int nGCPCount, const GDAL_GCP *pasGCPList,
+                          int bReversed)
+    void *GDALDestroyTPSTransformer( void *pTransformArg)
+    int GDALTPSTransform( void *pTransformArg, int bDstToSrc, int nPointCount,
+                          double *x, double *y, double *z, int *panSuccess)
     void *GDALCreateRPCTransformer( GDALRPCInfo *psRPC, int bReversed,
                           double dfPixErrThreshold,
                           char **papszOptions )

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -533,13 +533,14 @@ class GCPTransformer(GCPTransformerBase, GDALTransformerBase):
 
     Uses GDALCreateGCPTransformer and GDALGCPTransform for computations.
     Ensure that GDAL transformer objects are destroyed by calling `close()`
-    method or using context manager interface.
+    method or using context manager interface. If `tps` is set to True,
+    uses GDALCreateTPSTransformer and GDALTPSTransform instead.
 
     """
-    def __init__(self, gcps):
+    def __init__(self, gcps, tps=False):
         if len(gcps) and not isinstance(gcps[0], GroundControlPoint):
             raise ValueError("GCPTransformer requires sequence of GroundControlPoint")
-        super().__init__(gcps)
+        super().__init__(gcps, tps)
 
     def __repr__(self):
         return "<{} GCPTransformer>".format(

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -507,7 +507,10 @@ def test_2421_rpc_height_ignored():
         assert abs(x2 - x1) > 0
         assert abs(y2 - y1) > 0
 
-def test_tps_transformer():
+def test_gcp_transformer_tps_option():
+    """Use thin plate spline transformation when requested."""
+    # TPS ensures that GCPs are (to within some precision) solutions of the transformation.
+    # This is not the case for polynomials transformations. 
     with GCPTransformer(gcps(), tps=True) as transformer:
         for gcp in gcps():
             x_, y_ = transformer.xy(gcp.row, gcp.col, offset='ul')

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -506,3 +506,13 @@ def test_2421_rpc_height_ignored():
         x2, y2 = src.xy(0, 0, z=2000, transform_method=transform_method)
         assert abs(x2 - x1) > 0
         assert abs(y2 - y1) > 0
+
+def test_tps_transformer():
+    with GCPTransformer(gcps(), tps=True) as transformer:
+        for gcp in gcps():
+            x_, y_ = transformer.xy(gcp.row, gcp.col, offset='ul')
+            assert gcp.x == pytest.approx(x_)
+            assert gcp.y == pytest.approx(y_)
+            row_, col_ = transformer.rowcol(gcp.x, gcp.y, op=lambda arg: arg)
+            assert gcp.row == pytest.approx(row_)
+            assert gcp.col == pytest.approx(col_)


### PR DESCRIPTION
Resolves #2982 by adding a boolean option `tps` to the constructor of `GCPTransformer` that switches the behavior to use `GDALTPSTransform` instead of `GDALGCPTransform`.