### PR TITLE
Restore default behavior of rowcol(), returning ints

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,6 +1,17 @@
 Changes
 =======
 
+1.4.2 (TBD)
+-----------
+
+Version 1.4.2 fixes a regression and further improves compatibility with
+GDAL 3.10.
+
+Bug fixes:
+
+- The various rowcol() methods once again return integers by default as
+  they did in 1.3.11 (#3219).
+
 1.4.1 (2024-09-30)
 ------------------
 


### PR DESCRIPTION
The change was caused by replacing `math.floor()` (given floats, returns ints) with `numpy.floor()` (returns floats).