### PR TITLE
Eliminate much to_epsg() usage and speed up __eq__()

### DIFF
--- a/rasterio/crs.pxd
+++ b/rasterio/crs.pxd
@@ -5,5 +5,5 @@ cdef class CRS:
 
     cdef OGRSpatialReferenceH _osr
     cdef object _data
-    cdef object _epsg
-    cdef object _wkt
+    cdef public object _epsg
+    cdef public object _wkt

--- a/rasterio/crs.pyx
+++ b/rasterio/crs.pyx
@@ -930,7 +930,7 @@ cdef class CRS:
     def __eq__(self, other):
         cdef CRS crs_o
         cdef const char* options[2]
-        options[0] = b"IGNORE_DATA_AXIS_TO_SRS_AXIS_MAPPING=YES"
+        options[0] = b"IGNORE_DATA_AXIS_TO_SRS_AXIS_MAPPING=NO"
         options[1] = NULL
 
         try:

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -176,6 +176,7 @@ cdef extern from "ogr_srs_api.h" nogil:
     int OSRIsGeographic(OGRSpatialReferenceH srs)
     int OSRIsProjected(OGRSpatialReferenceH srs)
     int OSRIsSame(OGRSpatialReferenceH srs1, OGRSpatialReferenceH srs2)
+    int OSRIsSameEx(OGRSpatialReferenceH srs1, OGRSpatialReferenceH srs2, const char* const* options)
     OGRSpatialReferenceH OSRNewSpatialReference(const char *wkt)
     void OSRRelease(OGRSpatialReferenceH srs)
     int OSRSetFromUserInput(OGRSpatialReferenceH srs, const char *input)

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -45,21 +45,19 @@ class CustomCRS:
 def test_crs_constructor_dict():
     """Can create a CRS from a dict"""
     crs = CRS({'init': 'epsg:3857'})
-    assert crs['init'] == 'epsg:3857'
     assert 'PROJCS["WGS 84 / Pseudo-Mercator"' in crs.wkt
 
 
 def test_crs_constructor_keywords():
     """Can create a CRS from keyword args, ignoring unknowns"""
+    # Note: `init="epsg:dddd"` is no longer recommended usage.
     crs = CRS(init='epsg:3857', foo='bar')
-    assert crs['init'] == 'epsg:3857'
     assert 'PROJCS["WGS 84 / Pseudo-Mercator"' in crs.wkt
 
 
 def test_crs_constructor_crs_obj():
     """Can create a CRS from a CRS obj"""
-    crs = CRS(CRS(init='epsg:3857'))
-    assert crs['init'] == 'epsg:3857'
+    crs = CRS(CRS.from_epsg(3857))
     assert 'PROJCS["WGS 84 / Pseudo-Mercator"' in crs.wkt
 
 
@@ -123,21 +121,21 @@ def test_from_proj4_json():
 
 
 def test_from_epsg():
-    crs_dict = CRS.from_epsg(4326)
-    assert crs_dict['init'].lower() == 'epsg:4326'
+    assert CRS.from_epsg(4326)._epsg == 4326
 
-    # Test with invalid EPSG code
+
+def test_from_epsg_fail():
     with pytest.raises(ValueError):
-        assert CRS.from_epsg(0)
+        CRS.from_epsg(0)
 
 
 def test_from_epsg_string():
-    crs_dict = CRS.from_string('epsg:4326')
-    assert crs_dict['init'].lower() == 'epsg:4326'
+    assert CRS.from_string("epsg:4326")._epsg == 4326
 
-    # Test with invalid EPSG code
+
+def test_from_epsg_string_fail():
     with pytest.raises(ValueError):
-        assert CRS.from_string('epsg:xyz')
+        CRS.from_string("epsg:xyz")
 
 
 def test_from_epsg_overflow():
@@ -147,12 +145,20 @@ def test_from_epsg_overflow():
 
 
 def test_from_string():
