### PR TITLE
Improvements to transformations

### DIFF
--- a/rasterio/_transform.pyx
+++ b/rasterio/_transform.pyx
@@ -163,7 +163,7 @@ cdef class RPCTransformerBase:
         if self._transformer == NULL:
             raise ValueError("Unexpected NULL transformer")
 
-        cdef int i
+        cdef Py_ssize_t i, n
         cdef double *x = NULL
         cdef double *y = NULL
         cdef double *z = NULL
@@ -173,19 +173,19 @@ cdef class RPCTransformerBase:
 
         cdef double[:] rxview, ryview, rzview
 
-        n = len(xs)
+        n = xs.size
         x = <double *>CPLMalloc(n * sizeof(double))
         y = <double *>CPLMalloc(n * sizeof(double))
         z = <double *>CPLMalloc(n * sizeof(double))
         panSuccess = <int *>CPLMalloc(n * sizeof(int))
 
-        rxview = xs
-        ryview = ys
-        rzview = zs
+        rxview = xs.astype('float64')
+        ryview = ys.astype('float64')
+        rzview = zs.astype('float64')
         for i in range(n):
-            x[i] = xs[i]
-            y[i] = ys[i]
-            z[i] = zs[i]
+            x[i] = rxview[i]
+            y[i] = ryview[i]
+            z[i] = rzview[i]
 
         try:
             err = GDALRPCTransform(self._transformer, bDstToSrc, n, x, y, z, panSuccess)
@@ -318,7 +318,7 @@ cdef class GCPTransformerBase:
         if self._transformer == NULL:
             raise ValueError("Unexpected NULL transformer")
 
-        cdef int i
+        cdef Py_ssize_t i, n
         cdef double *x = NULL
         cdef double *y = NULL
         cdef double *z = NULL
@@ -328,19 +328,19 @@ cdef class GCPTransformerBase:
 
         cdef double[:] rxview, ryview, rzview
 
-        n = len(xs)
+        n = xs.size
         x = <double *>CPLMalloc(n * sizeof(double))
         y = <double *>CPLMalloc(n * sizeof(double))
         z = <double *>CPLMalloc(n * sizeof(double))
         panSuccess = <int *>CPLMalloc(n * sizeof(int))
 
-        rxview = xs
-        ryview = ys
-        rzview = zs
+        rxview = xs.astype('float64')
+        ryview = ys.astype('float64')
+        rzview = zs.astype('float64')
         for i in range(n):
-            x[i] = xs[i]
-            y[i] = ys[i]
-            z[i] = zs[i]
+            x[i] = rxview[i]
+            y[i] = ryview[i]
+            z[i] = rzview[i]
 
         try:
             if self._tps:

--- a/rasterio/_transform.pyx
+++ b/rasterio/_transform.pyx
@@ -8,6 +8,8 @@ from contextlib import ExitStack
 import logging
 import warnings
 
+import numpy as np
+
 from rasterio._err import GDALError
 from rasterio._err cimport exc_wrap_pointer
 from rasterio.errors import NotGeoreferencedWarning, TransformWarning
@@ -132,7 +134,7 @@ cdef class RPCTransformerBase:
 
         Parameters
         ----------
-        xs, ys, zs : list
+        xs, ys, zs : ndarray
             List of coordinates to be transformed. May be either pixel/line/height or
             lon/lat/height)
         transform_direction : TransformDirection
@@ -151,7 +153,7 @@ cdef class RPCTransformerBase:
 
         Returns
         -------
-        tuple of list
+        tuple of ndarray
     
         Notes
         -----
@@ -169,12 +171,17 @@ cdef class RPCTransformerBase:
         cdef int src_count
         cdef int *panSuccess = NULL
 
+        cdef double[:] rxview, ryview, rzview
+
         n = len(xs)
         x = <double *>CPLMalloc(n * sizeof(double))
         y = <double *>CPLMalloc(n * sizeof(double))
         z = <double *>CPLMalloc(n * sizeof(double))
         panSuccess = <int *>CPLMalloc(n * sizeof(int))
 
+        rxview = xs
+        ryview = ys
+        rzview = zs
         for i in range(n):
             x[i] = xs[i]
             y[i] = ys[i]
