### PR TITLE
restore gdalinfo output check for tag test with fix for variance

### DIFF
--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -1,5 +1,8 @@
 """Tests of updating a dataset's tags etc."""
 
+import re
+import subprocess
+
 import affine
 import numpy as np
 import pytest
@@ -16,6 +19,13 @@ def test_update_tags(data):
             f.update_tags(4, d=4)
         assert f.tags() == {'AREA_OR_POINT': 'Area', 'a': '1', 'b': '2'}
         assert ('c', '3') in f.tags(1).items()
+    info = subprocess.check_output(["gdalinfo", tiffname]).decode('utf-8')
+    assert (
+        # older gdalinfo ordering
+        re.search(r'Metadata:\W+a=1\W+AREA_OR_POINT=Area\W+b=2', info)
+        # newer gdalinfo ordering
+        or re.search(r'Metadata:\W+a=1\W+b=2\W+AREA_OR_POINT=Area', info)
+    )
 
 
 def test_update_band(data):


### PR DESCRIPTION
https://github.com/rasterio/rasterio/pull/3091 dropped this check entirely, but that seems unnecessary. All that changed in newer gdalinfo is the ordering - it now puts AREA_OR_POINT last. It's easy enough to handle that just by checking for both forms.