### PR TITLE
Sidecar support for Python openers

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,16 @@ Changes
 Next
 ----
 
+New features:
+
+- Python openers can now support discovery of auxiliary "sidecar" files like
+  .aux.xml, .msk, and .tfw files for GeoTIFFs (#3032). Additionally, filesystem
+  objects, such as those from fsspec, can be used as openers. This will become
+  the recommended usage, supplanting the use of single file openers.
+
+1.4a1 (2024-02-16)
+------------------
+
 Deprecations:
 
 - The is_tiled property of a dataset will be removed in a future version and

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -43,6 +43,9 @@ New Features:
 
 Bug fixes:
 
+- A nodata value passed to _boundless_vrt_doc(), used for boundless reads, has
+  been ignored in favor of the source dataset's own nodata value. It is no
+  longer ignored (#3026).
 - Avoid squeezing narrow 2-D arrays to 1-D (#3008).
 - Operations on closed MemoryFile and ZipMemoryFile objects now raise
   ValueError as with other Python file objects (#2870, #).

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,6 @@ RUN apt-get update && apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:deadsnakes/ppa
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
-    git \
     g++ \
     gdb \
     make \

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,6 +6,7 @@ RUN apt-get update && apt-get install -y software-properties-common
 RUN add-apt-repository -y ppa:deadsnakes/ppa
 RUN apt-get update && \
     DEBIAN_FRONTEND=noninteractive apt-get install -y --no-install-recommends \
+    git \
     g++ \
     gdb \
     make \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-ARG GDAL=ubuntu-small-3.3.3
+ARG GDAL=ubuntu-small-3.6.4
 FROM ghcr.io/osgeo/gdal:${GDAL} AS gdal
 ARG PYTHON_VERSION=3.9
 ENV LANG="C.UTF-8" LC_ALL="C.UTF-8"

--- a/Makefile
+++ b/Makefile
@@ -32,11 +32,17 @@ doctest:
 dockertestimage:
 	docker build --build-arg GDAL=$(GDAL) --build-arg PYTHON_VERSION=$(PYTHON_VERSION) --target gdal -t rasterio:$(GDAL)-py$(PYTHON_VERSION) .
 
+dockertestimage_amd64:
+	docker build --platform linux/amd64 --build-arg GDAL=$(GDAL) --build-arg PYTHON_VERSION=$(PYTHON_VERSION) --target gdal -t rasterio-amd64:$(GDAL)-py$(PYTHON_VERSION) .
+
 dockertest: dockertestimage
-	docker run -it -v $(shell pwd):/app -v /tmp:/tmp --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py develop && /venv/bin/python -B -m pytest -m "not wheel" --cov rasterio --cov-report term-missing $(OPTS)'
+	docker run --rm -it -v $(shell pwd):/app -v /tmp:/tmp --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py develop && /venv/bin/python -B -m pytest -m "not wheel" --cov rasterio --cov-report term-missing $(OPTS)'
+
+dockertest_amd64: dockertestimage_amd64
+	docker run --platform linux/amd64 --rm -it -v $(shell pwd):/app -v /tmp:/tmp --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio-amd64:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py develop && /venv/bin/python -m pip install tiledb && /venv/bin/python -B -m pytest -m "not wheel" --cov rasterio --cov-report term-missing $(OPTS)'
 
 dockershell: dockertestimage
-	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py develop && /bin/bash'
+	docker run --platform linux/amd64 -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py develop && /bin/bash'
 
 dockersdist: dockertestimage
 	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py sdist'

--- a/Makefile
+++ b/Makefile
@@ -32,17 +32,11 @@ doctest:
 dockertestimage:
 	docker build --build-arg GDAL=$(GDAL) --build-arg PYTHON_VERSION=$(PYTHON_VERSION) --target gdal -t rasterio:$(GDAL)-py$(PYTHON_VERSION) .
 
-dockertestimage_amd64:
-	docker build --platform linux/amd64 --build-arg GDAL=$(GDAL) --build-arg PYTHON_VERSION=$(PYTHON_VERSION) --target gdal -t rasterio-amd64:$(GDAL)-py$(PYTHON_VERSION) .
-
 dockertest: dockertestimage
 	docker run --rm -it -v $(shell pwd):/app -v /tmp:/tmp --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py develop && /venv/bin/python -B -m pytest -m "not wheel" --cov rasterio --cov-report term-missing $(OPTS)'
 
-dockertest_amd64: dockertestimage_amd64
-	docker run --platform linux/amd64 --rm -it -v $(shell pwd):/app -v /tmp:/tmp --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio-amd64:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py develop && /venv/bin/python -m pip install tiledb && /venv/bin/python -B -m pytest -m "not wheel" --cov rasterio --cov-report term-missing $(OPTS)'
-
 dockershell: dockertestimage
-	docker run --platform linux/amd64 -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py develop && /bin/bash'
+	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py develop && /bin/bash'
 
 dockersdist: dockertestimage
 	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py sdist'

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 PYTHON_VERSION ?= 3.9
-GDAL ?= ubuntu-small-3.3.3
+GDAL ?= ubuntu-small-3.6.4
 all: deps clean install test
 
 .PHONY: docs

--- a/docs/topics/vsi.rst
+++ b/docs/topics/vsi.rst
@@ -111,8 +111,8 @@ your code.
    and likely many more to fetch all the imagery from the TIFF. Consult the
    AWS S3 pricing guidelines before deciding if `aws.Session` is for you.
 
-Python file openers
--------------------
+Python file and filesystem openers
+----------------------------------
 
 Datasets stored in proprietary systems or addressable only through protocols
 not directly supported by GDAL can be accessed using the ``opener`` keyword
@@ -147,5 +147,25 @@ a time may be thus registered for a filename and access mode pair. Openers are
 unregistered when the dataset is closed or its context is exited. The other
 limitation is that auxiliary and sidecar files cannot be accessed and thus
 formats depending on them cannot be used in this way.
+
+To gain support for auxiliary "sidecar" files such as .aux.xml and .msk files
+that may accompany GeoTIFFs, an fsspec-like filesystem object may be used as
+the opener.
+
+.. code-block:: python
+
+    import rasterio
+    from fsspec
+
+    fs = fsspec.filesystem("s3", anon=True)
+
+    with rasterio.open(
+        "sentinel-cogs/sentinel-s2-l2a-cogs/45/C/VQ/2022/11/S2B_45CVQ_20221102_0_L2A/B01.tif",
+        opener=fs
+    ) as src:
+        print(src.profile)
+
+This kind of filesystem opener object must provide the following methods:
+``isdir()``, ``isfile()``, ``ls()``, ``mtime()``, ``open()``, and ``size()``.
 
 *New in version 1.4.0*

--- a/rasterio/_vsiopener.pxd
+++ b/rasterio/_vsiopener.pxd
@@ -2,5 +2,3 @@ include "gdal.pxi"
 
 cdef int install_pyopener_plugin(VSIFilesystemPluginCallbacksStruct *callbacks_struct)
 cdef void uninstall_pyopener_plugin(VSIFilesystemPluginCallbacksStruct *callbacks_struct)
-
-

--- a/rasterio/_vsiopener.pyx
+++ b/rasterio/_vsiopener.pyx
@@ -374,7 +374,7 @@ class _FilesystemOpener:
     def ls(self, path):
         return self._obj.ls(path)
     def size(self, path):
-        return self.size(path)
+        return self._obj.size(path)
 
 
 def _create_opener(obj):

--- a/rasterio/_vsiopener.pyx
+++ b/rasterio/_vsiopener.pyx
@@ -235,7 +235,6 @@ cdef void* pyopener_open(
         return NULL
     except FileNotFoundError as err:
         errmsg = "OpenFile didn't resolve".encode("utf-8")
-        CPLError(CE_Failure, <CPLErrorNum>4, <const char *>"%s", <const char *>errmsg)
         return NULL
     else:
         exit_stacks = _OPEN_FILE_EXIT_STACKS.get()

--- a/rasterio/_vsiopener.pyx
+++ b/rasterio/_vsiopener.pyx
@@ -174,7 +174,7 @@ cdef char ** pyopener_read_dir(
 
     for name in contents:
         fname = name.encode("utf-8")
-        CSLAddString(name_list, <char *>fname)
+        name_list = CSLAddString(name_list, <char *>fname)
 
     return name_list
 

--- a/rasterio/_vsiopener.pyx
+++ b/rasterio/_vsiopener.pyx
@@ -61,6 +61,7 @@ cdef int install_pyopener_plugin(VSIFilesystemPluginCallbacksStruct *callbacks_s
         log.debug("Installing Python opener handler plugin...")
         callbacks_struct = VSIAllocFilesystemPluginCallbacksStruct()
         callbacks_struct.open = <VSIFilesystemPluginOpenCallback>pyopener_open
+        callbacks_struct.eof = <VSIFilesystemPluginEofCallback>pyopener_eof
         callbacks_struct.tell = <VSIFilesystemPluginTellCallback>pyopener_tell
         callbacks_struct.seek = <VSIFilesystemPluginSeekCallback>pyopener_seek
         callbacks_struct.read = <VSIFilesystemPluginReadCallback>pyopener_read
@@ -242,6 +243,15 @@ cdef void* pyopener_open(
         _OPEN_FILE_EXIT_STACKS.set(exit_stacks)
         log.debug("Returning: file_obj=%r", file_obj)
         return <void *>file_obj
+
+
+cdef int pyopener_eof(void *pFile) with gil:
+    cdef object file_obj = <object>pFile
+    if file_obj.read(1):
+        file_obj.seek(-1, 1)
+        return 1
+    else:
+        return 0
 
 
 cdef vsi_l_offset pyopener_tell(void *pFile) with gil:

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -59,16 +59,13 @@ cdef extern from "cpl_string.h" nogil:
     const char* CPLParseNameValue(const char *pszNameValue, char **ppszKey)
 
 
-cdef extern from "sys/stat.h" nogil:
-    struct stat:
-        pass
-
-
 cdef extern from "cpl_vsi.h" nogil:
 
     ctypedef unsigned long long vsi_l_offset
     ctypedef FILE VSILFILE
-    ctypedef stat VSIStatBufL
+    ctypedef struct VSIStatBufL:
+        long st_size
+        long st_mode
     ctypedef enum VSIRangeStatus:
         VSI_RANGE_STATUS_UNKNOWN,
         VSI_RANGE_STATUS_DATA,

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -66,6 +66,7 @@ cdef extern from "cpl_vsi.h" nogil:
     ctypedef struct VSIStatBufL:
         long st_size
         long st_mode
+        int st_mtime
     ctypedef enum VSIRangeStatus:
         VSI_RANGE_STATUS_UNKNOWN,
         VSI_RANGE_STATUS_DATA,

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 
 # development specific requirements
+aiohttp
 cython>=3.0
 delocate
 fsspec
@@ -11,6 +12,7 @@ packaging
 pytest
 pytest-cov>=2.2.0
 pytest-randomly==3.10.1
+requests
 shapely
 sphinx
 sphinx-click

--- a/tests/test_filepath.py
+++ b/tests/test_filepath.py
@@ -226,11 +226,3 @@ def test_quieter_vsi_plugin_notifications(caplog, path_rgb_byte_tif):
                 _ = src.profile
 
         assert "not found in virtual filesystem" not in caplog.text
-
-import io
-
-
-def test_opener(path_rgb_byte_tif):
-    """First test of vsi python plugin opener."""
-    with rasterio.open(path_rgb_byte_tif, opener=io.open) as src:
-        _ = src.profile

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -17,21 +17,16 @@ def test_registration_failure():
     with pytest.raises(OpenerRegistrationError) as exc_info:
         with rasterio.open(
             "tests/data/RGB.byte.tif", opener=io.open
-        ) as a, rasterio.open("tests/data/RGB.byte.tif", opener=int) as b:
+        ) as a, rasterio.open("tests/data/RGB.byte.tif", opener=fsspec.open) as b:
             pass
 
-    assert exc_info.value.args[0] == "Opener already registered for urlpath and mode"
+    assert exc_info.value.args[0] == "Opener already registered for urlpath and mode."
 
 
 def test_opener_failure():
     """Use int as an opener :)"""
-    with pytest.raises(RasterioIOError) as exc_info:
+    with pytest.raises(OpenerRegistrationError) as exc_info:
         rasterio.open("tests/data/RGB.byte.tif", opener=int)
-
-    assert (
-        exc_info.value.args[0]
-        == "Opener failed to open file with arguments ('tests/data/RGB.byte.tif', 'rb'): TypeError(\"'str' object cannot be interpreted as an integer\")"
-    )
 
 
 def test_opener_io_open():

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -9,7 +9,7 @@ import pytest
 
 import rasterio
 from rasterio.enums import MaskFlags
-from rasterio.errors import RasterioIOError, OpenerRegistrationError
+from rasterio.errors import OpenerRegistrationError
 
 
 def test_registration_failure():

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -116,3 +116,12 @@ def test_fp_fsspec_openfile_write(tmp_path):
         assert src.mask_flag_enums == ([MaskFlags.nodata],)
         arr = src.read()
         assert list(arr.flatten()) == [0, 0, 2]
+
+
+def test_opener_msk_sidecar():
+    """Access .msk sidecar file via opener."""
+    # This test fails before issue 3027 is resolved because
+    # RGB2.byte.tif.msk is not found.
+    with rasterio.open("tests/data/RGB2.byte.tif", opener=io.open) as src:
+        for val in src.mask_flag_enums:
+            assert val == [MaskFlags.per_dataset]

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -66,6 +66,16 @@ def test_opener_fsspec_fs():
         assert profile["count"] == 3
 
 
+def test_opener_tiledb_vfs():
+    """Use tiledb virtual filesystem as opener."""
+    tiledb = pytest.importorskip("tiledb")
+    fs = tiledb.VFS()
+    with rasterio.open("tests/data/RGB.byte.tif", opener=fs) as src:
+        profile = src.profile
+        assert profile["driver"] == "GTiff"
+        assert profile["count"] == 3
+
+
 def test_opener_zipfile_open():
     """Use zipfile as opener."""
     with zipfile.ZipFile("tests/data/files.zip") as zf:


### PR DESCRIPTION
Towards resolving #3027. Lots of work remains to generalize this beyond paths in the local filesystem, for which this feature isn't actually needed at all. We're only doing so for testing and development.

How far will we generalize this? This kind of I/O plugin is interesting to me, but the main point of it is to support hierarchical storage systems with proprietary authentication and authorization, aka "the Cloud". Sidecar files can't exist without a container, either an actual directory/folder or a shared prefix. Thus it seems fine to require that "filenames" passed to the opener be parseable as URIs and have a path component.

One complication for all this is that sidecar discovery requires either built-in knowledge of possible sidecar extensions for all formats or readir/ls and stat support from the Python object. And the various Python filesystem packages don't implement a common standard for this.

I don't plan to include openers for all cloud platforms in rasterio. I prefer to make it possible to wrap `s3fs`, `fsspec`, `tiledb.VFS`, say, with a few lines of code for compatibility.

The `opener` keyword parameter of `rasterio.open()` will be extended to accept not only a Python file object or fsspec `OpenFile`, but also a "read-only directory" object that provides `stat()`, `ls()`, and `open()` methods.