### PR TITLE
Simplify rasterize

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -38,6 +38,10 @@ Bug fixes:
 
 Other changes:
 
+- rasterize() better matches the behavior of Numpy array constructors. It no
+  longer reduces the bit width of output, returning either float64 or int64
+  arrays unless a data type is explicitly selected, and the fill parameters no
+  longer has an effect on the default data type (#3003).
 - Rasterio now vendors and modifies the snuggs module (#2956).
 - Given an empty shapes argument, rasterize() now returns an empty array
   (#2993).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -40,7 +40,7 @@ Other changes:
 
 - rasterize() better matches the behavior of Numpy array constructors. It no
   longer reduces the bit width of output, returning either float64 or int64
-  arrays unless a data type is explicitly selected, and the fill parameters no
+  arrays unless a data type is explicitly selected, and the fill parameter no
   longer has an effect on the default data type (#3003).
 - Rasterio now vendors and modifies the snuggs module (#2956).
 - Given an empty shapes argument, rasterize() now returns an empty array

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -258,10 +258,6 @@ def rasterize(
     function of buffer size. For maximum speed, ensure that
     GDAL_CACHEMAX is larger than the size of `out` or `out_shape`.
     """
-
-    def format_invalid_dtype(param):
-        return "{0} dtype must be one of: {1}".format(param, ", ".join(valid_dtypes))
-
     valid_dtypes = (
         'int16', 'int32', 'uint8', 'uint16', 'uint32', 'float32', 'float64'
     )
@@ -278,7 +274,6 @@ def rasterize(
         raise ValueError(
             "Data type specified by out array or dtype parameter is not supported."
         )
-        # format_invalid_dtype("dtype"))
 
     valid_shapes = []
     shape_values = []

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -11,7 +11,6 @@ import rasterio
 from rasterio import warp
 from rasterio._base import DatasetBase
 from rasterio._features import _shapes, _sieve, _rasterize, _bounds
-from rasterio.dtypes import validate_dtype, can_cast_dtype, get_minimum_dtype, _getnpdtype
 from rasterio.enums import MergeAlg
 from rasterio.env import ensure_env, GDALVersion
 from rasterio.errors import ShapeSkipWarning
@@ -259,6 +258,10 @@ def rasterize(
     function of buffer size. For maximum speed, ensure that
     GDAL_CACHEMAX is larger than the size of `out` or `out_shape`.
     """
+
+    def format_invalid_dtype(param):
+        return "{0} dtype must be one of: {1}".format(param, ", ".join(valid_dtypes))
+
     valid_dtypes = (
         'int16', 'int32', 'uint8', 'uint16', 'uint32', 'float32', 'float64'
     )
@@ -267,32 +270,15 @@ def rasterize(
     if GDALVersion.runtime().at_least("3.7"):
         valid_dtypes += ("int8",)
 
-    def format_invalid_dtype(param):
-        return '{0} dtype must be one of: {1}'.format(
-            param, ', '.join(valid_dtypes)
+    # The output data type is determined by the output array or dtype
+    # parameter.
+    dtype = out.dtype.name if out is not None else dtype
+
+    if dtype is not None and dtype not in valid_dtypes:
+        raise ValueError(
+            "Data type specified by out array or dtype parameter is not supported."
         )
-
-    def format_cast_error(param, dtype):
-        return '{0} cannot be cast to specified dtype: {1}'.format(param, dtype)
-
-    if fill != 0:
-        fill_array = np.array([fill])
-        if not validate_dtype(fill_array, valid_dtypes):
-            raise ValueError(format_invalid_dtype('fill'))
-
-        if dtype is not None and not can_cast_dtype(fill_array, dtype):
-            raise ValueError(format_cast_error('fill', dtype))
-
-    if default_value != 1:
-        default_value_array = np.array([default_value])
-        if not validate_dtype(default_value_array, valid_dtypes):
-            raise ValueError(format_invalid_dtype('default_value'))
-
-        if dtype is not None and not can_cast_dtype(default_value_array, dtype):
-            raise ValueError(format_cast_error('default_vaue', dtype))
-
-    if dtype is not None and _getnpdtype(dtype).name not in valid_dtypes:
-        raise ValueError(format_invalid_dtype('dtype'))
+        # format_invalid_dtype("dtype"))
 
     valid_shapes = []
     shape_values = []
@@ -340,18 +326,27 @@ def rasterize(
             else:
                 raise ValueError("Invalid or empty shape cannot be rasterized.")
 
-    if out is not None:
-        if _getnpdtype(out.dtype).name not in valid_dtypes:
-            raise ValueError(format_invalid_dtype('out'))
+    # If neither an out array or dtype were given, we get the output
+    # data type from the shapes values, including the default.
+    if not dtype and valid_shapes:
+        values_arr = np.array(shape_values)
+        dtype = values_arr.dtype.name
+        assert dtype in ("int64", "float64")
 
-        if not can_cast_dtype(shape_values, out.dtype):
-            raise ValueError(format_cast_error('shape values', out.dtype.name))
+        # GDAL 3.5 doesn't support int64 output. We'll try int32.
+        if dtype not in valid_dtypes and dtype.startswith("int"):
+            lo, hi = values_arr.min(), values_arr.max()
+            if -2147483648 <= lo and hi <= 2147483647:
+                dtype = "int32"
+            else:
+                raise ValueError("GDAL versions < 3.6 cannot rasterize int64 values.")
+
+    if out is not None:
+        pass
 
     elif out_shape is not None:
-
         if len(out_shape) != 2:
             raise ValueError('Invalid out_shape, must be 2D')
-
         out = np.empty(out_shape, dtype=dtype)
         out.fill(fill)
 
@@ -364,17 +359,6 @@ def rasterize(
     transform = guard_transform(transform)
 
     if valid_shapes:
-        shape_values = np.array(shape_values)
-
-        if not validate_dtype(shape_values, valid_dtypes):
-            raise ValueError(format_invalid_dtype("shape values"))
-
-        if dtype is None:
-            dtype = get_minimum_dtype(np.append(shape_values, fill))
-
-        elif not can_cast_dtype(shape_values, dtype):
-            raise ValueError(format_cast_error("shape values", dtype))
-
         _rasterize(valid_shapes, out, transform, all_touched, merge_alg)
 
     return out

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -333,6 +333,8 @@ def rasterize(
             lo, hi = values_arr.min(), values_arr.max()
             if -2147483648 <= lo and hi <= 2147483647:
                 dtype = "int32"
+            elif 0 <= lo and hi <= 4294967295:
+                dtype = "uint32"
             else:
                 raise ValueError("GDAL versions < 3.6 cannot rasterize int64 values.")
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -686,6 +686,7 @@ def test_rasterize_fill_value(basic_geometry, basic_image_2x2):
     )
 
 
+@pytest.mark.xfail(reason="Fill arg no longer determines data type")
 def test_rasterize_invalid_fill_value(basic_geometry):
     """A fill value that requires an int64 should raise an exception."""
     if gdal_version.at_least("3.5"):
@@ -750,10 +751,10 @@ def test_rasterize_value(basic_geometry, basic_image_2x2):
 @requires_gdal_lt_35
 def test_rasterize_invalid_value(basic_geometry):
     """A shape value that requires an int64 should raise an exception."""
-    with pytest.raises(ValueError, match="Values out of range for supported dtypes"):
-        rasterize(
-            [(basic_geometry, 1000000000000)], out_shape=DEFAULT_SHAPE
-        )
+    with pytest.raises(
+        ValueError, match="GDAL versions < 3.6 cannot rasterize int64 values."
+    ):
+        rasterize([(basic_geometry, 1000000000000)], out_shape=DEFAULT_SHAPE)
 
 
 @pytest.mark.parametrize(
@@ -761,13 +762,7 @@ def test_rasterize_invalid_value(basic_geometry):
     [
         ("int16", -32768),
         ("int32", -2147483648),
-        pytest.param(
-            "uint32",
-            4294967295,
-            marks=pytest.mark.xfail(
-                gdal_version.at_least("3.5"), reason="GDAL regression? Works with 3.4.3"
-            ),
-        ),
+        ("uint32", 4294967295),
         pytest.param(
             "int8",
             -128,

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -13,8 +13,7 @@ from rasterio.features import (
     bounds, geometry_mask, geometry_window, is_valid_geom, rasterize, sieve,
     shapes)
 
-from .conftest import MockGeoInterface, gdal_version, requires_gdal_lt_35
-
+from .conftest import MockGeoInterface, gdal_version
 
 DEFAULT_SHAPE = (10, 10)
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -589,6 +589,7 @@ def test_rasterize_int64_out_dtype(basic_geometry):
             rasterize([basic_geometry], out=out)
 
 
+@pytest.mark.xfail(reason="shape values are always unsafely cast to the given dtype.")
 def test_rasterize_shapes_out_dtype_mismatch(basic_geometry):
     """Shape values must be able to fit in data type for out."""
     out = np.zeros(DEFAULT_SHAPE, dtype=np.uint8)
@@ -830,6 +831,7 @@ def test_rasterize_unsupported_dtype(basic_geometry):
             )
 
 
+@pytest.mark.xfail(reason="shape values are always unsafely cast to the given dtype.")
 def test_rasterize_mismatched_dtype(basic_geometry):
     """Mismatched values and dtypes should raise exceptions."""
     mismatched_types = (('uint8', 3.2423), ('uint8', -2147483648))


### PR DESCRIPTION
Gives up output data type cleverness to allow deprecation/elimination of helper functions and removal of complicated tests.

Resolves #3004