### PR TITLE
Rel 1.3.10

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,7 +74,8 @@ jobs:
           python -m pip install numpy==1.23.5
           python -m pip wheel -r requirements-dev.txt
           python -m pip install dist/*.whl
-          python -m pytest -v -m "not wheel" -rxXs --cov rasterio --cov-report term-missing
+          python -m pip install pytest
+          python -m pytest -v -m "not wheel" -rxXs
 
   docker_tests:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -75,6 +75,7 @@ jobs:
           python -m pip wheel -r requirements-dev.txt
           python -m pip install dist/*.whl
           python -m pip install boto3 hypothesis packaging pytest shapely
+          rm -rf rasterio
           python -m pytest -v -m "not wheel" -rxXs
 
   docker_tests:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -31,7 +31,7 @@ on:
 jobs:
   numpy_compat_test:
     runs-on: ubuntu-latest
-    name: Docker | GDAL=${{ matrix.gdal-version }} | python=${{ matrix.python-version }}
+    name: Build with Numpy 2.0.0rc1, test with 1.23.5
     container: osgeo/gdal:ubuntu-small-${{ matrix.gdal-version }}
     env:
         DEBIAN_FRONTEND: noninteractive
@@ -39,7 +39,7 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.10']
-        gdal-version: ['3.6.4']
+        gdal-version: ['3.8.4']
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -121,7 +121,6 @@ jobs:
           python${{ matrix.python-version }} -m venv testenv
           . testenv/bin/activate
           python -m pip install --upgrade pip
-          python -m pip wheel -r requirements-dev.txt
           python -m pip install --no-deps --force-reinstall -e .[test]
 
       - name: run tests

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -29,6 +29,52 @@ on:
     - cron:  '0 0 * * 0'
 
 jobs:
+  numpy_compat_test:
+    runs-on: ubuntu-latest
+    name: Docker | GDAL=${{ matrix.gdal-version }} | python=${{ matrix.python-version }}
+    container: osgeo/gdal:ubuntu-small-${{ matrix.gdal-version }}
+    env:
+        DEBIAN_FRONTEND: noninteractive
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ['3.10']
+        gdal-version: ['3.6.4']
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Update
+        run: |
+          apt-get update
+          apt-get -y install software-properties-common
+          add-apt-repository -y ppa:deadsnakes/ppa
+          apt-get update
+
+      - name: Set up Python ${{ matrix.python-version }}
+        run: |
+          apt-get install -y --no-install-recommends \
+            python${{ matrix.python-version }} \
+            python${{ matrix.python-version }}-dev \
+            python${{ matrix.python-version }}-venv \
+            python3-pip \
+            g++
+
+      - name: Install dependencies
+        run: |
+          python${{ matrix.python-version }} -m venv testenv
+          . testenv/bin/activate
+          python -m pip install --upgrade pip
+          python -m pip install numpy==1.23.5
+          python -m pip wheel -r requirements-dev.txt
+          python -m pip install --no-deps --force-reinstall -e .[test]
+
+      - name: run tests
+        run: |
+          . testenv/bin/activate
+          python -m pip install -r requirements-dev.txt
+          python -m pytest -v -m "not wheel" -rxXs --cov rasterio --cov-report term-missing
+
   docker_tests:
     runs-on: ubuntu-latest
     name: Docker | GDAL=${{ matrix.gdal-version }} | python=${{ matrix.python-version }}

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -32,7 +32,7 @@ jobs:
   numpy_compat_test:
     runs-on: ubuntu-latest
     name: Build with Numpy 2.0.0rc1, test with 1.23.5
-    container: osgeo/gdal:ubuntu-small-${{ matrix.gdal-version }}
+    container: ghcr.io/osgeo/gdal:ubuntu-small-${{ matrix.gdal-version }}
     env:
         DEBIAN_FRONTEND: noninteractive
     strategy:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -60,19 +60,20 @@ jobs:
             python3-pip \
             g++
 
-      - name: Install dependencies
+      - name: build wheel with Numpy 2
         run: |
           python${{ matrix.python-version }} -m venv testenv
           . testenv/bin/activate
           python -m pip install --upgrade pip
-          python -m pip install numpy==1.23.5
-          python -m pip wheel -r requirements-dev.txt
-          python -m pip install --no-deps --force-reinstall -e .[test]
+          python -m pip install build
+          python -m build
 
-      - name: run tests
+      - name: run tests with Numpy 1
         run: |
           . testenv/bin/activate
-          python -m pip install -r requirements-dev.txt
+          python -m pip install numpy==1.23.5
+          python -m pip wheel -r requirements-dev.txt
+          python -m pip install dist/*.whl
           python -m pytest -v -m "not wheel" -rxXs --cov rasterio --cov-report term-missing
 
   docker_tests:

--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -74,7 +74,7 @@ jobs:
           python -m pip install numpy==1.23.5
           python -m pip wheel -r requirements-dev.txt
           python -m pip install dist/*.whl
-          python -m pip install pytest
+          python -m pip install boto3 hypothesis packaging pytest shapely
           python -m pytest -v -m "not wheel" -rxXs
 
   docker_tests:

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,8 +4,8 @@ Changes
 1.3.10 (TBD)
 ------------
 
-This version is compatible with recent versions of Numpy 1.x and Numpy 2.0.0rc1
-(#).
+This version is compatible with recent versions of Numpy 1.x and Numpy
+2.0.0rc1.
 
 Packaging:
 
@@ -16,8 +16,8 @@ Packaging:
 
 Bug fixes:
 
-- Eliminate usage of pytest.warns(None) (#).
-- All use of pkg_resouces has been eliminated (#).
+- Eliminate usage of pytest.warns(None) (#3054).
+- All use of pkg_resouces has been eliminated (#3054).
 - Adjust several tests to small differences in output between GDAL 3.7 and 3.8
   (#2959).
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,11 +1,23 @@
 Changes
 =======
 
-Next (TBD)
-----------
+1.3.10 (TBD)
+------------
+
+This version is compatible with recent versions of Numpy 1.x and Numpy 2.0.0rc1
+(#).
+
+Packaging:
+
+- Wheels for Python versions >= 3.9 will be built using Numpy 2.0.0rc1 or
+  a newer version and will be compatible with the oldest supported Numpy 1.x.
+- Wheels for Python version 3.8 will be built using Numpy < 2 and will not be
+  compatible with Numpy 2.
 
 Bug fixes:
 
+- Eliminate usage of pytest.warns(None) (#).
+- All use of pkg_resouces has been eliminated (#).
 - Adjust several tests to small differences in output between GDAL 3.7 and 3.8
   (#2959).
 

--- a/Makefile
+++ b/Makefile
@@ -33,6 +33,9 @@ dockertestimage:
 dockertest: dockertestimage
 	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py develop && /venv/bin/python -B -m pytest -m "not wheel" --cov rasterio --cov-report term-missing $(OPTS)'
 
+dockernumpytest: dockertestimage
+	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python -m build && /venv/bin/python -m pip install numpy==1.23.5 && /venv/bin/python -m pip install dist/*.whl && /venv/bin/python -B -m pytest -m "not wheel" --cov rasterio --cov-report term-missing $(OPTS)'
+
 dockershell: dockertestimage
 	docker run -it -v $(shell pwd):/app --env AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY --entrypoint=/bin/bash rasterio:$(GDAL)-py$(PYTHON_VERSION) -c '/venv/bin/python setup.py develop && /bin/bash'
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=67.8", "wheel", "cython~=3.0.2", "oldest-supported-numpy"]
+requires = ["setuptools>=67.8", "wheel", "cython~=3.0.2", "numpy>=2.0.0rc1"]
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,12 @@
 [build-system]
-requires = ["setuptools>=67.8", "wheel", "cython~=3.0.2", "numpy>=2.0.0rc1"]
+requires = [
+    "setuptools>=67.8",
+    "wheel",
+    "cython~=3.0.2",
+    "numpy>=2.0.0rc1; python_version >= '3.9'",
+    "numpy<2; python_version < '3.9'"
+]
+
 build-backend = "setuptools.build_meta"
 
 [tool.pytest.ini_options]

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -81,7 +81,7 @@ except ImportError:
     have_vsi_plugin = False
 
 __all__ = ['band', 'open', 'pad', 'Env', 'CRS']
-__version__ = "1.3.10dev"
+__version__ = "1.3.10.dev0"
 __gdal_version__ = gdal_version()
 __proj_version__ = ".".join([str(version) for version in get_proj_version()])
 __geos_version__ = ".".join([str(version) for version in get_geos_version()])

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -46,6 +46,8 @@ from rasterio._err cimport exc_wrap_int, exc_wrap_pointer, exc_wrap_vsilfile
 
 cimport numpy as np
 
+np.import_array()
+
 log = logging.getLogger(__name__)
 
 gdal33_version_checked = False

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -42,6 +42,7 @@ from rasterio._io cimport (
 from rasterio._features cimport GeomBuilder, OGRGeomBuilder
 from rasterio.crs cimport CRS
 
+np.import_array()
 log = logging.getLogger(__name__)
 
 # Gauss (7) is not supported for warp
@@ -50,12 +51,14 @@ SUPPORTED_RESAMPLING = [r for r in Resampling if r.value != 7 and r.value <= 13]
 if GDALVersion.runtime().at_least('3.3'):
     SUPPORTED_RESAMPLING.append(Resampling.rms)
 
+
 def recursive_round(val, precision):
     """Recursively round coordinates."""
     if isinstance(val, (int, float)):
         return round(val, precision)
     else:
         return [recursive_round(part, precision) for part in val]
+
 
 cdef object _transform_single_geom(
     object single_geom,

--- a/rasterio/rio/main.py
+++ b/rasterio/rio/main.py
@@ -30,14 +30,18 @@ Please add yours to the registry
 so that other ``rio`` users may find it.
 """
 
-
+import itertools
 import logging
-from pkg_resources import iter_entry_points
 import sys
 
 from click_plugins import with_plugins
 import click
 import cligj
+
+if sys.version_info < (3, 10):
+    from importlib_metadata import entry_points
+else:
+    from importlib.metadata import entry_points
 
 from . import options
 import rasterio
@@ -64,11 +68,11 @@ def show_versions_cb(ctx, param, value):
     ctx.exit()
 
 
-
 @with_plugins(
-    ep
-    for ep in list(iter_entry_points("rasterio.rio_commands"))
-    + list(iter_entry_points("rasterio.rio_plugins"))
+    itertools.chain(
+        entry_points(group="rasterio.rio_commands"),
+        entry_points(group="rasterio.rio_plugins")
+    )
 )
 @click.group()
 @cligj.verbose_opt

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,7 @@
 -r requirements.txt
 
 # development specific requirements
+build
 cython~=0.29
 delocate
 hypothesis

--- a/tests/test_cli_main.py
+++ b/tests/test_cli_main.py
@@ -1,7 +1,7 @@
-from pkg_resources import iter_entry_points
+"""Basic test of the CLI version and command plugins."""
 
 import rasterio
-from rasterio.rio.main import main_group
+from rasterio.rio.main import entry_points, main_group
 
 
 def test_version(runner):
@@ -14,5 +14,5 @@ def test_all_registered():
     # This test makes sure that all of the subcommands defined in the
     # rasterio.rio_commands entry-point are actually registered to the main
     # cli group.
-    for ep in iter_entry_points('rasterio.rio_commands'):
+    for ep in entry_points(group="rasterio.rio_commands"):
         assert ep.name in main_group.commands

--- a/tests/test_rio_shapes.py
+++ b/tests/test_rio_shapes.py
@@ -19,16 +19,15 @@ def bbox(*args):
 
 
 def test_shapes(runner, pixelated_image_file):
-    with pytest.warns(None):
+    result = runner.invoke(main_group, ["shapes", "--collection", pixelated_image_file])
 
-        result = runner.invoke(main_group, ['shapes', '--collection', pixelated_image_file])
-
-        assert result.exit_code == 0
-        assert result.output.count('"FeatureCollection"') == 1
-        assert result.output.count('"Feature"') == 4
-        assert np.allclose(
-            json.loads(result.output)['features'][0]['geometry']['coordinates'],
-            [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]])
+    assert result.exit_code == 0
+    assert result.output.count('"FeatureCollection"') == 1
+    assert result.output.count('"Feature"') == 4
+    assert np.allclose(
+        json.loads(result.output)["features"][0]["geometry"]["coordinates"],
+        [[[0, 0], [0, 1], [1, 1], [1, 0], [0, 0]]],
+    )
 
 
 def test_shapes_invalid_bidx(runner, pixelated_image_file):
@@ -44,15 +43,14 @@ def test_shapes_sequence(runner, pixelated_image_file):
     --sequence option should produce 4 features in series rather than
     inside a feature collection.
     """
-    with pytest.warns(None):
+    result = runner.invoke(
+        main_group, ["shapes", "--collection", pixelated_image_file, "--sequence"]
+    )
 
-        result = runner.invoke(
-            main_group, ['shapes', '--collection', pixelated_image_file, '--sequence'])
-
-        assert result.exit_code == 0
-        assert result.output.count('"FeatureCollection"') == 0
-        assert result.output.count('"Feature"') == 4
-        assert result.output.count('\n') == 4
+    assert result.exit_code == 0
+    assert result.output.count('"FeatureCollection"') == 0
+    assert result.output.count('"Feature"') == 4
+    assert result.output.count("\n") == 4
 
 
 def test_shapes_sequence_rs(runner, pixelated_image_file):
@@ -91,29 +89,27 @@ def test_shapes_indent(runner, pixelated_image_file):
     """
     --indent option should produce lots of newlines and contiguous spaces
     """
-    with pytest.warns(None):
+    result = runner.invoke(
+        main_group, ["shapes", "--collection", pixelated_image_file, "--indent", 2]
+    )
 
-        result = runner.invoke(
-            main_group, ['shapes', '--collection', pixelated_image_file, '--indent', 2])
-
-        assert result.exit_code == 0
-        assert result.output.count('"FeatureCollection"') == 1
-        assert result.output.count('"Feature"') == 4
-        assert result.output.count("\n") > 100
-        assert result.output.count("        ") > 100
+    assert result.exit_code == 0
+    assert result.output.count('"FeatureCollection"') == 1
+    assert result.output.count('"Feature"') == 4
+    assert result.output.count("\n") > 100
+    assert result.output.count("        ") > 100
 
 
 def test_shapes_compact(runner, pixelated_image_file):
-    with pytest.warns(None):
+    result = runner.invoke(
+        main_group, ["shapes", "--collection", pixelated_image_file, "--compact"]
+    )
 
-        result = runner.invoke(
-            main_group, ['shapes', '--collection', pixelated_image_file, '--compact'])
-
-        assert result.exit_code == 0
-        assert result.output.count('"FeatureCollection"') == 1
-        assert result.output.count('"Feature"') == 4
-        assert result.output.count(', ') == 0
-        assert result.output.count(': ') == 0
+    assert result.exit_code == 0
+    assert result.output.count('"FeatureCollection"') == 1
+    assert result.output.count('"Feature"') == 4
+    assert result.output.count(", ") == 0
+    assert result.output.count(": ") == 0
 
 
 def test_shapes_sampling(runner, pixelated_image_file):
@@ -150,13 +146,13 @@ def test_shapes_mask(runner, pixelated_image, pixelated_image_file):
     with rasterio.open(pixelated_image_file, 'r+') as out:
         out.write(pixelated_image, indexes=1)
 
-    with pytest.warns(None):
-        result = runner.invoke(
-            main_group, ['shapes', '--collection', pixelated_image_file, '--mask'])
-        assert result.exit_code == 0
-        assert result.output.count('"FeatureCollection"') == 1
-        assert result.output.count('"Feature"') == 1
-        assert shape(json.loads(result.output)["features"][0]["geometry"]).area == 31.0
+    result = runner.invoke(
+        main_group, ["shapes", "--collection", pixelated_image_file, "--mask"]
+    )
+    assert result.exit_code == 0
+    assert result.output.count('"FeatureCollection"') == 1
+    assert result.output.count('"Feature"') == 1
+    assert shape(json.loads(result.output)["features"][0]["geometry"]).area == 31.0
 
 
 def test_shapes_mask_sampling(runner, pixelated_image, pixelated_image_file):
@@ -173,16 +169,15 @@ def test_shapes_mask_sampling(runner, pixelated_image, pixelated_image_file):
     with rasterio.open(pixelated_image_file, 'r+') as out:
         out.write(pixelated_image, indexes=1)
 
-    with pytest.warns(None):
+    result = runner.invoke(
+        main_group,
+        ["shapes", "--collection", pixelated_image_file, "--mask", "--sampling", 5],
+    )
 
-        result = runner.invoke(
-            main_group,
-            ['shapes', '--collection', pixelated_image_file, '--mask', '--sampling', 5])
-
-        assert result.exit_code == 0
-        assert result.output.count('"FeatureCollection"') == 1
-        assert result.output.count('"Feature"') == 1
-        assert shape(json.loads(result.output)["features"][0]["geometry"]).area == 25.0
+    assert result.exit_code == 0
+    assert result.output.count('"FeatureCollection"') == 1
+    assert result.output.count('"Feature"') == 1
+    assert shape(json.loads(result.output)["features"][0]["geometry"]).area == 25.0
 
 
 def test_shapes_band1_as_mask(runner, pixelated_image, pixelated_image_file):
@@ -198,12 +193,20 @@ def test_shapes_band1_as_mask(runner, pixelated_image, pixelated_image_file):
     with rasterio.open(pixelated_image_file, 'r+') as out:
         out.write(pixelated_image, indexes=1)
 
-    with pytest.warns(None):
-        result = runner.invoke(
-            main_group,
-            ['shapes', '--collection', pixelated_image_file, '--band', '--bidx', '1', '--as-mask'])
+    result = runner.invoke(
+        main_group,
+        [
+            "shapes",
+            "--collection",
+            pixelated_image_file,
+            "--band",
+            "--bidx",
+            "1",
+            "--as-mask",
+        ],
+    )
 
-        assert result.exit_code == 0
-        assert result.output.count('"FeatureCollection"') == 1
-        assert result.output.count('"Feature"') == 3
-        assert shape(json.loads(result.output)["features"][0]["geometry"]).area == 1.0
+    assert result.exit_code == 0
+    assert result.output.count('"FeatureCollection"') == 1
+    assert result.output.count('"Feature"') == 3
+    assert shape(json.loads(result.output)["features"][0]["geometry"]).area == 1.0

--- a/tests/test_warnings.py
+++ b/tests/test_warnings.py
@@ -36,8 +36,5 @@ def test_no_notgeoref_warning(transform, gcps, rpcs):
             if rpcs:
                 src.rpcs = rpcs
 
-        with pytest.warns(None) as record:
-            with mem.open() as dst:
-                pass
-        
-        assert len(record) == 0
+        with mem.open() as dst:
+            pass


### PR DESCRIPTION
Last 1.3 release, to make sure that we have wheels out there that will work with Numpy 2.0.

Note to self: Python 3.8 wheels for the release will have to be built with Numpy<2.