### PR TITLE
rasterize(): given an empty shapes sequence return an empty or filled array

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -36,7 +36,8 @@ Bug fixes:
 
 Other changes:
 
-- Given an empty shapes argument, rasterize() now returns an empty array (#).
+- Given an empty shapes argument, rasterize() now returns an empty array
+  (#2993).
 - AffineTransformer's bulk transformations have been sped up by replacing
   a loop with a Numpy ufunc (#2936).
 - The crop and invert mutual exclusivity test in raster_geomtry_mask() has been

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -34,6 +34,14 @@ Bug fixes:
 - Delay clamping of I/O windows until just before GDAL methods calls to improve
   accuracy of sub-pixel reads (#2864).
 
+Other changes:
+
+- Given an empty shapes argument, rasterize() now returns an empty array (#).
+- AffineTransformer's bulk transformations have been sped up by replacing
+  a loop with a Numpy ufunc (#2936).
+- The crop and invert mutual exclusivity test in raster_geomtry_mask() has been
+  removed (#2702).
+
 1.3.9 (2023-10-18)
 ------------------
 


### PR DESCRIPTION
Resolves #2743 by [defining an error out of existence](https://wiki.tcl-lang.org/page/Define+Errors+Out+of+Existence).

Also adds an option to *not* skip invalid shapes.