### PR TITLE
Use mask as alpha when reprojecting a masked array

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,9 @@ Next (TBD)
 
 Bug fixes:
 
+- When reprojecting a masked array, we now use the mask (reduced) as an alpha
+  band. There is now also an option to create an alpha band in the output, and
+  turn that into a mask when returning a mask array (#).
 - Allow rasterio.open() to receive instances of MemoryFile (#3145).
 - Leaks of CSL string lists in get/set_proj_data_search_path() have been fixed
   (#3140).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -8,7 +8,7 @@ Bug fixes:
 
 - When reprojecting a masked array, we now use the mask (reduced) as an alpha
   band. There is now also an option to create an alpha band in the output, and
-  turn that into a mask when returning a mask array (#).
+  turn that into a mask when returning a mask array (#3156).
 - Allow rasterio.open() to receive instances of MemoryFile (#3145).
 - Leaks of CSL string lists in get/set_proj_data_search_path() have been fixed
   (#3140).

--- a/rasterio/_io.pxd
+++ b/rasterio/_io.pxd
@@ -42,3 +42,5 @@ ctypedef np.float64_t DTYPE_FLOAT64_t
 cdef bint in_dtype_range(value, dtype)
 
 cdef int io_auto(image, GDALRasterBandH band, bint write, int resampling=*) except -1
+cdef int io_band(GDALRasterBandH band, int mode, double x0, double y0, double width, double height, object data, int resampling=*) except -1
+cdef int io_multi_band(GDALDatasetH hds, int mode, double x0, double y0, double width, double height, object data, Py_ssize_t[:] indexes, int resampling=*) except -1

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -381,7 +381,7 @@ def _reproject(
             src_bidx = range(1, src_count + 1)
 
             if hasattr(source, "mask"):
-                mask = ~np.logical_or.reduce(source.mask) * 255
+                mask = ~np.logical_or.reduce(source.mask) * np.uint8(255)
                 source_arr = np.concatenate((source.data, [mask]))
                 src_alpha = src_alpha or source_arr.shape[0]
             else:
@@ -455,7 +455,7 @@ def _reproject(
                 msk = np.logical_or.reduce(destination.mask)
                 if msk == np.ma.nomask:
                     msk = np.zeros((height, width), dtype="bool")
-                msk = ~msk * 255
+                msk = ~msk * np.uint8(255)
                 dest_arr = np.concatenate((destination.data, [msk]))
                 dst_alpha = dst_alpha or dest_arr.shape[0]
             else:

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -367,10 +367,6 @@ def _reproject(
             if not src_crs:
                 raise CRSError("Missing src_crs.")
 
-            if src_nodata is None and hasattr(source, 'fill_value'):
-                # source is a masked array
-                src_nodata = source.fill_value
-
             # ensure data converted to numpy array
             if hasattr(source, "mask"):
                 source = np.ma.asanyarray(source)
@@ -435,12 +431,7 @@ def _reproject(
             if not dst_crs:
                 raise CRSError("Missing dst_crs.")
 
-            if dst_nodata is None:
-                if hasattr(destination, "fill_value"):
-                    # destination is a masked array
-                    dst_nodata = destination.fill_value
-                elif src_nodata is not None:
-                    dst_nodata = src_nodata
+            dst_nodata = dst_nodata or src_nodata
 
             if hasattr(destination, "mask"):
                 destination = np.ma.asanyarray(destination)

--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -172,6 +172,7 @@ def reproject(
     dst_resolution=None,
     src_alpha=0,
     dst_alpha=0,
+    masked=False,
     resampling=Resampling.nearest,
     num_threads=1,
     init_dest_nodata=True,
@@ -250,6 +251,8 @@ def reproject(
         Index of a band to use as the alpha band when warping.
     dst_alpha : int, optional
         Index of a band to use as the alpha band when warping.
+    masked: bool, optional
+        If True and destination is None, return a masked array.
     resampling: int, rasterio.enums.Resampling
         Resampling method to use.
         Default is :attr:`rasterio.enums.Resampling.nearest`.
@@ -378,8 +381,10 @@ def reproject(
             destination = np.empty(
                 (int(dst_count), int(dst_height), int(dst_width)), dtype=source.dtype
             )
+            if masked:
+                destination = np.ma.masked_array(destination).filled(dst_nodata)
 
-    _reproject(
+    dest = _reproject(
         source,
         destination,
         src_transform=src_transform,
@@ -400,7 +405,7 @@ def reproject(
         **kwargs
     )
 
-    return destination, dst_transform
+    return dest, dst_transform
 
 
 def aligned_target(transform, width, height, resolution):

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1338,30 +1338,16 @@ def test_reproject_array_interface(test3d, count_nonzero, path_rgb_byte_tif):
     [
         pytest.param(
             True,
-            1312959,
+            1308064,
             marks=pytest.mark.skipif(
                 not gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
-            ),
-        ),
-        pytest.param(
-            False,
-            438113,
-            marks=pytest.mark.skipif(
-                not gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
-            ),
-        ),
-        pytest.param(
-            True,
-            1308604,
-            marks=pytest.mark.skipif(
-                gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
             ),
         ),
         pytest.param(
             False,
             437686,
             marks=pytest.mark.skipif(
-                gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
+                not gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
             ),
         ),
     ],
@@ -1404,21 +1390,7 @@ def test_reproject_masked(test3d, count_nonzero, path_rgb_byte_tif):
                 not gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
             ),
         ),
-        pytest.param(
-            True,
-            1308604,
-            marks=pytest.mark.skipif(
-                gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
-            ),
-        ),
-        pytest.param(
-            False,
-            437686,
-            marks=pytest.mark.skipif(
-                gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
-            ),
-        ),
-    ],
+    ]
 )
 def test_reproject_masked_masked_output(test3d, count_nonzero, path_rgb_byte_tif):
     with rasterio.open(path_rgb_byte_tif) as src:
@@ -1434,7 +1406,6 @@ def test_reproject_masked_masked_output(test3d, count_nonzero, path_rgb_byte_tif
         src_crs=src.crs,
         dst_transform=DST_TRANSFORM,
         dst_crs="EPSG:3857",
-        dst_nodata=99,
     )
     assert np.count_nonzero(out[out != np.ma.masked]) == count_nonzero
 

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1333,7 +1333,7 @@ def test_reproject_array_interface(test3d, count_nonzero, path_rgb_byte_tif):
     assert np.count_nonzero(out.data[out.data != 99]) == count_nonzero
 
 
-@pytest.mark.parametrize("test3d,count_nonzero", [(True, 1309625), (False, 437686)])
+@pytest.mark.parametrize("test3d,count_nonzero", [(True, 1312959), (False, 438113)])
 def test_reproject_masked(test3d, count_nonzero, path_rgb_byte_tif):
     with rasterio.open(path_rgb_byte_tif) as src:
         if test3d:
@@ -1352,6 +1352,27 @@ def test_reproject_masked(test3d, count_nonzero, path_rgb_byte_tif):
     )
     assert np.ma.is_masked(source)
     assert np.count_nonzero(out[out != 99]) == count_nonzero
+    assert not np.ma.is_masked(out)
+
+
+@pytest.mark.parametrize("test3d,count_nonzero", [(True, 1312959), (False, 438113)])
+def test_reproject_masked_masked_output(test3d, count_nonzero, path_rgb_byte_tif):
+    with rasterio.open(path_rgb_byte_tif) as src:
+        if test3d:
+            inp = src.read(masked=True)
+        else:
+            inp = src.read(1, masked=True)
+    out = np.ma.masked_array(np.empty(inp.shape, dtype=np.uint8))
+    out, _ = reproject(
+        inp,
+        out,
+        src_transform=src.transform,
+        src_crs=src.crs,
+        dst_transform=DST_TRANSFORM,
+        dst_crs="EPSG:3857",
+        dst_nodata=99,
+    )
+    assert np.count_nonzero(out[out != np.ma.masked]) == count_nonzero
 
 
 @pytest.mark.parametrize("method", SUPPORTED_RESAMPLING)

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1333,7 +1333,39 @@ def test_reproject_array_interface(test3d, count_nonzero, path_rgb_byte_tif):
     assert np.count_nonzero(out.data[out.data != 99]) == count_nonzero
 
 
-@pytest.mark.parametrize("test3d,count_nonzero", [(True, 1312959), (False, 438113)])
+@pytest.mark.parametrize(
+    "test3d,count_nonzero",
+    [
+        pytest.param(
+            True,
+            1312959,
+            marks=pytest.mark.skipif(
+                not gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
+            ),
+        ),
+        pytest.param(
+            False,
+            438113,
+            marks=pytest.mark.skipif(
+                not gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
+            ),
+        ),
+        pytest.param(
+            True,
+            1308604,
+            marks=pytest.mark.skipif(
+                gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
+            ),
+        ),
+        pytest.param(
+            False,
+            437686,
+            marks=pytest.mark.skipif(
+                gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
+            ),
+        ),
+    ],
+)
 def test_reproject_masked(test3d, count_nonzero, path_rgb_byte_tif):
     with rasterio.open(path_rgb_byte_tif) as src:
         if test3d:
@@ -1355,7 +1387,39 @@ def test_reproject_masked(test3d, count_nonzero, path_rgb_byte_tif):
     assert not np.ma.is_masked(out)
 
 
-@pytest.mark.parametrize("test3d,count_nonzero", [(True, 1312959), (False, 438113)])
+@pytest.mark.parametrize(
+    "test3d,count_nonzero",
+    [
+        pytest.param(
+            True,
+            1312959,
+            marks=pytest.mark.skipif(
+                not gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
+            ),
+        ),
+        pytest.param(
+            False,
+            438113,
+            marks=pytest.mark.skipif(
+                not gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
+            ),
+        ),
+        pytest.param(
+            True,
+            1308604,
+            marks=pytest.mark.skipif(
+                gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
+            ),
+        ),
+        pytest.param(
+            False,
+            437686,
+            marks=pytest.mark.skipif(
+                gdal_version.at_least("3.8"), reason="Requires GDAL 3.8.x"
+            ),
+        ),
+    ],
+)
 def test_reproject_masked_masked_output(test3d, count_nonzero, path_rgb_byte_tif):
     with rasterio.open(path_rgb_byte_tif) as src:
         if test3d:


### PR DESCRIPTION
Background: `reproject()` can take an array and return an array. GDAL's warper requires input and output GDALDatasetH, so we construct them using the GDAL "MEM" driver, pointing at the memory location of two arrays.

What this PR does is add alpha bands to those datasets when the inputs and outputs are masked arrays. For input, 3-D array masks are reduced to a 2-D array via `logical_or()` (because GDAL needs a single alpha mask channel). For output, the alpha mask band is repeated over the number of image bands.

I suspect the approach could be made more efficient. Copying is required in some cases because the "MEM" driver needs a precise memory layout.

Resolves #2575.