### PR TITLE
ENH: enable support for extra dtypes in features.shapes: int8 and float64

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -16,6 +16,10 @@ Bug fixes:
   calc() and merge() have been added (#3073, #3076). This constrains memory
   use as originally intended.
 
+Other changes:
+
+- Enable support for extra dtypes in features.shapes: int8, float64 (#3125).
+
 1.4a3 (2024-04-16)
 ------------------
 

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -10,6 +10,7 @@ from rasterio.enums import MergeAlg
 
 from rasterio._err cimport exc_wrap_int, exc_wrap_pointer
 from rasterio._io cimport DatasetReaderBase, MemoryDataset, io_auto
+from rasterio.env import GDALVersion
 
 
 log = logging.getLogger(__name__)
@@ -62,7 +63,9 @@ def _shapes(image, mask, connectivity, transform):
     is_float = _getnpdtype(image.dtype).kind == "f"
     fieldtp = 2 if is_float else 0
 
-    valid_dtypes = ("int8", "int16", "int32", "uint8", "uint16", "float32", "float64")
+    valid_dtypes = ("int16", "int32", "uint8", "uint16", "float32", "float64")
+    if GDALVersion.runtime().at_least("3.7"):
+        valid_dtypes += ("int8",)
 
     if _getnpdtype(image.dtype).name not in valid_dtypes:
         raise ValueError("image dtype must be one of: {0}".format(

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -23,8 +23,8 @@ def _shapes(image, mask, connectivity, transform):
     Parameters
     ----------
     image : array or dataset object opened in 'r' mode or Band or tuple(dataset, bidx)
-        Data type must be one of rasterio.int16, rasterio.int32,
-        rasterio.uint8, rasterio.uint16, or rasterio.float32.
+        Data type must be one of rasterio.int8, rasterio.int16, rasterio.int32,
+        rasterio.uint8, rasterio.uint16, rasterio.float32, or rasterio.float64.
     mask : numpy.ndarray or rasterio Band object
         Values of False or 0 will be excluded from feature generation
         Must evaluate to bool (rasterio.bool_ or rasterio.uint8)

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -62,7 +62,7 @@ def _shapes(image, mask, connectivity, transform):
     is_float = _getnpdtype(image.dtype).kind == "f"
     fieldtp = 2 if is_float else 0
 
-    valid_dtypes = ('int16', 'int32', 'uint8', 'uint16', 'float32')
+    valid_dtypes = ("int8", "int16", "int32", "uint8", "uint16", "float32", "float64")
 
     if _getnpdtype(image.dtype).name not in valid_dtypes:
         raise ValueError("image dtype must be one of: {0}".format(

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -80,8 +80,8 @@ def shapes(source, mask=None, connectivity=4, transform=IDENTITY):
     Parameters
     ----------
     source : numpy.ndarray, dataset object, Band, or tuple(dataset, bidx)
-        Data type must be one of rasterio.int16, rasterio.int32,
-        rasterio.uint8, rasterio.uint16, or rasterio.float32.
+        Data type must be one of rasterio.int8, rasterio.int16, rasterio.int32,
+        rasterio.uint8, rasterio.uint16, rasterio.float32, or rasterio.float64.
     mask : numpy.ndarray or rasterio Band object, optional
         Must evaluate to bool (rasterio.bool_ or rasterio.uint8). Values
         of False or 0 will be excluded from feature generation.  Note

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -668,12 +668,15 @@ requires_gdal35 = pytest.mark.skipif(
     reason="Requires GDAL 3.5.x")
 
 requires_gdal37 = pytest.mark.skipif(
-    not gdal_version.at_least('3.7'),
-    reason="Requires GDAL 3.7.x")
+    not gdal_version.at_least('3.7'), reason="Requires GDAL 3.7.x"
+)
 
 requires_gdal_lt_35 = pytest.mark.skipif(
-    gdal_version.at_least('3.5'),
-    reason="Requires GDAL before 3.5",
+    gdal_version.at_least('3.5'), reason="Requires GDAL before 3.5"
+)
+
+requires_gdal_lt_37 = pytest.mark.skipif(
+    gdal_version.at_least('3.7'), reason="Requires GDAL before 3.7"
 )
 
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -667,6 +667,10 @@ requires_gdal35 = pytest.mark.skipif(
     not gdal_version.at_least('3.5'),
     reason="Requires GDAL 3.5.x")
 
+requires_gdal37 = pytest.mark.skipif(
+    not gdal_version.at_least('3.7'),
+    reason="Requires GDAL 3.7.x")
+
 requires_gdal_lt_35 = pytest.mark.skipif(
     gdal_version.at_least('3.5'),
     reason="Requires GDAL before 3.5",

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -13,7 +13,9 @@ from rasterio.features import (
     bounds, geometry_mask, geometry_window, is_valid_geom, rasterize, sieve,
     shapes)
 
-from .conftest import MockGeoInterface, gdal_version, requires_gdal37
+from .conftest import (
+    MockGeoInterface, gdal_version, requires_gdal_lt_37, requires_gdal37
+)
 
 DEFAULT_SHAPE = (10, 10)
 
@@ -1018,7 +1020,12 @@ def test_shapes_supported_dtypes(basic_image, dtype, test_value):
 
 @pytest.mark.parametrize(
     "dtype, test_value",
-    [("uint32", 4294967295), ("int64", 20439845334323), ("float16", -9343.232)],
+    [
+        pytest.param("int8", -127, marks=requires_gdal_lt_37),
+        ("uint32", 4294967295),
+        ("int64", 20439845334323),
+        ("float16", -9343.232),
+    ],
 )
 def test_shapes_unsupported_dtypes(basic_image, dtype, test_value):
     """Unsupported data types should raise exceptions."""

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -998,34 +998,32 @@ def test_shapes_invalid_mask_dtype(basic_image):
             ))
 
 
-def test_shapes_supported_dtypes(basic_image):
+@pytest.mark.parametrize(
+    "dtype, test_value",
+    [
+        ("int8", -127),
+        ("int16", -32768),
+        ("int32", -2147483648),
+        ("uint8", 255),
+        ("uint16", 65535),
+        ("float32", 1.434532),
+        ("float64", 1.434532),
+    ],
+)
+def test_shapes_supported_dtypes(basic_image, dtype, test_value):
     """Supported data types should return valid results."""
-    supported_types = (
-        ('int16', -32768),
-        ('int32', -2147483648),
-        ('uint8', 255),
-        ('uint16', 65535),
-        ('float32', 1.434532)
-    )
-
-    for dtype, test_value in supported_types:
-        shape, value = next(shapes(basic_image.astype(dtype) * test_value))
-        assert np.allclose(value, test_value)
+    shape, value = next(shapes(basic_image.astype(dtype) * test_value))
+    assert np.allclose(value, test_value)
 
 
-def test_shapes_unsupported_dtypes(basic_image):
+@pytest.mark.parametrize(
+    "dtype, test_value",
+    [("uint32", 4294967295), ("int64", 20439845334323), ("float16", -9343.232)],
+)
+def test_shapes_unsupported_dtypes(basic_image, dtype, test_value):
     """Unsupported data types should raise exceptions."""
-    unsupported_types = (
-        ('int8', -127),
-        ('uint32', 4294967295),
-        ('int64', 20439845334323),
-        ('float16', -9343.232),
-        ('float64', -98332.133422114)
-    )
-
-    for dtype, test_value in unsupported_types:
-        with pytest.raises(ValueError):
-            next(shapes(basic_image.astype(dtype) * test_value))
+    with pytest.raises(ValueError):
+        next(shapes(basic_image.astype(dtype) * test_value))
 
 
 def test_shapes_internal_driver_manager(basic_image):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -13,7 +13,7 @@ from rasterio.features import (
     bounds, geometry_mask, geometry_window, is_valid_geom, rasterize, sieve,
     shapes)
 
-from .conftest import MockGeoInterface, gdal_version
+from .conftest import MockGeoInterface, gdal_version, requires_gdal37
 
 DEFAULT_SHAPE = (10, 10)
 
@@ -1001,7 +1001,7 @@ def test_shapes_invalid_mask_dtype(basic_image):
 @pytest.mark.parametrize(
     "dtype, test_value",
     [
-        ("int8", -127),
+        pytest.param("int8", -127, marks=requires_gdal37),
         ("int16", -32768),
         ("int32", -2147483648),
         ("uint8", 255),


### PR DESCRIPTION
I noticed polygonizing an image of type `float64` isn't supported using `features.shapes`, while `gdal.Polygonize` does.

This PR enables support for the dtypes that were blocked now but do seem to work in practice: `float64`, `int8`.