### PR TITLE
Generalize window_split

### DIFF
--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -13,7 +13,7 @@ from rasterio.merge import merge
 from rasterio.crs import CRS
 from rasterio.errors import RasterioError
 from rasterio.warp import aligned_target
-from rasterio.windows import window_split
+from rasterio.windows import subdivide
 
 from .conftest import gdal_version
 
@@ -155,7 +155,7 @@ def test_merge_destination_1(tmp_path):
         from rasterio import windows
 
         with rasterio.open(tmp_path.joinpath("test.tif"), "w", **profile) as dst:
-            for _, chunk in window_split(dst.height, dst.width, max_pixels=256 * 256):
+            for chunk in subdivide(windows.Window(0, 0, dst.width, dst.height), 256, 256):
                 chunk_bounds = windows.bounds(chunk, dst.transform)
                 chunk_arr, chunk_transform = merge([src], bounds=chunk_bounds)
                 dst_window = windows.from_bounds(*chunk_bounds, dst.transform).round(3)
@@ -183,7 +183,7 @@ def test_merge_destination_2(tmp_path):
         from rasterio import windows
 
         with rasterio.open(tmp_path.joinpath("test.tif"), "w", **profile) as dst:
-            for _, chunk in window_split(dst.height, dst.width, max_pixels=256 * 256):
+            for chunk in subdivide(windows.Window(0, 0, dst.width, dst.height), 256, 256):
                 chunk_bounds = windows.bounds(chunk, dst.transform)
                 chunk_arr, chunk_transform = merge([src], bounds=chunk_bounds)
                 dst_window = windows.from_bounds(*chunk_bounds, dst.transform).round(3)

--- a/tests/test_rio_calc.py
+++ b/tests/test_rio_calc.py
@@ -1,7 +1,6 @@
 import pytest
 
 import rasterio
-from rasterio.rio.calc import _chunk_output
 from rasterio.rio.main import main_group
 
 
@@ -167,19 +166,6 @@ def test_positional_calculation_byindex(tmpdir, runner):
 
     with rasterio.open(outfile) as src:
         assert src.read(1, window=window) == answer
-
-
-@pytest.mark.parametrize('width', [10, 791, 3000])
-@pytest.mark.parametrize('height', [8, 718, 4000])
-@pytest.mark.parametrize('count', [1, 3, 4])
-@pytest.mark.parametrize('itemsize', [1, 2, 8])
-@pytest.mark.parametrize('mem_limit', [1, 16, 64, 512])
-def test_chunk_output(width, height, count, itemsize, mem_limit):
-    work_windows = _chunk_output(width, height, count, itemsize, mem_limit=mem_limit)
-    num_windows_rows = max([i for ((i, j), w) in work_windows]) + 1
-    num_windows_cols = max([j for ((i, j), w) in work_windows]) + 1
-    assert sum((w.width for ij, w in work_windows)) == width * num_windows_rows
-    assert sum((w.height for ij, w in work_windows)) == height * num_windows_cols
 
 
 def test_bool(tmpdir, runner):

--- a/tests/test_rio_calc.py
+++ b/tests/test_rio_calc.py
@@ -1,5 +1,3 @@
-import pytest
-
 import rasterio
 from rasterio.rio.main import main_group
 

--- a/tests/test_windows.py
+++ b/tests/test_windows.py
@@ -14,7 +14,7 @@ from rasterio.errors import WindowError
 from rasterio.windows import (
     crop, from_bounds, bounds, transform, evaluate, window_index, shape,
     Window, intersect, intersection, get_data_window, union,
-    round_window_to_full_blocks)
+    round_window_to_full_blocks, subdivide)
 
 EPS = 1.0e-8
 
@@ -690,3 +690,25 @@ def test_nonintersecting_window_index():
     selection = data[window_index(w, height=5, width=5)]
     assert selection.shape == (2, 0)
     assert selection.flatten().tolist() == []
+
+
+def test_subdivide_offsets():
+    src = Window(10, 12, 3, 5)
+    subs = subdivide(src, 3, 2)
+    
+    expected = {Window(col_off=10, row_off=12, width=2, height=3),
+                Window(col_off=12, row_off=12, width=1, height=3),
+                Window(col_off=10, row_off=15, width=2, height=2),
+                Window(col_off=12, row_off=15, width=1, height=2)}
+    assert set(subs) == expected
+
+
+def test_subdivide():
+    src = Window(0, 0, 4, 4)
+    subs = subdivide(src, 2, 2)
+
+    expected = {Window(col_off=0, row_off=0, width=2, height=2),
+                Window(col_off=2, row_off=0, width=2, height=2),
+                Window(col_off=0, row_off=2, width=2, height=2),
+                Window(col_off=2, row_off=2, width=2, height=2)}
+    assert set(subs) == expected


### PR DESCRIPTION
The existing `window_split` function was dependent on the dataset's dimensions and assumed zero offsets for rows and columns. This PR generalizes the function to split any arbitrary source window. This allows any region of interest in a dataset to be subdivided and processed in chunks.
For example:
```
src_win = windows.Window(10, 12, 3, 5)
subdivide(k, 3, 2)

[Window(col_off=10, row_off=12, width=2, height=3),
 Window(col_off=12, row_off=12, width=1, height=3),
 Window(col_off=10, row_off=15, width=2, height=2),
 Window(col_off=12, row_off=15, width=1, height=2)]
```

I've renamed the function from `windows.window_split` to `windows.subdivide` (though happy to revert the name if desired). It seemed strange to prefix the function verb with `window` which sticks out among the other window functions.

The function's signature has also been modified to be consistent with the API of other window functions. The new signature is `subdivide(window, height, width)` where window will be subdivided into non-overlapping subwindows of size `(width, height)` which is consistent with other window functions that operate on an input window.

This PR also updates rio-calc to remove previously duplicated code.