### PR TITLE
TST: Check for lowerCase netCDF instead of NetCDF

### DIFF
--- a/tests/test_rio_info.py
+++ b/tests/test_rio_info.py
@@ -9,7 +9,7 @@ from .conftest import credentials
 
 
 with rasterio.Env() as env:
-    HAVE_NETCDF = 'NetCDF' in env.drivers().keys()
+    HAVE_NETCDF = "netCDF" in env.drivers().keys()
 
 
 def test_env(runner):

--- a/tests/test_subdatasets.py
+++ b/tests/test_subdatasets.py
@@ -3,7 +3,7 @@ import pytest
 import rasterio
 
 with rasterio.Env() as env:
-    HAVE_NETCDF = "NetCDF" in env.drivers().keys()
+    HAVE_NETCDF = "netCDF" in env.drivers().keys()
     HAVE_HDF5 = "HDF5" in env.drivers().keys()
 
 


### PR DESCRIPTION
Some tests were accidentally skipped even though netCDF driver was installed due to incorrect capitalization. Should be `netCDF` instead of `NetCDF`.

```
SKIPPED [1] tests/test_rio_info.py:397: GDAL not compiled with NetCDF driver.
...
SKIPPED [1] tests/test_subdatasets.py:10: GDAL not compiled with NetCDF driver.
```

Sample Output from `with rasterio.Env() as env: print(env.drivers().keys())`

> dict_keys(['VRT', 'GTI', 'DERIVED', 'GTiff', 'COG', 'NITF', 'RPFTOC', 'ECRGTOC', 'HFA', 'SAR_CEOS', 'CEOS', 'JAXAPALSAR', 'GFF', 'ELAS', 'ESRIC', 'AIG', 'AAIGrid', 'GRASSASCIIGrid', 'ISG', 'SDTS', 'DTED', 'PNG', 'JPEG', 'MEM', 'JDEM', 'GIF', 'BIGGIF', 'ESAT', 'FITS', 'BSB', 'XPM', 'BMP', 'DIMAP', 'AirSAR', 'RS2', 'SAFE', 'PCIDSK', 'PCRaster', 'ILWIS', 'SGI', 'SRTMHGT', 'Leveller', 'Terragen', **'netCDF'**, 'HDF4', 'HDF4Image', 'ISIS3', 'ISIS2', 'PDS', 'PDS4', 'VICAR', 'TIL', 'ERS', 'JP2OpenJPEG', 'L1B', 'FIT', 'GRIB', 'RMF', 'WCS', 'WMS', 'MSGN', 'RST', 'GSAG', 'GSBG', 'GS7BG', 'COSAR', 'TSX', 'COASP', 'R', 'MAP', 'KMLSUPEROVERLAY', 'WEBP', 'PDF', 'Rasterlite', 'MBTiles', 'PLMOSAIC', 'CALS', 'WMTS', 'SENTINEL2', 'MRF', 'TileDB', 'PNM', 'DOQ1', 'DOQ2', 'PAux', 'MFF', 'MFF2', 'GSC', 'FAST', 'BT', 'LAN', 'CPG', 'NDF', 'EIR', 'DIPEx', 'LCP', 'GTX', 'LOSLAS', 'NTv2', 'CTable2', 'ACE2', 'SNODAS', 'KRO', 'ROI_PAC', 'RRASTER', 'BYN', 'NOAA_B', 'RIK', 'USGSDEM', 'GXF', 'KEA', 'BAG', 'S102', 'S104', 'S111', 'HDF5', 'HDF5Image', 'NWT_GRD', 'NWT_GRC', 'ADRG', 'SRP', 'BLX', 'PostGISRaster', 'SAGA', 'XYZ', 'HF2', 'OZI', 'CTG', 'ZMap', 'NGSGEOID', 'IRIS', 'PRF', 'EEDAI', 'EEDA', 'DAAS', 'SIGDEM', 'TGA', 'OGCAPI', 'STACTA', 'STACIT', 'NSIDCbin', 'GNMFile', 'GNMDatabase', 'ESRI Shapefile', 'MapInfo File', 'UK .NTF', 'LVBAG', 'OGR_SDTS', 'S57', 'DGN', 'OGR_VRT', 'Memory', 'CSV', 'NAS', 'GML', 'GPX', 'LIBKML', 'KML', 'GeoJSON', 'GeoJSONSeq', 'ESRIJSON', 'TopoJSON', 'Interlis 1', 'Interlis 2', 'OGR_GMT', 'GPKG', 'SQLite', 'WAsP', 'PostgreSQL', 'OpenFileGDB', 'DXF', 'CAD', 'FlatGeobuf', 'Geoconcept', 'GeoRSS', 'VFK', 'PGDUMP', 'OSM', 'GPSBabel', 'OGR_PDS', 'WFS', 'OAPIF', 'EDIGEO', 'SVG', 'Idrisi', 'XLS', 'ODS', 'XLSX', 'Elasticsearch', 'Carto', 'AmigoCloud', 'SXF', 'Selafin', 'JML', 'PLSCENES', 'CSW', 'VDV', 'GMLAS', 'MVT', 'NGW', 'MapML', 'GTFS', 'PMTiles', 'JSONFG', 'MiraMonVector', 'TIGER', 'AVCBin', 'AVCE00', 'GenBin', 'ENVI', 'EHdr', 'ISCE', 'Zarr', 'HTTP'])