-    wgs84_crs = CRS.from_string('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
-    assert wgs84_crs.to_dict() == {'init': 'epsg:4326'}
+    wgs84_crs = CRS.from_string("+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs")
+    assert wgs84_crs.to_dict() == {"proj": "longlat", "datum": "WGS84", "no_defs": True}
 
+
+def test_from_string_2():
     # Make sure this doesn't get handled using the from_epsg() even though 'epsg' is in the string
-    epsg_init_crs = CRS.from_string('+init=epsg:26911')
-    assert epsg_init_crs.to_dict() == {'init': 'epsg:26911'}
+    epsg_init_crs = CRS.from_string("+init=epsg:26911")
+    assert epsg_init_crs.to_dict() == {
+        "proj": "utm",
+        "zone": 11,
+        "datum": "NAD83",
+        "units": "m",
+        "no_defs": True,
+    }
 
 
 @pytest.mark.parametrize('proj,expected', [({'init': 'epsg:4326'}, True), ({'init': 'epsg:3857'}, False)])
@@ -328,7 +334,7 @@ def test_from_wkt_invalid():
 
 
 def test_from_user_input_epsg():
-    assert 'init' in CRS.from_user_input('epsg:4326')
+    assert CRS.from_user_input("epsg:4326")._epsg == 4326
 
 
 @pytest.mark.parametrize("version", ["WKT2_2019", WktVersion.WKT2_2019])

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -200,15 +200,6 @@ def test_equality_from_dict(epsg_code):
 
 
 def test_is_same_crs():
-    crs1 = CRS({'init': 'epsg:4326'})
-    crs2 = CRS({'init': 'epsg:3857'})
-
-    assert crs1 == crs1
-    assert crs1 != crs2
-
-    wgs84_crs = CRS.from_string('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
-    assert crs1 == wgs84_crs
-
     # Make sure that same projection with different parameter are not equal
     lcc_crs1 = CRS.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
     lcc_crs2 = CRS.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=45 +lat_0=0')
@@ -297,9 +288,7 @@ def test_epsg__no_code_available():
 def test_crs_OSR_equivalence():
     crs1 = CRS.from_string('+proj=longlat +datum=WGS84 +no_defs')
     crs2 = CRS.from_string('+proj=latlong +datum=WGS84 +no_defs')
-    crs3 = CRS({'init': 'epsg:4326'})
     assert crs1 == crs2
-    assert crs1 == crs3
 
 
 def test_crs_OSR_no_equivalence():

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -653,3 +653,9 @@ def test_crs_proj_json__from_string():
 
 def test_crs_compound_epsg():
     assert CRS.from_string("EPSG:4326+3855").to_wkt().startswith("COMPD")
+
+
+@pytest.mark.parametrize("crs", [CRS.from_epsg(4326), CRS.from_string("EPSG:4326")])
+def test_epsg_4326_ogc_crs84(crs):
+    """EPSG:4326 not equivalent to OGC:CRS84."""
+    assert CRS.from_string("OGC:CRS84") != crs

--- a/tests/test_rio_edit_info.py
+++ b/tests/test_rio_edit_info.py
@@ -8,10 +8,15 @@ import numpy
 import pytest
 
 import rasterio
+from rasterio import CRS
 from rasterio.enums import ColorInterp
 from rasterio.rio.edit_info import (
-    all_handler, crs_handler, tags_handler, transform_handler,
-    colorinterp_handler)
+    all_handler,
+    crs_handler,
+    tags_handler,
+    transform_handler,
+    colorinterp_handler,
+)
 from rasterio.rio.main import main_group
 import rasterio.shutil
 
@@ -97,7 +102,7 @@ def test_edit_crs_epsg(data, runner):
         main_group, ['edit-info', inputfile, '--crs', 'EPSG:32618'])
     assert result.exit_code == 0
     with rasterio.open(inputfile) as src:
