### PR TITLE
Add tests with multiple GDAL threads and implement truncate

### DIFF
--- a/rasterio/_vsiopener.pyx
+++ b/rasterio/_vsiopener.pyx
@@ -287,7 +287,8 @@ cdef size_t pyopener_write(void *pFile, void *pBuffer, size_t nSize, size_t nCou
         "Writing data: file_obj=%r, buff_view=%r, buffer_len=%r",
         file_obj,
         buff_view,
-        buffer_len)
+        buffer_len
+    )
     try:
         num = file_obj.write(buff_view)
     except TypeError:
@@ -300,6 +301,16 @@ cdef int pyopener_flush(void *pFile) with gil:
     log.debug("Flushing: file_obj=%r", file_obj)
     try:
         file_obj.flush()
+        return 0
+    except AttributeError:
+        return 1
+
+
+cdef int pyopener_truncate(void *pFile, vsi_l_offset size) with gil:
+    cdef object file_obj = <object>pFile
+    log.debug("Truncating: file_obj=%r, size=%r", file_obj, size)
+    try:
+        file_obj.truncate(size)
         return 0
     except AttributeError:
         return 1
@@ -372,6 +383,7 @@ def _opener_registration(urlpath, obj):
             callbacks_struct.read = <VSIFilesystemPluginReadCallback>pyopener_read
             callbacks_struct.write = <VSIFilesystemPluginWriteCallback>pyopener_write
             callbacks_struct.flush = <VSIFilesystemPluginFlushCallback>pyopener_flush
+            callbacks_struct.truncate = <VSIFilesystemPluginTruncateCallback>pyopener_truncate
             callbacks_struct.close = <VSIFilesystemPluginCloseCallback>pyopener_close
             callbacks_struct.read_dir = <VSIFilesystemPluginReadDirCallback>pyopener_read_dir
             callbacks_struct.stat = <VSIFilesystemPluginStatCallback>pyopener_stat

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -256,7 +256,7 @@ def test_warp(tmp_path):
 def test_opener_fsspec_fs_tiff_threads():
     """Fsspec filesystem opener is compatible with multithreaded tiff decoding."""
     fs = fsspec.filesystem("file")
-    with rasterio.open("tests/data/RGB.byte.tif", opener=fs, num_threads=2) as src:
+    with rasterio.open("tests/data/rgb_lzw.tif", opener=fs, num_threads=2) as src:
         profile = src.profile
         assert profile["driver"] == "GTiff"
         assert profile["count"] == 3
@@ -267,7 +267,7 @@ def test_opener_fsspec_fs_tiff_threads_2():
     """Fsspec filesystem opener is compatible with multithreaded tiff decoding."""
     fs = fsspec.filesystem("file")
     with rasterio.Env(GDAL_NUM_THREADS=2):
-        with rasterio.open("tests/data/RGB.byte.tif", opener=fs) as src:
+        with rasterio.open("tests/data/rgb_lzw.tif", opener=fs) as src:
             profile = src.profile
             assert profile["driver"] == "GTiff"
             assert profile["count"] == 3

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -2246,6 +2246,7 @@ def test_geoloc_warp_dataset(data, tmp_path):
                 src_crs=src.crs,
                 src_geoloc_array=np.stack((xs, ys)),
                 resampling=Resampling.bilinear,
+                num_threads=2,
             )
 
     with rasterio.open(tmp_path.joinpath("test.tif")) as dst:


### PR DESCRIPTION
Follow up to #3113.

Building overviews with multiple GDAL threads results in a deadlock. There is no such deadlock for multithreaded warping or TIFF decompression.

Implementation of `truncate()` was required by the warper, and probably by other untested features/drivers.