### PR TITLE
Add test for out of range nodata value

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -300,13 +300,14 @@ def merge(
                 if cmath.isfinite(nodataval):
                     info = np.finfo(dt)
                     inrange = info.min <= nodataval <= info.max
-                    inrange = inrange
+                    nodata_dt = np.min_scalar_type(nodataval)
+                    inrange = inrange & np.can_cast(nodata_dt, dt)
                 else:
                     inrange = True
 
             if not inrange:
                 warnings.warn(
-                    "The nodata value, %s, cannot safely be represented "
+                    "Ignoring nodata value. The nodata value, %s, cannot safely be represented "
                     "in the chosen data type, %s. Consider overriding it "
                     "using the --nodata option for better results." % (nodataval, dt)
                 )

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -216,3 +216,9 @@ def test_complex_nodata(test_data_complex):
 
         result, _ = merge(inputs, nodata=0-1j)
         assert numpy.all(result[:, 2] == 0-1j)
+
+
+def test_complex_outrange_nodata_():
+    with rasterio.open("tests/data/float_raster_with_nodata.tif") as src:
+        with pytest.warns(UserWarning, match="Ignoring nodata value"):
+            res, _ = merge([src], nodata=1+1j, dtype='float64')


### PR DESCRIPTION
Make usage of `np.can_cast` compatible with numpy 2. Added a test for datatype check.

Without this check, setting a nodata value that cannot be safely cast chosen datatype will raise a TypeError.
```
FAILED tests/test_merge.py::test_complex_nodata_dt - TypeError: float() argument must be a string or a real number, not 'complex'
```

I also modified the warning to inform the user that the nodata value will be ignored. In practice, the nodataval is essentially being set to 0.