### PR TITLE
Release 1.3.11

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -18,6 +18,8 @@ Wheels on PyPI include recent versions of GDAL, PROJ, Curl, and libjpeg:
 
 Bug fixes:
 
+- Leaks of CSL string lists in get/set_proj_data_search_path() have been fixed
+  (#).
 - Color interpretation is correctly set to "palette" after a colormap is
   written.
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,8 +1,29 @@
 Changes
 =======
 
-1.3.10.post1 (2024-09-03)
--------------------------
+1.3.11 (2024-09-03)
+-------------------
+
+Packaging:
+
+This release allows any Numpy version >=2.0,<3 to be used to build the package.
+That is the only source change.
+
+Wheels on PyPI include recent versions of GDAL, PROJ, Curl, and libjpeg:
+
+* GDAL 3.9.2 (3.9.1 on Windows)
+* PROJ 9.4.1
+* Curl 8.8.0
+* libjpeg 9f
+
+Bug fixes:
+
+- Color interpretation is correctly set to "palette" after a colormap is
+  written.
+
+1.4b1 (2024-08-10)
+------------------
+>>>>>>> a467cbd7 (Properly set color interpretation after writing a colormap (#3136))
 
 This release allows any Numpy version >=2.0,<3 to be used to build the package.
 That is the only source change.

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,19 @@
 Changes
 =======
 
+1.3.10.post1 (2024-09-03)
+-------------------------
+
+This release allows any Numpy version >=2.0,<3 to be used to build the package.
+That is the only source change.
+
+Wheels on PyPI include recent versions of GDAL, PROJ, Curl, and libjpeg:
+
+* GDAL 3.9.2 (3.9.1 on Windows)
+* PROJ 9.4.1
+* Curl 8.8.0
+* libjpeg 9f
+
 1.3.10 (2024-04-10)
 -------------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -23,20 +23,6 @@ Bug fixes:
 - Color interpretation is correctly set to "palette" after a colormap is
   written (backport of #3133).
 
-1.4b1 (2024-08-10)
-------------------
->>>>>>> a467cbd7 (Properly set color interpretation after writing a colormap (#3136))
-
-This release allows any Numpy version >=2.0,<3 to be used to build the package.
-That is the only source change.
-
-Wheels on PyPI include recent versions of GDAL, PROJ, Curl, and libjpeg:
-
-* GDAL 3.9.2 (3.9.1 on Windows)
-* PROJ 9.4.1
-* Curl 8.8.0
-* libjpeg 9f
-
 1.3.10 (2024-04-10)
 -------------------
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -19,9 +19,9 @@ Wheels on PyPI include recent versions of GDAL, PROJ, Curl, and libjpeg:
 Bug fixes:
 
 - Leaks of CSL string lists in get/set_proj_data_search_path() have been fixed
-  (#).
+  (backport of #3140).
 - Color interpretation is correctly set to "palette" after a colormap is
-  written.
+  written (backport of #3133).
 
 1.4b1 (2024-08-10)
 ------------------

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 ARG GDAL=ubuntu-small-3.3.3
 ARG PYTHON_VERSION=3.8
-FROM osgeo/gdal:${GDAL} AS gdal
+FROM ghcr.io/osgeo/gdal:${GDAL} AS gdal
 ARG PYTHON_VERSION
 ENV LANG="C.UTF-8" LC_ALL="C.UTF-8"
 RUN apt-get update && apt-get install -y software-properties-common

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=67.8",
     "wheel",
     "cython~=3.0.2",
-    "numpy>=2.0.0,<3; python_version >= '3.9'",
+    "numpy>=2.0.0,<3.0; python_version >= '3.9'",
     "oldest-supported-numpy; python_version < '3.9'"
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,7 +3,7 @@ requires = [
     "setuptools>=67.8",
     "wheel",
     "cython~=3.0.2",
-    "numpy==2.0.0rc1; python_version >= '3.9'",
+    "numpy>=2.0.0,<3; python_version >= '3.9'",
     "oldest-supported-numpy; python_version < '3.9'"
 ]
 

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -81,7 +81,7 @@ except ImportError:
     have_vsi_plugin = False
 
 __all__ = ['band', 'open', 'pad', 'Env', 'CRS']
-__version__ = "1.3.10.post1"
+__version__ = "1.3.11"
 __gdal_version__ = gdal_version()
 __proj_version__ = ".".join([str(version) for version in get_proj_version()])
 __geos_version__ = ".".join([str(version) for version in get_geos_version()])

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -81,7 +81,7 @@ except ImportError:
     have_vsi_plugin = False
 
 __all__ = ['band', 'open', 'pad', 'Env', 'CRS']
-__version__ = "1.3.11"
+__version__ = "1.3.12.dev"
 __gdal_version__ = gdal_version()
 __proj_version__ = ".".join([str(version) for version in get_proj_version()])
 __geos_version__ = ".".join([str(version) for version in get_geos_version()])

--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -81,7 +81,7 @@ except ImportError:
     have_vsi_plugin = False
 
 __all__ = ['band', 'open', 'pad', 'Env', 'CRS']
-__version__ = "1.3.10"
+__version__ = "1.3.10.post1"
 __gdal_version__ = gdal_version()
 __proj_version__ = ".".join([str(version) for version in get_proj_version()])
 __geos_version__ = ".".join([str(version) for version in get_geos_version()])

--- a/rasterio/_env.pyx
+++ b/rasterio/_env.pyx
@@ -225,7 +225,7 @@ class GDALDataFinder:
         Parameters
         ----------
         basename : str
-            Basename of a data file such as "header.dxf"
+            Basename of a data file such as "gdalvrt.xsd"
 
         Returns
         -------
@@ -263,18 +263,18 @@ class GDALDataFinder:
         if prefix is None:
             prefix = __file__
         datadir = os.path.abspath(os.path.join(os.path.dirname(prefix), "gdal_data"))
-        return datadir if os.path.exists(os.path.join(datadir, 'header.dxf')) else None
+        return datadir if os.path.exists(os.path.join(datadir, 'gdalvrt.xsd')) else None
 
     def search_prefix(self, prefix=sys.prefix):
         """Check sys.prefix location"""
         datadir = os.path.join(prefix, 'share', 'gdal')
-        return datadir if os.path.exists(os.path.join(datadir, 'header.dxf')) else None
+        return datadir if os.path.exists(os.path.join(datadir, 'gdalvrt.xsd')) else None
 
     def search_debian(self, prefix=sys.prefix):
         """Check Debian locations"""
         gdal_release_name = gdal_version()
         datadir = os.path.join(prefix, 'share', 'gdal', '{}.{}'.format(*gdal_release_name.split('.')[:2]))
-        return datadir if os.path.exists(os.path.join(datadir, 'header.dxf')) else None
+        return datadir if os.path.exists(os.path.join(datadir, 'gdalvrt.xsd')) else None
 
 
 @contextmanager
@@ -377,7 +377,7 @@ cdef class GDALEnv(ConfigEnv):
                             self.update_config_options(GDAL_DATA=path)
 
                         # See https://github.com/rasterio/rasterio/issues/1631.
-                        elif GDALDataFinder().find_file("header.dxf"):
+                        elif GDALDataFinder().find_file("gdalvrt.xsd"):
                             log.debug("GDAL data files are available at built-in paths.")
 
                         else:

--- a/rasterio/_env.pyx
+++ b/rasterio/_env.pyx
@@ -460,20 +460,19 @@ cdef class GDALEnv(ConfigEnv):
 
 
 def set_proj_data_search_path(path):
-    """Set PROJ data search path"""
-    cdef char **paths = NULL
-    cdef const char *path_c = NULL
+    """Set PROJ data search path."""
     path_b = path.encode("utf-8")
-    path_c = path_b
-    paths = CSLAddString(paths, path_c)
-    OSRSetPROJSearchPaths(<const char *const *>paths)
+    cdef const char *path_c = path_b
+    cdef char **paths = CSLAddString(NULL, path_c)
+    try:
+        OSRSetPROJSearchPaths(<const char *const *>paths)
+    finally:
+        CSLDestroy(paths)
 
 
 def get_proj_data_search_paths():
     """
-    Get the PROJ DATA search paths
-
-    Requires GDAL 3.0.3+
+    Get the PROJ DATA search paths.
 
     Returns
     -------
@@ -485,12 +484,14 @@ def get_proj_data_search_paths():
     while paths[iii] != NULL:
         path_list.append(paths[iii])
         iii += 1
-    return path_list
-
+    try:
+        return path_list
+    finally:
+        CSLDestroy(paths)
 
 def get_gdal_data():
     """
-    Get the GDAL DATA path
+    Get the GDAL DATA path.
 
     Returns
     -------

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1926,7 +1926,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                 GDALSetColorEntry(hTable, i, &color)
 
             # TODO: other color interpretations?
-            GDALSetRasterColorInterpretation(hBand, <GDALColorInterp>1)
+            GDALSetRasterColorInterpretation(hBand, GCI_PaletteIndex)
             GDALSetRasterColorTable(hBand, hTable)
 
         finally:

--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -368,7 +368,7 @@ def _reproject(
                 # source is a masked array
                 src_nodata = source.fill_value
             # ensure data converted to numpy array
-            source = np.array(source, copy=False)
+            source = np.asarray(source)
             # Convert 2D single-band arrays to 3D multi-band.
             if len(source.shape) == 2:
                 source = source.reshape(1, *source.shape)
@@ -410,7 +410,7 @@ def _reproject(
             if not dst_crs:
                 raise CRSError("Missing dst_crs.")
             # ensure data converted to numpy array
-            destination = np.array(destination, copy=False)
+            destination = np.asarray(destination)
             if len(destination.shape) == 2:
                 destination = destination.reshape(1, *destination.shape)
 

--- a/rasterio/env.py
+++ b/rasterio/env.py
@@ -645,7 +645,7 @@ if 'GDAL_DATA' not in os.environ:
         set_gdal_config("GDAL_DATA", path)
 
     # See https://github.com/rasterio/rasterio/issues/1631.
-    elif GDALDataFinder().find_file("header.dxf"):
+    elif GDALDataFinder().find_file("gdalvrt.xsd"):
         log.debug("GDAL data files are available at built-in paths.")
 
     else:

--- a/tests/test__env.py
+++ b/tests/test__env.py
@@ -19,7 +19,7 @@ def mock_wheel(tmpdir):
     moduledir = tmpdir.mkdir("rasterio")
     moduledir.ensure("__init__.py")
     moduledir.ensure("_env.py")
-    moduledir.ensure("gdal_data/header.dxf")
+    moduledir.ensure("gdal_data/gdalvrt.xsd")
     moduledir.ensure("proj_data/epsg")
     return moduledir
 
@@ -27,7 +27,7 @@ def mock_wheel(tmpdir):
 @pytest.fixture
 def mock_fhs(tmpdir):
     """A fake FHS system"""
-    tmpdir.ensure("share/gdal/header.dxf")
+    tmpdir.ensure("share/gdal/gdalvrt.xsd")
     tmpdir.ensure("share/proj/epsg")
     return tmpdir
 
@@ -35,13 +35,13 @@ def mock_fhs(tmpdir):
 @pytest.fixture
 def mock_debian(tmpdir):
     """A fake Debian multi-install system"""
-    tmpdir.ensure("share/gdal/3.1/header.dxf")
-    tmpdir.ensure("share/gdal/3.2/header.dxf")
-    tmpdir.ensure("share/gdal/3.3/header.dxf")
-    tmpdir.ensure("share/gdal/3.4/header.dxf")
-    tmpdir.ensure("share/gdal/3.5/header.dxf")
-    tmpdir.ensure("share/gdal/3.6/header.dxf")
-    tmpdir.ensure(f"share/gdal/{gdal_version.major}.{gdal_version.minor}/header.dxf")
+    tmpdir.ensure("share/gdal/3.1/gdalvrt.xsd")
+    tmpdir.ensure("share/gdal/3.2/gdalvrt.xsd")
+    tmpdir.ensure("share/gdal/3.3/gdalvrt.xsd")
+    tmpdir.ensure("share/gdal/3.4/gdalvrt.xsd")
+    tmpdir.ensure("share/gdal/3.5/gdalvrt.xsd")
+    tmpdir.ensure("share/gdal/3.6/gdalvrt.xsd")
+    tmpdir.ensure(f"share/gdal/{gdal_version.major}.{gdal_version.minor}/gdalvrt.xsd")
     tmpdir.ensure("share/proj/epsg")
     return tmpdir
 

--- a/tests/test_data_paths.py
+++ b/tests/test_data_paths.py
@@ -4,7 +4,7 @@ from rasterio._env import GDALDataFinder, PROJDataFinder
 
 def test_gdal_data_find_file():
     """Find_file shouldn't raise any exceptions"""
-    GDALDataFinder().find_file("header.dxf")
+    GDALDataFinder().find_file("gdalvrt.xsd")
 
 
 def test_proj_data_has_data():

--- a/tests/test_env.py
+++ b/tests/test_env.py
@@ -128,7 +128,7 @@ def test_ensure_env_decorator_sets_gdal_data_prefix(find_file, gdalenv, monkeypa
 
     find_file.return_value = None
 
-    tmpdir.ensure("share/gdal/header.dxf")
+    tmpdir.ensure("share/gdal/gdalvrt.xsd")
     monkeypatch.delenv('GDAL_DATA', raising=False)
     monkeypatch.setattr(sys, 'prefix', str(tmpdir))
 
@@ -144,7 +144,7 @@ def test_ensure_env_decorator_sets_gdal_data_wheel(find_file, gdalenv, monkeypat
 
     find_file.return_value = None
 
-    tmpdir.ensure("gdal_data/header.dxf")
+    tmpdir.ensure("gdal_data/gdalvrt.xsd")
     monkeypatch.delenv('GDAL_DATA', raising=False)
     monkeypatch.setattr(_env, '__file__', str(tmpdir.join(os.path.basename(_env.__file__))))
 

--- a/tests/test_mask_creation.py
+++ b/tests/test_mask_creation.py
@@ -10,6 +10,8 @@ from rasterio.enums import MaskFlags
 from rasterio.errors import RasterioIOError
 from rasterio.windows import Window
 
+from .conftest import gdal_version
+
 
 def test_create_internal_mask(data):
     """Write an internal mask to the fixture's RGB.byte.tif."""
@@ -32,6 +34,9 @@ def test_create_internal_mask(data):
             assert MaskFlags.nodata not in flags
 
 
+@pytest.mark.xfail(
+    gdal_version.at_least("3.9"), reason="Internal mask are the default since 3.9.0."
+)
 def test_create_sidecar_mask(data):
     """Write a .msk sidecar mask."""
     with rasterio.open(str(data.join('RGB.byte.tif')), 'r+') as dst:

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -10,6 +10,8 @@ import affine
 import rasterio
 from rasterio.merge import merge
 
+from .conftest import gdal_version
+
 # Non-coincident datasets test fixture.
 # Three overlapping GeoTIFFs, two to the NW and one to the SE.
 @pytest.fixture(scope="function")
@@ -57,6 +59,9 @@ def test_merge_method(test_data_dir_overlapping, method, value):
     numpy.testing.assert_array_equal(arr[:, 5:10, 5:10], value)
 
 
+@pytest.mark.xfail(
+    not gdal_version.at_least("3.3"), reason="Unknown issue with GDAL 3.2."
+)
 def test_issue2163():
     """Demonstrate fix for issue 2163"""
     with rasterio.open("tests/data/float_raster_with_nodata.tif") as src:

--- a/tests/test_rio_merge.py
+++ b/tests/test_rio_merge.py
@@ -420,7 +420,6 @@ def test_merge_tiny_base(tiffs, runner):
 
     with rasterio.open(outputname) as src:
         data = src.read()
-        print(data)
         assert (data[0][0:2, 1] == 120).all()
         assert (data[0][0:2, 2:4] == 90).all()
         assert data[0][2][1] == 60
@@ -486,7 +485,7 @@ def test_merge_out_of_range_nodata(tiffs):
 
     with pytest.warns(UserWarning):
         rv, transform = merge(datasets, nodata=9999)
-    assert not (rv == np.uint8(9999)).any()
+
 
 def test_merge_rgb(tmpdir, runner):
     """Get back original image"""
@@ -566,7 +565,7 @@ def test_merge_precision(tmpdir, precision):
         # Compare header lines.
         for i in range(5):
             assert out_file.readline().strip() == expected_file.readline().strip()
-        
+
         # Compare raster data as single strings.
         out_data = " ".join(line.strip() for line in out_file.readlines())
         expected_data = " ".join(line.strip() for line in expected_file.readlines())

--- a/tests/test_update.py
+++ b/tests/test_update.py
@@ -19,8 +19,6 @@ def test_update_tags(data):
             f.update_tags(4, d=4)
         assert f.tags() == {'AREA_OR_POINT': 'Area', 'a': '1', 'b': '2'}
         assert ('c', '3') in f.tags(1).items()
-    info = subprocess.check_output(["gdalinfo", tiffname]).decode('utf-8')
-    assert re.search(r'Metadata:\W+a=1\W+AREA_OR_POINT=Area\W+b=2', info)
 
 
 def test_update_band(data):


### PR DESCRIPTION
Nevermind the branch name. This will be 1.3.11.

The numpy project deleted their 2.0.0rc1 PyPI release and thus 1.3.10 can no longer be built from source. This PR lets numpy versions >=2.0.0,<3 be used to build 1.3.11.

Additions: numpy 2.1 and GDAL 3.9 compatibility, plus backports of #3133 and #3140.