@@ -186,9 +193,11 @@ cdef class RPCTransformerBase:
                 warnings.warn(
                 "Could not transform points using RPCs.",
                 TransformWarning)
-            res_xs = [0] * n
-            res_ys = [0] * n
-            res_zs = [0] * n
+            res_xs = np.zeros(n)
+            res_ys = np.zeros(n)
+            #res_zs = np.zeros(n)
+            rxview = res_xs
+            ryview = res_ys
             checked = False
             for i in range(n):
                 # GDALRPCTransformer may return a success overall despite individual points failing. Warn once.
@@ -197,9 +206,9 @@ cdef class RPCTransformerBase:
                     "One or more points could not be transformed using RPCs.",
                     TransformWarning)
                     checked = True
-                res_xs[i] = x[i]
-                res_ys[i] = y[i]
-                res_zs[i] = z[i]
+                rxview[i] = x[i]
+                ryview[i] = y[i]
+                #res_zs[i] = z[i]
         finally:
             CPLFree(x)
             CPLFree(y)
@@ -285,7 +294,7 @@ cdef class GCPTransformerBase:
 
         Parameters
         ----------
-        xs, ys, zs : list
+        xs, ys, zs : ndarray
             List of coordinates to be transformed. May be either pixel/line/height or
             lon/lat/height)
         transform_direction : TransformDirection
@@ -304,7 +313,7 @@ cdef class GCPTransformerBase:
 
         Returns
         -------
