### PR TITLE
Mark additional tests that use the network

### DIFF
--- a/tests/test_pyopener.py
+++ b/tests/test_pyopener.py
@@ -70,6 +70,7 @@ def test_opener_fsspec_fs():
         assert profile["count"] == 3
 
 
+@pytest.mark.network
 def test_opener_fsspec_http_fs():
     """Use fsspec http filesystem as opener."""
     fs = fsspec.filesystem("http")
@@ -170,6 +171,7 @@ def test_fsspec_msk_sidecar():
             assert val == [MaskFlags.per_dataset]
 
 
+@pytest.mark.network
 def test_fsspec_http_msk_sidecar():
     """Use fsspec http filesystem as opener."""
     fs = fsspec.filesystem("http")

--- a/tests/test_read_boundless.py
+++ b/tests/test_read_boundless.py
@@ -146,6 +146,7 @@ def test_msk_read_masks(path_rgb_msk_byte_tif):
         assert msk.mean() > 90
 
 
+@pytest.mark.network
 def test_issue1982(capfd):
     """See a curl request for overview file"""
     with rasterio.Env(CPL_CURL_VERBOSE=True), rasterio.open(


### PR DESCRIPTION
The network marker is already used in other places, but these tests are new.

PS, 1.4.0 is tagged off of a commit that isn't in `main` or `maint-1.4`, and seems to have a duplicate commit (based on its message); not sure if that's intentional or not.