### PR TITLE
Adds CRS.geodetic_crs property

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -73,6 +73,7 @@ VERSION.txt
 rasterio/*.cpp
 rasterio/*.c
 tests/data/white-gemini-iv.zip
+tests/data/all-nodata.tif.aux.xml
 .hypothesis/
 
 # vim

--- a/rasterio/crs.pxd
+++ b/rasterio/crs.pxd
@@ -7,3 +7,4 @@ cdef class CRS:
     cdef object _data
     cdef object _epsg
     cdef object _wkt
+    cdef object _geodetic_crs

--- a/rasterio/crs.pyx
+++ b/rasterio/crs.pyx
@@ -285,7 +285,7 @@ cdef class CRS:
             obj._osr = exc_wrap_pointer(OSRCloneGeogCS(self._osr))
         except CPLE_BaseError as exc:
             raise CRSError("The Geodetic CRS for this CRS could not be found: {}".format(exc))
-        finally:
+        else:
             # TODO do we actually want this? Wouldn't we want OAMS_AUTHORITY_COMPLIANT?
             osr_set_traditional_axis_mapping_strategy(obj._osr)
             return obj

--- a/rasterio/crs.pyx
+++ b/rasterio/crs.pyx
@@ -274,19 +274,23 @@ cdef class CRS:
             return (units_b.decode('utf-8'), factor)
 
     def to_geodetic(self):
-        """
-        Returns the geographic CRS but 
-        with traditional long/lat,easting/northing ordering
+        """Get the Geographic CRS from the CRS.
+
+        Returns
+        -------
+        CRS
+
+        Raises
+        ------
+        CRSError
 
         """
         cdef CRS obj = CRS.__new__(CRS)
         try:
-            # TODO can GeogCS be null/empty?
             obj._osr = exc_wrap_pointer(OSRCloneGeogCS(self._osr))
         except CPLE_BaseError as exc:
             raise CRSError("The Geodetic CRS for this CRS could not be found: {}".format(exc))
         else:
-            # TODO do we actually want this? Wouldn't we want OAMS_AUTHORITY_COMPLIANT?
             osr_set_traditional_axis_mapping_strategy(obj._osr)
             return obj
         

--- a/rasterio/crs.pyx
+++ b/rasterio/crs.pyx
@@ -106,7 +106,6 @@ cdef class CRS:
             self._wkt = tmp._wkt
             self._data = tmp.data
             self._epsg = tmp._epsg
-            self._geodetic_crs = tmp._geodetic_crs
 
     @property
     def data(self):

--- a/rasterio/crs.pyx
+++ b/rasterio/crs.pyx
@@ -524,6 +524,37 @@ cdef class CRS:
             OSRFreeSRSArray(matches)
             CPLFree(confidences)
 
+    def equals(self, other, ignore_axis_order=False):
+        """
+        Check if the crs objects are equivalent.
+
+        Properties
+        ----------
+        other: CRS
+            the other CRS to compare to
+        ignore_axis_order: bool, default=False
+            If True, it will compare the CRS class and ignore the axis order.
+
+        Returns
+        -------
+        bool
+        """
+        cdef CRS crs_o
+        cdef const char* options[2]
+        
+        if ignore_axis_order:
+            options[0] = b"IGNORE_DATA_AXIS_TO_SRS_AXIS_MAPPING=YES"
+        else:
+            options[0] = b"IGNORE_DATA_AXIS_TO_SRS_AXIS_MAPPING=NO"
+        options[1] = NULL
+
+        try:
+            crs_o = CRS.from_user_input(other)
+            return bool(OSRIsSameEx(self._osr, crs_o._osr, options) == 1)
+        except CRSError:
+            return False
+        
+
     def to_string(self):
         """Convert to a PROJ4 or WKT string.
 
@@ -921,31 +952,7 @@ cdef class CRS:
             return "CRS.from_wkt('{}')".format(self.wkt)
 
     def __eq__(self, other):
-        cdef OGRSpatialReferenceH osr_s = NULL
-        cdef OGRSpatialReferenceH osr_o = NULL
-        cdef CRS crs_o
-
-        try:
-            crs_o = CRS.from_user_input(other)
-        except CRSError:
-            return False
-
-        epsg_s = self.to_epsg()
-        epsg_o = crs_o.to_epsg()
-
-        if epsg_s is not None and epsg_o is not None and epsg_s == epsg_o:
-            return True
-
-        else:
-            try:
-                osr_s = exc_wrap_pointer(OSRClone(self._osr))
-                osr_o = exc_wrap_pointer(OSRClone(crs_o._osr))
-                return bool(OSRIsSame(osr_s, osr_o) == 1)
-
-            finally:
-                _safe_osr_release(osr_s)
-                _safe_osr_release(osr_o)
-
+        return self.equals(other, ignore_axis_order=False)
 
     def _projjson(self):
         """Get a PROJ JSON representation.

--- a/rasterio/crs.pyx
+++ b/rasterio/crs.pyx
@@ -287,14 +287,13 @@ cdef class CRS:
         CRSError
 
         """
-        if self._geodetic_crs is not None:
-            return self._geodetic_crs if self._geodetic_crs is not False else None
+        if self._geodetic_crs:
+            return self._geodetic_crs
         cdef CRS obj = CRS.__new__(CRS)
         try:
             obj._osr = exc_wrap_pointer(OSRCloneGeogCS(self._osr))
         except CPLE_BaseError as exc:
-            self._geodetic_crs = False
-            return None
+            raise CRSError("Cannot determine Geodetic CRS. {}".format(exc))
         else:
             osr_set_traditional_axis_mapping_strategy(obj._osr)
             self._geodetic_crs = obj

--- a/rasterio/crs.pyx
+++ b/rasterio/crs.pyx
@@ -273,6 +273,24 @@ cdef class CRS:
             units_b = units_c
             return (units_b.decode('utf-8'), factor)
 
+    def to_geodetic(self):
+        """
+        Returns the geographic CRS but 
+        with traditional long/lat,easting/northing ordering
+
+        """
+        cdef CRS obj = CRS.__new__(CRS)
+        try:
+            # TODO can GeogCS be null/empty?
+            obj._osr = exc_wrap_pointer(OSRCloneGeogCS(self._osr))
+        except CPLE_BaseError as exc:
+            raise CRSError("The Geodetic CRS for this CRS could not be found: {}".format(exc))
+        finally:
+            # TODO do we actually want this? Wouldn't we want OAMS_AUTHORITY_COMPLIANT?
+            osr_set_traditional_axis_mapping_strategy(obj._osr)
+            return obj
+        
+
     def to_dict(self, projjson=False):
         """Convert CRS to a PROJ dict.
 

--- a/rasterio/crs.pyx
+++ b/rasterio/crs.pyx
@@ -969,7 +969,6 @@ cdef class CRS:
         self._wkt = tmp._wkt
         self._data = tmp.data
         self._epsg = tmp._epsg
-        self._geodetic_crs = tmp._geodetic_crs
 
     def __copy__(self):
         return pickle.loads(pickle.dumps(self))

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -176,6 +176,7 @@ cdef extern from "ogr_srs_api.h" nogil:
     int OSRIsGeographic(OGRSpatialReferenceH srs)
     int OSRIsProjected(OGRSpatialReferenceH srs)
     int OSRIsSame(OGRSpatialReferenceH srs1, OGRSpatialReferenceH srs2)
+    int OSRIsSameEx(OGRSpatialReferenceH srs1, OGRSpatialReferenceH srs2, const char* const* papszOptions)
     OGRSpatialReferenceH OSRNewSpatialReference(const char *wkt)
     void OSRRelease(OGRSpatialReferenceH srs)
     int OSRSetFromUserInput(OGRSpatialReferenceH srs, const char *input)

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -166,6 +166,7 @@ cdef extern from "ogr_srs_api.h" nogil:
                      double *y, double *z)
     void OSRCleanup()
     OGRSpatialReferenceH OSRClone(OGRSpatialReferenceH srs)
+    OGRSpatialReferenceH OSRCloneGeogCS(OGRSpatialReferenceH srs)
     int OSRExportToProj4(OGRSpatialReferenceH srs, char **params)
     int OSRExportToWkt(OGRSpatialReferenceH srs, char **params)
     const char *OSRGetAuthorityName(OGRSpatialReferenceH srs, const char *key)

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -680,7 +680,7 @@ def test_crs_compound_epsg():
         (CRS.from_epsg(3031), CRS.from_epsg(4326)),
         (CRS.from_user_input("ESRI:102004"), CRS.from_user_input("EPSG:4269")),
         (CRS.from_user_input("IAU_2015:49910"), CRS.from_user_input("IAU_2015:49900")),
-        (CRS.from_user_input("IAU_2015:49911"), CRS.from_user_input("IAU_2015:49901")),
+        (CRS.from_user_input("IAU_2015:49911"), CRS.from_user_input("IAU_2015:49901"))
     ]
 )
 def test_construct_geodetic_crs(crs_obj, geod_crs):

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -192,6 +192,15 @@ def test_equality_from_dict(epsg_code):
         init=f"epsg:{epsg_code}"
     )
 
+def test_crs_equals():
+    crs1 = CRS({'init': 'epsg:4326'})
+    assert CRS({'init': 'epsg:4326'}).equals(crs1)
+
+
+def test_crs_equals__ignore_axis_order():
+    crs1 = CRS({'init': 'epsg:4326'})
+    assert CRS({'init': 'epsg:4326'}).equals(crs1, ignore_axis_order=True)
+
 
 def test_is_same_crs():
     crs1 = CRS({'init': 'epsg:4326'})
@@ -201,7 +210,7 @@ def test_is_same_crs():
     assert crs1 != crs2
 
     wgs84_crs = CRS.from_string('+proj=longlat +ellps=WGS84 +datum=WGS84 +no_defs')
-    assert crs1 == wgs84_crs
+    assert crs1 != wgs84_crs
 
     # Make sure that same projection with different parameter are not equal
     lcc_crs1 = CRS.from_string('+lon_0=-95 +ellps=GRS80 +y_0=0 +no_defs=True +proj=lcc +x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
@@ -287,13 +296,19 @@ def test_epsg__no_code_available():
                               '+x_0=0 +units=m +lat_2=77 +lat_1=49 +lat_0=0')
     assert lcc_crs.to_epsg() is None
 
+def test_crs_4326_if_equivalent_crs84():
+    crs1 = CRS.from_epsg(4326)
+    crs2 = CRS.from_string("OGC:CRS84")
+    assert not crs1.equals(crs2, ignore_axis_order=False)
+    assert crs1.equals(crs2, ignore_axis_order=True)
+    assert not crs1 == crs2
 
 def test_crs_OSR_equivalence():
     crs1 = CRS.from_string('+proj=longlat +datum=WGS84 +no_defs')
     crs2 = CRS.from_string('+proj=latlong +datum=WGS84 +no_defs')
     crs3 = CRS({'init': 'epsg:4326'})
     assert crs1 == crs2
-    assert crs1 == crs3
+    assert crs1 != crs3
 
 
 def test_crs_OSR_no_equivalence():

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -673,3 +673,19 @@ def test_crs_proj_json__from_string():
 
 def test_crs_compound_epsg():
     assert CRS.from_string("EPSG:4326+3855").to_wkt().startswith("COMPD")
+
+
+@pytest.mark.parametrize(
+    'crs_obj,geod_crs',
+    [
+        (CRS.from_epsg(4087), CRS.from_epsg(4326)),
+        (CRS.from_epsg(3995), CRS.from_epsg(4326)),
+        (CRS.from_epsg(3031), CRS.from_epsg(4326)),
+        (CRS.from_user_input("ESRI:102004"), CRS.from_user_input("EPSG:4269")),
+        (CRS.from_user_input("IAU_2015:49910"), CRS.from_user_input("IAU_2015:49900")),
+        (CRS.from_user_input("IAU_2015:49911"), CRS.from_user_input("IAU_2015:49901")),
+    ]
+)
+def test_construct_geodetic_crs(crs_obj, geod_crs):
+    """Test if CRS should be treated as latlon."""
+    assert crs_obj.to_geodetic() == geod_crs

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -687,5 +687,5 @@ def test_crs_compound_epsg():
     ]
 )
 def test_construct_geodetic_crs(crs_obj, geod_crs):
-    """Test if CRS should be treated as latlon."""
+    """Test if CRS geodetic CRS matches expectations."""
     assert crs_obj.to_geodetic() == geod_crs

--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -688,4 +688,4 @@ def test_crs_compound_epsg():
 )
 def test_construct_geodetic_crs(crs_obj, geod_crs):
     """Test if CRS geodetic CRS matches expectations."""
-    assert crs_obj.to_geodetic() == geod_crs
+    assert crs_obj.geodetic_crs == geod_crs


### PR DESCRIPTION
Following a discussion on the rasterio groups.io email list,

This PR adds a new function `.to_geodetic` that is inspired by pyproj's `.geodetic_crs` function to return the corresponding base geographic CRS for a given CRS. This is helpful for projections that may not use common geographic CRSs and for cases when you want to know what geographic CRS to use for vector features that minimizes the work needed to get to projected coordinates or vice versa.

I went with the name `to_geodetic` for the moment as it is returning a new object that is transformed from the parent object, and reflects the intent imho better than `.geodetic_crs` which reads more as a property of the CRS, but as a new object is created... Anyways I don't hold a strong desire here on the name of the function.

`geodetic` is retained because of this heritage, the vocabulary here is majorly overloaded but maybe `to_geographic` would be better here? Happy to look into this more. It could also make sense to just keep it aligned to pyproj to maintain compatibility better. 