### PR TITLE
Remove run-time dependency on setuptools

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -260,7 +260,6 @@ inst_reqs = [
     "numpy",
     "click-plugins",
     "pyparsing",
-    "setuptools",
 ]
 
 extra_reqs = {


### PR DESCRIPTION
Reverts #2168 

Follow-up to #3061 

The run-time dependency on setuptools was only added because `pkg_resources` was imported at run-time, but now that these imports have been removed, the package no longer depends on setuptools after installation.

This should be included in the next 1.4 pre-release.