### PR TITLE
Use gdalvrt.xsd as a marker for GDAL's data directory

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ Next (TBD)
 
 Bug fixes:
 
+- Find installed GDAL data directory by searching for gdalvrt.xsd (#).
 - Allow rasterio.open() to receive instances of MemoryFile (#3145).
 - Leaks of CSL string lists in get/set_proj_data_search_path() have been fixed
   (#3140).

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,7 +6,7 @@ Next (TBD)
 
 Bug fixes:
 
-- Find installed GDAL data directory by searching for gdalvrt.xsd (#).
+- Find installed GDAL data directory by searching for gdalvrt.xsd (#3157).
 - Allow rasterio.open() to receive instances of MemoryFile (#3145).
 - Leaks of CSL string lists in get/set_proj_data_search_path() have been fixed
   (#3140).

--- a/rasterio/_env.pyx
+++ b/rasterio/_env.pyx
@@ -238,7 +238,7 @@ class GDALDataFinder:
         Parameters
         ----------
         basename : str
-            Basename of a data file such as "header.dxf"
+            Basename of a data file such as "gdalvrt.xsd"
 
         Returns
         -------
@@ -276,18 +276,18 @@ class GDALDataFinder:
         if prefix is None:
             prefix = __file__
         datadir = os.path.abspath(os.path.join(os.path.dirname(prefix), "gdal_data"))
-        return datadir if os.path.exists(os.path.join(datadir, 'header.dxf')) else None
+        return datadir if os.path.exists(os.path.join(datadir, 'gdalvrt.xsd')) else None
 
     def search_prefix(self, prefix=sys.prefix):
         """Check sys.prefix location"""
         datadir = os.path.join(prefix, 'share', 'gdal')
-        return datadir if os.path.exists(os.path.join(datadir, 'header.dxf')) else None
+        return datadir if os.path.exists(os.path.join(datadir, 'gdalvrt.xsd')) else None
 
     def search_debian(self, prefix=sys.prefix):
         """Check Debian locations"""
         gdal_release_name = gdal_version()
         datadir = os.path.join(prefix, 'share', 'gdal', '{}.{}'.format(*gdal_release_name.split('.')[:2]))
-        return datadir if os.path.exists(os.path.join(datadir, 'header.dxf')) else None
+        return datadir if os.path.exists(os.path.join(datadir, 'gdalvrt.xsd')) else None
 
 
 @contextmanager
@@ -390,7 +390,7 @@ cdef class GDALEnv(ConfigEnv):
                             self.update_config_options(GDAL_DATA=path)
 
                         # See https://github.com/rasterio/rasterio/issues/1631.
-                        elif GDALDataFinder().find_file("header.dxf"):
+                        elif GDALDataFinder().find_file("gdalvrt.xsd"):
                             log.debug("GDAL data files are available at built-in paths.")
 
                         else:

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -661,7 +661,7 @@ if 'GDAL_DATA' not in os.environ:
         set_gdal_config("GDAL_DATA", path)
 
     # See https://github.com/rasterio/rasterio/issues/1631.
-    elif GDALDataFinder().find_file("header.dxf"):
+    elif GDALDataFinder().find_file("gdalvrt.xsd"):
         log.debug("GDAL data files are available at built-in paths.")
 
     else:

--- a/tests/test__env.py
+++ b/tests/test__env.py
@@ -18,7 +18,7 @@ def mock_wheel(tmpdir):
     moduledir = tmpdir.mkdir("rasterio")
     moduledir.ensure("__init__.py")
     moduledir.ensure("_env.py")
-    moduledir.ensure("gdal_data/header.dxf")
+    moduledir.ensure("gdal_data/gdalvrt.xsd")
     moduledir.ensure("proj_data/epsg")
     return moduledir
 
@@ -26,7 +26,7 @@ def mock_wheel(tmpdir):
 @pytest.fixture
 def mock_fhs(tmpdir):
     """A fake FHS system"""
-    tmpdir.ensure("share/gdal/header.dxf")
+    tmpdir.ensure("share/gdal/gdalvrt.xsd")
     tmpdir.ensure("share/proj/epsg")
     return tmpdir
 
@@ -34,11 +34,11 @@ def mock_fhs(tmpdir):
 @pytest.fixture
 def mock_debian(tmpdir):
     """A fake Debian multi-install system"""
-    tmpdir.ensure("share/gdal/3.3/header.dxf")
-    tmpdir.ensure("share/gdal/3.4/header.dxf")
-    tmpdir.ensure("share/gdal/3.5/header.dxf")
-    tmpdir.ensure("share/gdal/3.6/header.dxf")
-    tmpdir.ensure(f"share/gdal/{gdal_version.major}.{gdal_version.minor}/header.dxf")
+    tmpdir.ensure("share/gdal/3.3/gdalvrt.xsd")
+    tmpdir.ensure("share/gdal/3.4/gdalvrt.xsd")
+    tmpdir.ensure("share/gdal/3.5/gdalvrt.xsd")
+    tmpdir.ensure("share/gdal/3.6/gdalvrt.xsd")
+    tmpdir.ensure(f"share/gdal/{gdal_version.major}.{gdal_version.minor}/gdalvrt.xsd")
     tmpdir.ensure("share/proj/epsg")
     return tmpdir
 

--- a/tests/test_data_paths.py
+++ b/tests/test_data_paths.py
@@ -4,7 +4,7 @@ from rasterio._env import GDALDataFinder, PROJDataFinder
 
 def test_gdal_data_find_file():
     """Find_file shouldn't raise any exceptions"""
-    GDALDataFinder().find_file("header.dxf")
+    GDALDataFinder().find_file("gdalvrt.xsd")
 
 
 def test_proj_data_has_data():

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -129,7 +129,7 @@ def test_ensure_env_decorator_sets_gdal_data_prefix(find_file, gdalenv, monkeypa
 
     find_file.return_value = None
 
-    tmpdir.ensure("share/gdal/header.dxf")
+    tmpdir.ensure("share/gdal/gdalvrt.xsd")
     monkeypatch.delenv('GDAL_DATA', raising=False)
     monkeypatch.setattr(sys, 'prefix', str(tmpdir))
 
@@ -145,7 +145,7 @@ def test_ensure_env_decorator_sets_gdal_data_wheel(find_file, gdalenv, monkeypat
 
     find_file.return_value = None
 
-    tmpdir.ensure("gdal_data/header.dxf")
+    tmpdir.ensure("gdal_data/gdalvrt.xsd")
     monkeypatch.delenv('GDAL_DATA', raising=False)
     monkeypatch.setattr(_env, '__file__', str(tmpdir.join(os.path.basename(_env.__file__))))
 


### PR DESCRIPTION
Because header.dxf (for the OGR DXF driver) isn't packaged with wheels anymore. Resolves #3153