### PR TITLE
Windows should intersect if they share any point in space.

### DIFF
--- a/rasterio/windows.py
+++ b/rasterio/windows.py
@@ -251,7 +251,7 @@ def _compute_intersection(w1, w2):
 def _intersection(w1, w2):
     """ Compute intersection of window 1 and window 2"""
     coeffs = _compute_intersection(w1, w2)
-    if coeffs[2] > 0 and coeffs[3] > 0:
+    if coeffs[2] >= 0 and coeffs[3] >= 0:
         return Window(*coeffs)
     else:
         raise WindowError(f"Intersection is empty {w1} {w2}")


### PR DESCRIPTION
@sgillies This PR is an attempt to resolve #3111.

Before, two windows intersect if they had any common interior point. This changes that definition to mean that two windows intersect if they share any common point.

For example, the test the PR fails is:
Does `Window(0, 0, 10, 10)` intersect `Window(10, 10, 10, 10)`?

What do you think?