### PR TITLE
Use Decimal objects to calculate exact bounds

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -4,6 +4,7 @@
 
 from collections import defaultdict
 from contextlib import ExitStack
+from decimal import Decimal
 import logging
 import math
 import os
@@ -940,7 +941,11 @@ cdef class DatasetBase:
         width = self.width
         height = self.height
         if b == d == 0:
-            return BoundingBox(c, f + e * height, c + a * width, f)
+            # Use Decimal objects to calculate exact bounds
+            minx = c
+            miny = float(Decimal(str(f)) + Decimal(str(e)) * height)
+            maxx = float(Decimal(str(c)) + Decimal(str(a)) * width)
+            maxy = f
         else:
             c0x, c0y = c, f
             c1x, c1y = self.transform * (0, height)
@@ -948,7 +953,11 @@ cdef class DatasetBase:
             c3x, c3y = self.transform * (width, 0)
             xs = (c0x, c1x, c2x, c3x)
             ys = (c0y, c1y, c2y, c3y)
-            return BoundingBox(min(xs), min(ys), max(xs), max(ys))
+            minx = min(xs)
+            miny = min(ys)
+            maxx = max(xs)
+            maxy = max(ys)
+        return BoundingBox(minx, miny, maxx, maxy)
 
     @property
     def res(self):


### PR DESCRIPTION
With a raster with 0.1 degree resolution and transform:
```
Affine(0.1, 0.0, 163.95,
       0.0, -0.1, -31.95)
```
the bounds are not exactly calculated:
```
BoundingBox(left=163.95, bottom=-49.05, right=180.04999999999998, top=-31.95)
```
This is due to the same reason why `0.3 - 0.1 * 3 != 0`, because of floating point behaviour.

My suggested fix is to to use [`Decimal`](https://docs.python.org/3/library/decimal.html) objects, which yield expected bounds:
```
BoundingBox(left=163.95, bottom=-49.05, right=180.05, top=-31.95)
```
Is this change welcome? If so, then I'll refine this PR further with tests.