### PR TITLE
Fix typo in calculation of `max_pixels` in `rasterio.merge.merge()`

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -332,7 +332,7 @@ def merge(
                 dst = rasterio.open(dst_path, "w", **out_profile)
                 exit_stack.enter_context(dst)
 
-            max_pixels = mem_limit * 1.0e6 / np.dtype(dt).itemsize * output_count
+            max_pixels = mem_limit * 1.0e6 / (np.dtype(dt).itemsize * output_count)
 
             if output_width * output_height < max_pixels:
                 chunks = [((0, 0), windows.Window(0, 0, output_width, output_height))]


### PR DESCRIPTION
Addresses parts of the issue reported in rasterio/rasterio#3072

This PR fixes a typo in the computation of `max_pixels` in `rasterio.merge.merge()`:

Line 335 of `rasterio.merge.merge` was missing brackets around the denominator and thus computing `max_pixels`too large by a factor of `output_count**2`. This has been fixed.

