### PR TITLE
BUG: Use np.asanyarray in MemoryDataset for numpy 2 compat

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -2137,10 +2137,13 @@ cdef class MemoryDataset(DatasetWriterBase):
         copy : bool, optional
             Create an internal copy of the array. If set to False,
             caller must make sure that arr is valid while this object
-            lives.
+            lives. Default is to copy only as needed.
 
         """
-        self._array = np.array(arr, copy=copy)
+        self._array = np.asanyarray(arr)
+        if copy and self._array is arr:
+            self._array = self._array.copy()
+
         dtype = self._array.dtype
 
         if self._array.ndim == 2:


### PR DESCRIPTION
Error encountered [here](https://github.com/corteva/geocube/actions/runs/9629708861/job/26559455123).

```
../../../micromamba/envs/test/lib/python3.10/site-packages/rasterio/features.py:126: in shapes
    for s, v in _shapes(source, mask, connectivity, transform):
rasterio/_features.pyx:77: in _shapes
    ???
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ 

>   ???
E   ValueError: Unable to avoid copy while creating an array as requested.
E   If using `np.array(obj, copy=False)` replace it with `np.asarray(obj)` to allow a copy when needed (no behavior change in NumPy 1.x).
E   For more details, see https://numpy.org/devdocs/numpy_2_0_migration_guide.html#adapting-to-changes-in-the-copy-keyword.
```