### PR TITLE
Python file opener VSI plugin: read-multi-range support 

### DIFF
--- a/rasterio/abc.py
+++ b/rasterio/abc.py
@@ -1,3 +1,3 @@
 """Abstract base classes."""
 
-from rasterio._vsiopener import FileContainer, MultiByteRangeResourceContainer
+from rasterio._vsiopener import FileContainer, MultiByteRangeResourceContainer  # noqa: F401

--- a/rasterio/abc.py
+++ b/rasterio/abc.py
@@ -1,0 +1,3 @@
+"""Abstract base classes."""
+
+from rasterio._vsiopener import FileContainer, MultiByteRangeResourceContainer

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -352,7 +352,7 @@ def test_opener_multi_range_read_err():
         def read_multi_range(self):
             return True
 
-    with rasterio.open("tests/data/RGB.byte.tif", opener=VSIOpener) as src:
+    with rasterio.open("tests/data/RGB.byte.tif", opener=VSIOpener()) as src:
         profile = src.profile
         assert profile["driver"] == "GTiff"
         assert profile["count"] == 3

--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -2,6 +2,7 @@
 
 import io
 import os
+import warnings
 from pathlib import Path
 from threading import Thread
 import zipfile
@@ -15,6 +16,7 @@ import rasterio
 from rasterio.enums import MaskFlags
 from rasterio.errors import OpenerRegistrationError
 from rasterio.warp import reproject
+from rasterio._vsiopener import _AbstractOpener
 
 
 def test_opener_failure():
@@ -272,3 +274,86 @@ def test_opener_fsspec_fs_tiff_threads_2():
             assert profile["driver"] == "GTiff"
             assert profile["count"] == 3
             assert src.read().shape == (3, 718, 791)
+
+
+def test_opener_multi_range_read():
+    """Test with Opener with multi-range-read method."""
+
+    class Opener(io.FileIO):
+        """Custom FileIO FS with `read_multi_range` method."""
+        def read_multi_range(
+            self,
+            nranges,
+            offsets,
+            sizes,
+        ):
+            warnings.warn("Using MultiRange Reads", UserWarning, stacklevel=2)
+            return [
+                self._read_range(offset, size) for (offset, size) in zip(offsets, sizes)
+            ]
+
+        def _read_range(self, offset, size):
+            _ = self.seek(offset)
+            return self.read(size)
+
+    class VSIOpener(_AbstractOpener):
+        """SubClass of _AbstractOpener with `read_multi_range` attribute."""
+        def __init__(self):
+            self._obj = Opener
+        def open(self, path, mode="r", **kwds):
+            return self._obj(path, mode=mode, **kwds)
+        def isfile(self, path):
+            return True
+        def isdir(self, path):
+            return False
+        def ls(self, path):
+            return []
+        def mtime(self, path):
+            return 0
+        def size(self, path):
+            with self._obj(path) as f:
+                return f.size()
+        def read_multi_range(self):
+            return True
+
+
+    with rasterio.open("tests/data/RGB.byte.tif", opener=VSIOpener()) as src:
+        profile = src.profile
+        assert profile["driver"] == "GTiff"
+        assert profile["count"] == 3
+        # Should emit a multi-range read
+        with pytest.warns(UserWarning, match="Using MultiRange Reads"):
+            _ = src.read()
+
+
+def test_opener_multi_range_read_err():
+    """Test with Opener without multi-range-read method. """
+
+    class VSIOpener(_AbstractOpener):
+        """SubClass of _AbstractOpener with `read_multi_range` attribute.
+
+        The class will have the read_multi_range attr, but the file handler won't have it.
+        """
+        def __init__(self):
+            self._obj = io.FileIO
+        def open(self, path, mode="r", **kwds):
+            return self._obj(path, mode=mode, **kwds)
+        def isfile(self, path):
+            return True
+        def isdir(self, path):
+            return False
+        def ls(self, path):
+            return []
+        def mtime(self, path):
+            return 0
+        def size(self, path):
+            with self._obj(path) as f:
+                return f.size()
+        def read_multi_range(self):
+            return True
+
+    with rasterio.open("tests/data/RGB.byte.tif", opener=VSIOpener) as src:
+        profile = src.profile
+        assert profile["driver"] == "GTiff"
+        assert profile["count"] == 3
+        arr = src.read()


### PR DESCRIPTION
another take at #2969

GDAL provide a method to fetch [multiple range requests](https://github.com/OSGeo/gdal/blob/dd3396b45944799ed6492267c2754f26f635a7dc/port/cpl_vsil_plugin.cpp#L259-L341) (when supported by the driver) in the VSI plugin. 

Without this, all drivers will make single (non-merged) range requests when using a VSIPlugin, meaning that when using vsi opener, the GTIFF driver will emit a ton of GET requests instead of one `merged` request (see https://github.com/rasterio/rasterio/pull/2969#issuecomment-1814298097, https://github.com/rasterio/rasterio/pull/2969#issuecomment-1830365788)

This PR does:
- add `hasattr(opener, "read_multi_range")` check when registering the Opener object, and add a `VSIFilesystemPluginReadMultiRangeCallback` is found.
- add `pyopener_read_multi_range` method 

The previous argument for closing #2969 where that no `usual` filesystem are supporting `merged_range_request`, but as proven in https://github.com/rasterio/rasterio/pull/2969#issuecomment-1814298097, without the `read_multi_range`, using `vsiplugin` could be quite inefficient for non-local filesystem. 

Note: examples of a library implementing `read_multi_range` method can be found at https://github.com/vincentsarago/vsifile