-        assert src.crs == {'init': 'epsg:32618'}
+        assert src.crs == CRS.from_epsg(32618)
 
 
 def test_edit_crs_proj4(data, runner):
@@ -106,7 +111,7 @@ def test_edit_crs_proj4(data, runner):
         main_group, ['edit-info', inputfile, '--crs', '+init=epsg:32618'])
     assert result.exit_code == 0
     with rasterio.open(inputfile) as src:
-        assert src.crs == {'init': 'epsg:32618'}
+        assert src.crs == CRS.from_epsg(32618)
 
 
 def test_edit_crs_obj(data, runner):
@@ -116,7 +121,13 @@ def test_edit_crs_obj(data, runner):
         ['edit-info', inputfile, '--crs', '{"init": "epsg:32618"}'])
     assert result.exit_code == 0
     with rasterio.open(inputfile) as src:
-        assert src.crs.to_dict() == {'init': 'epsg:32618'}
+        assert src.crs.to_dict() == {
+            "datum": "WGS84",
+            "no_defs": True,
+            "proj": "utm",
+            "units": "m",
+            "zone": 18,
+        }
 
 
 def test_edit_transform_err_not_json(data, runner):
@@ -192,12 +203,12 @@ def test_edit_crs_like(data, runner):
     # Set up the file to be edited.
     inputfile = str(data.join('RGB.byte.tif'))
     with rasterio.open(inputfile, 'r+') as dst:
-        dst.crs = {'init': 'epsg:32617'}
+        dst.crs = "EPSG:32617"
         dst.nodata = 1.0
 
     # Double check.
     with rasterio.open(inputfile) as src:
-        assert src.crs == {'init': 'epsg:32617'}
+        assert src.crs == CRS.from_epsg(32617)
         assert src.nodata == 1.0
 
     # The test.
@@ -215,12 +226,12 @@ def test_edit_nodata_like(data, runner):
     # Set up the file to be edited.
     inputfile = str(data.join('RGB.byte.tif'))
     with rasterio.open(inputfile, 'r+') as dst:
-        dst.crs = {'init': 'epsg:32617'}
+        dst.crs = "EPSG:32617"
         dst.nodata = 1.0
 
     # Double check.
     with rasterio.open(inputfile) as src:
-        assert src.crs == {'init': 'epsg:32617'}
+        assert src.crs == CRS.from_epsg(32617)
         assert src.nodata == 1.0
 
     # The test.
@@ -230,19 +241,19 @@ def test_edit_nodata_like(data, runner):
         ['edit-info', inputfile, '--like', templatefile, '--nodata', 'like'])
     assert result.exit_code == 0
     with rasterio.open(inputfile) as src:
-        assert src.crs == {'init': 'epsg:32617'}
+        assert src.crs == CRS.from_epsg(32617)
         assert src.nodata == 0.0
 
 
 def test_edit_all_like(data, runner):
     inputfile = str(data.join('RGB.byte.tif'))
     with rasterio.open(inputfile, 'r+') as dst:
-        dst.crs = {'init': 'epsg:32617'}
+        dst.crs = "EPSG:32617"
         dst.nodata = 1.0
 
     # Double check.
     with rasterio.open(inputfile) as src:
-        assert src.crs == {'init': 'epsg:32617'}
+        assert src.crs == CRS.from_epsg(32617)
         assert src.nodata == 1.0
 
     templatefile = 'tests/data/RGB.byte.tif'


### PR DESCRIPTION
Change to `CRS.__eq__()` is based on #3208.

Several evaluations of `to_epsg()`, which is slow, are replaced by a check of `CRS._epsg`.

A notable change in behavior is that `CRS.from_epsg(4326).to_dict()` no longer returns `{"init": "epsg:4326"}`, but the full PROJ definition. PROJ4 init files aren't quite deprecated yet, but we need to steer users away from this. See https://github.com/rasterio/rasterio/issues/1809#issuecomment-546019513 (which I'll try to replace with a better reference).