-        tuple of list
+        tuple of ndarray
         """
         if self._transformer == NULL:
             raise ValueError("Unexpected NULL transformer")
@@ -317,12 +326,17 @@ cdef class GCPTransformerBase:
         cdef int src_count
         cdef int *panSuccess = NULL
 
+        cdef double[:] rxview, ryview, rzview
+
         n = len(xs)
         x = <double *>CPLMalloc(n * sizeof(double))
         y = <double *>CPLMalloc(n * sizeof(double))
         z = <double *>CPLMalloc(n * sizeof(double))
         panSuccess = <int *>CPLMalloc(n * sizeof(int))
 
+        rxview = xs
+        ryview = ys
+        rzview = zs
         for i in range(n):
             x[i] = xs[i]
             y[i] = ys[i]
@@ -337,9 +351,11 @@ cdef class GCPTransformerBase:
                 warnings.warn(
                 "Could not transform points using GCPs.",
                 TransformWarning)
-            res_xs = [0] * n
-            res_ys = [0] * n
-            res_zs = [0] * n
+            res_xs = np.zeros(n)
+            res_ys = np.zeros(n)
+            #res_zs = np.zeros(n)
+            rxview = res_xs
+            ryview = res_ys
             checked = False
             for i in range(n):
                 # GDALGCPTransformer or GDALTPSTransformer may return a success overall despite individual points failing. Warn once.
@@ -348,9 +364,9 @@ cdef class GCPTransformerBase:
                     "One or more points could not be transformed using GCPs.",
                     TransformWarning)
                     checked = True
-                res_xs[i] = x[i]
-                res_ys[i] = y[i]
-                res_zs[i] = z[i]
+                rxview[i] = x[i]
+                ryview[i] = y[i]
+                #res_zs[i] = z[i]
         finally:
             CPLFree(x)
             CPLFree(y)

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -513,22 +513,21 @@ class AffineTransformer(TransformerBase):
         if not isinstance(affine_transform, Affine):
             raise ValueError("Not an affine transform")
         self._transformer = affine_transform
+        self._transform_arr = np.empty((3, 3), dtype='float64')
 
     def _transform(self, xs, ys, zs, transform_direction):
+        transform = self._transform_arr
         if transform_direction is TransformDirection.forward:
-            transform = self._transformer
+            transform.flat[:] = self._transformer
         elif transform_direction is TransformDirection.reverse:
-            transform = ~self._transformer
+            transform.flat[:] = ~self._transformer
 
-        is_arr = True if type(xs) in [list, tuple] else False
-        if is_arr:
-            a, b, c, d, e, f, _, _, _ = transform
-            transform_matrix = np.array([[a, b, c], [d, e, f]])
-            input_matrix = np.array([xs, ys, np.ones(len(xs))])
-            output_matrix = np.dot(transform_matrix, input_matrix)
-            return (list(output_matrix[0]), list(output_matrix[1]))
-        else:
-            return transform * (xs, ys)
+        input_matrix = np.empty((3, len(xs)))
+        input_matrix[0] = xs
+        input_matrix[1] = ys
+        input_matrix[2] = 1
+        transform.dot(input_matrix, out=input_matrix)
+        return input_matrix[0], input_matrix[1]
 
 
     def __repr__(self):

--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -407,10 +407,22 @@ class TransformerBase:
                 xs, ys, zs, transform_direction=TransformDirection.reverse
             )
 
+            is_op_ufunc = isinstance(op, np.ufunc)
+            if is_op_ufunc:
+                op(new_rows, out=new_rows)
+                op(new_cols, out=new_cols)
+            
+            new_rows = new_rows.tolist()
+            new_cols = new_cols.tolist()
+
+            if not is_op_ufunc:
+                new_rows = list(map(op, new_rows))
+                new_cols = list(map(op, new_cols))
+            
             if IS_SCALAR:
-                return (op(new_rows[0]), op(new_cols[0]))
+                return new_rows[0], new_cols[0]
             else:
-                return ([op(r) for r in new_rows], [op(c) for c in new_cols])
+                return new_rows, new_cols
         except TypeError:
             raise TransformError("Invalid inputs")
 


### PR DESCRIPTION
Investigated some major performance regressions with affine transformations. Re-worked the logic to make them faster again.

All times are given release version first, PR changes second order
```python
# For scalar coordinates, roughly the same performance
%timeit riotransform.rowcol(i, -77, 44)
25.7 µs ± 739 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
%timeit riotransform.rowcol(i, -77, 44)
21.1 µs ± 313 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

# List inputs
%timeit riotransform.rowcol(i, [-77], [44])
48.9 µs ± 308 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
%timeit riotransform.rowcol(i, [-77], [44])
20 µs ± 519 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

# ndarray inputs
alist = np.array([-77])
blist = np.array([44])
%timeit riotransform.rowcol(i, alist, blist)
48 µs ± 3.38 µs per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
%timeit riotransform.rowcol(i, alist, blist)
18.7 µs ± 95.1 ns per loop (mean ± std. dev. of 7 runs, 100,000 loops each)

# uneven inputs (forces array broadcasting)
%timeit riotransform.rowcol(i, -77, [44, 23, 55])
64.3 µs ± 923 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
%timeit riotransform.rowcol(i, -77, [44, 23, 55])
27.6 µs ± 282 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

Now for some longer sequences
```python
a = np.random.rand(100) * 100
b = np.random.rand(100) * 100
%timeit riotransform.rowcol(i, a, b)
160 µs ± 709 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
%timeit riotransform.rowcol(i, a, b)
31.5 µs ± 527 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)

# Using a ufunc
%timeit riotransform.rowcol(i, a, b, op=np.floor)
296 µs ± 29.6 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
%timeit riotransform.rowcol(i, a, b, op=np.floor)
26.1 µs ± 307 ns per loop (mean ± std. dev. of 7 runs, 10,000 loops each)
```

A small summary of the changes:
1. Make `_transform()` assume ndarrays for inputs and outputs. Since `_ensure_arr_input` is called before calling `_transform()` the inputs are always ndarrays. The transformers make the assumption that the inputs are ndarrays and already broadcasted to the same length. This assumption also makes redundant some of the type checking.
2. Create a happy path for ndarrays specifically. The user is using ndarrays because the care about performance and we should try to make processing those arrays fast too. This means minimal processing for inputs that already are the proper dimensions.
3. Allow the efficient use of numpy ufuncs (`np.floor`, `np.ceil`, etc).
4. For affine transforms, create the arrays more efficiently and then do an inplace matrix multiply. Of the methods for multiplying the matrices, the `.dot` method was the fastest, so I went with that. Note that numpy docs recommend using `np.matmul`

There are a few more changes I will make soon and then this should be ready to review.