### PR TITLE
tests.yaml: change macos-latest to macos-13

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -146,8 +146,9 @@ jobs:
     strategy:
       fail-fast: true
       matrix:
-        # macos-14 is osx-arm64
-        os: [macos-latest, macos-14]
+        # macos-13 is OSX Intel
+        # macos-14 is OSX Arm64
+        os: [macos-13, macos-14]
         python-version: ['3.9', '3.10', '3.11']
         include:
           - os: ubuntu-latest
@@ -191,7 +192,7 @@ jobs:
           python -m pytest -v -m "not wheel" -rxXs --cov rasterio --cov-report term-missing -k "not issue2353"
 
       - name: Test with Coverage (OSX)
-        if: "${{matrix.os}} == 'macos-latest' || ${{matrix.os}} == 'macos-14'"
+        if: "${{matrix.os}} == 'macos-13' || ${{matrix.os}} == 'macos-14'"
         shell: bash -l {0}
         run: |
           conda activate test


### PR DESCRIPTION
GHA has changed the macos-latest alias to macos-14 (arm64), hence to get Intel Mac one now needs to explicitly select macos-13. Cf https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners/about-github-hosted-runners#standard-github-hosted-runners-for-public-repositories