### PR TITLE
Test maint-1.4 against GDAL 3.10-to-be and add more MEM file checks

### DIFF
--- a/.github/workflows/tests.yaml
+++ b/.github/workflows/tests.yaml
@@ -2,7 +2,7 @@ name: Tests
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, maint-1.4 ]
     paths:
       - '.github/workflows/tests.yaml'
       - 'requirements*.txt'
@@ -14,7 +14,7 @@ on:
       - 'rasterio/**'
       - 'tests/**'
   pull_request:
-    branches: [ main ]
+    branches: [ main, maint-1.4 ]
     paths:
       - '.github/workflows/tests.yaml'
       - 'requirements*.txt'
@@ -98,8 +98,10 @@ jobs:
       fail-fast: false
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-        gdal-version: ['3.9.2']
+        gdal-version: ['3.9.3']
         include:
+          - python-version: '3.12'
+            gdal-version: 'latest'
           - python-version: '3.9'
             gdal-version: '3.8.5'
           - python-version: '3.9'

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -2147,7 +2147,7 @@ def test_reproject_error_propagation(http_error_server, caplog):
                 dst_transform=src.transform,
             )
 
-    assert len([rec for rec in caplog.records if "Retrying again" in rec.message]) == 2
+    assert len([rec for rec in caplog.records if "Retrying again" in rec.message]) >= 2
 
 
 def test_reproject_to_specified_output_bands():


### PR DESCRIPTION
https://github.com/rasterio/rasterio/actions/runs/11349030115/job/31564203380 showed that Rasterio 1.4.1 is not quite ready for GDAL 3.10.

Our `MEM::` dataset gets opened several times in `_reproject()`.