### PR TITLE
Return numpy arrays from transformations

### DIFF
--- a/rasterio/transform.py
+++ b/rasterio/transform.py
@@ -400,14 +400,10 @@ class TransformerBase:
             if is_op_ufunc:
                 op(new_rows, out=new_rows)
                 op(new_cols, out=new_cols)
-            
-            new_rows = new_rows.tolist()
-            new_cols = new_cols.tolist()
+            else:
+                new_rows = np.array(list(map(op, new_rows)))
+                new_cols = np.array(list(map(op, new_cols)))
 
-            if not is_op_ufunc:
-                new_rows = list(map(op, new_rows))
-                new_cols = list(map(op, new_cols))
-            
             if IS_SCALAR:
                 return new_rows[0], new_cols[0]
             else:
@@ -471,7 +467,7 @@ class TransformerBase:
             if IS_SCALAR:
                 return new_xs[0], new_ys[0]
             else:
-                return new_xs.tolist(), new_ys.tolist()
+                return new_xs, new_ys
         except TypeError:
             raise TransformError("Invalid inputs")
 

--- a/tests/test_transform.py
+++ b/tests/test_transform.py
@@ -387,9 +387,10 @@ def test_rowcol_gcps_rpcs(dataset, transform_attr, coords, expected):
 def test_xy_rowcol_inverse(transform):
     # TODO this is an ideal candiate for
     # property-based testing with hypothesis
-    rows_cols = ([0, 0, 10, 10],
-                 [0, 10, 0, 10])
-    assert rows_cols == rowcol(transform, *xy(transform, *rows_cols))
+    rows = [0, 0, 10, 10]
+    cols = [0, 10, 0, 10]
+    crows, ccols = rowcol(transform, *xy(transform, rows, cols))
+    assert numpy.allclose(rows, crows) and numpy.allclose(cols, ccols)
 
 
 @pytest.mark.parametrize("aff", [Affine.identity()])
@@ -436,7 +437,9 @@ def test_transformer_open_closed(transformer_cls, transform):
 )
 def test_ensure_arr_input(coords, expected):
     transformer = transform.AffineTransformer(Affine.identity())
-    assert transformer.xy(*coords, offset='ul') == expected
+    rows, cols = expected
+    crows, ccols = transformer.xy(*coords, offset='ul')
+    assert numpy.allclose(rows, crows) and numpy.allclose(cols, ccols)
 
 
 def test_ensure_arr_input_same_shape():


### PR DESCRIPTION
This PR changes the return type of `xy()` and `rowcol()` to be numpy arrays instead of coercing to Python lists. 

These functions now use numpy internally to make the computation more efficient when working with lots of points. Returning a numpy array feels much more sensible and makes working with the transformed points easier.