### PR TITLE
Adds read/write access to raster attribute tables

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -3,7 +3,7 @@
 """Numpy-free base classes."""
 
 from collections import (
-    defaultdict, OrderedDict)
+    defaultdict)
 from contextlib import ExitStack
 import logging
 import math
@@ -1343,7 +1343,7 @@ cdef class DatasetBase:
         row_count = GDALRATGetRowCount(rat)
         col_count = GDALRATGetColumnCount(rat)
 
-        retval = OrderedDict()
+        retval = []
 
         for c in range(col_count):
             col_name = GDALRATGetNameOfCol(rat, c)
@@ -1361,11 +1361,12 @@ cdef class DatasetBase:
                 else:
                     raise ValueError(f'Unknown column type {col_type}')
 
-            retval[col_name] = {
-                'field_type': RATFieldType(col_type),
-                'field_usage': RATFieldUsage(col_use),
-                'values': values
-            }
+            retval.append({
+                'NameOfCol': col_name,
+                'TypeOfCol': RATFieldType(col_type),
+                'UsageOfCol': RATFieldUsage(col_use),
+                'Values': values
+            })
 
         return retval
 

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -1361,8 +1361,8 @@ cdef class DatasetBase:
                     raise ValueError(f'Unknown column type {col_type}')
 
             retval[col_name] = {
-                'column_type': <GDALRATFieldType>col_type,
-                'column_use': <GDALRATFieldUsage>col_use,
+                'field_type': <GDALRATFieldType>col_type,
+                'field_usage': <GDALRATFieldUsage>col_use,
                 'values': values
             }
 

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -2,7 +2,8 @@
 
 """Numpy-free base classes."""
 
-from collections import defaultdict
+from collections import (
+    defaultdict, OrderedDict)
 from contextlib import ExitStack
 import logging
 import math
@@ -1341,8 +1342,7 @@ cdef class DatasetBase:
         row_count = GDALRATGetRowCount(rat)
         col_count = GDALRATGetColumnCount(rat)
 
-        # TODO: Make ordered dict
-        retval = {}
+        retval = OrderedDict()
 
         for c in range(col_count):
             col_name = GDALRATGetNameOfCol(rat, c)

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -2,8 +2,7 @@
 
 """Numpy-free base classes."""
 
-from collections import (
-    defaultdict)
+from collections import defaultdict
 from contextlib import ExitStack
 import logging
 import math
@@ -25,7 +24,7 @@ from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
 from rasterio.enums import (
     ColorInterp, Compression, Interleaving, MaskFlags, PhotometricInterp,
-    RATFieldType, RATFieldUsage)
+    RATFieldType, RATFieldUsage, RATTableType)
 from rasterio.env import env_ctx_if_needed
 from rasterio.errors import (
     DatasetAttributeError,
@@ -1330,6 +1329,43 @@ cdef class DatasetBase:
         return retval
 
     def rat(self, bidx):
+        """Returns a list of dicts containing the raster attribute table (rat)
+        for a band. Each list element is a column of the rat and describes the 
+        column metadata as well as the values:
+
+        NameOfCol Name of the column
+        TypeOfCol Data type of the column values.
+                    ``RATFieldType.<enum>``
+            see https://gdal.org/en/latest/doxygen/gdal_8h.html#a810154ac91149d1a63c42717258fe16e
+        UsageOfCol Indicates the specific usage of the column if defined. 
+                    ``RATFieldUsage.<enum>``
+            see https://gdal.org/en/latest/doxygen/gdal_8h.html#a27bf786b965d5227da1acc2a4cab69a1
+        Values list of column values
+
+        Parameters
+        ----------
+        bidx : int
+            Index of the band whose raster attribute table will be returned.
+            Band index starts at 1.
+
+        Returns
+        -------
+        list
+            Columns of the raster attribute table including column metadata and
+            attribute values.
+        GDALRATTableType.<enum>
+            Raster attribute table type (thematic or athematic)
+            see https://gdal.org/en/latest/doxygen/gdal_8h.html#a038eb9102e8131feebb7874f386f0b74
+
+        Raises
+        ------
+        ValueError
+            If no raster attribute table is found for the specified band.
+        ValueError
+            If a column data type is not understood.
+        IndexError
+            If no band exists for the provided index.
+        """
 
         cdef GDALRasterBandH band = NULL
         cdef GDALRasterAttributeTableH rat = NULL
@@ -1368,7 +1404,8 @@ cdef class DatasetBase:
                 'Values': values
             })
 
-        return retval
+        table_type = GDALRATGetTableType(rat)
+        return retval, RATTableType(table_type)
 
     def overviews(self, bidx):
         cdef GDALRasterBandH ovrband = NULL

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -1398,10 +1398,10 @@ cdef class DatasetBase:
                     raise ValueError(f'Unknown column type {col_type}')
 
             retval.append({
-                'NameOfCol': col_name,
-                'TypeOfCol': RATFieldType(col_type),
-                'UsageOfCol': RATFieldUsage(col_use),
-                'Values': values
+                'column_name': col_name,
+                'column_type': RATFieldType(col_type),
+                'column_usage': RATFieldUsage(col_use),
+                'column_values': values
             })
 
         table_type = GDALRATGetTableType(rat)

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -24,7 +24,8 @@ from rasterio import dtypes
 from rasterio.coords import BoundingBox
 from rasterio.crs import CRS
 from rasterio.enums import (
-    ColorInterp, Compression, Interleaving, MaskFlags, PhotometricInterp)
+    ColorInterp, Compression, Interleaving, MaskFlags, PhotometricInterp,
+    RATFieldType, RATFieldUsage)
 from rasterio.env import env_ctx_if_needed
 from rasterio.errors import (
     DatasetAttributeError,
@@ -1351,18 +1352,18 @@ cdef class DatasetBase:
 
             values = []
             for r in range(row_count):
-                if col_type == <GDALRATFieldType>GFT_Integer:
+                if col_type == GFT_Integer:
                     values.append(GDALRATGetValueAsInt(rat, r, c))
-                elif col_type == <GDALRATFieldType>GFT_Real:
+                elif col_type == GFT_Real:
                     values.append(GDALRATGetValueAsDouble(rat, r, c))
-                elif col_type == <GDALRATFieldType>GFT_String:
+                elif col_type == GFT_String:
                     values.append(GDALRATGetValueAsString(rat, r, c))
                 else:
                     raise ValueError(f'Unknown column type {col_type}')
 
             retval[col_name] = {
-                'field_type': <GDALRATFieldType>col_type,
-                'field_usage': <GDALRATFieldUsage>col_use,
+                'field_type': RATFieldType(col_type),
+                'field_usage': RATFieldUsage(col_use),
                 'values': values
             }
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -2031,6 +2031,28 @@ cdef class DatasetWriterBase(DatasetReaderBase):
         finally:
             GDALDestroyColorTable(hTable)
 
+    def write_rat(self, bidx, rat):
+        """Write a raster attribute table for a band to the dataset.
+
+        A raster attribute table contains tabular data describing the raster
+        band such as category names, category descriptions, statistics,
+        and color.
+
+        Parameters
+        ----------
+        bidx : int
+            Index of the band (starting with 1).
+        rat: list
+            List of dictionaries containing column values and metadata
+            with keys 'NameOfCol', 'TypeOfCol', 'UsageOfCol', and 'Values'
+
+        Returns
+        -------
+        None
+
+        """
+        raise DatasetAttributeError("RAT write not supported")
+
     def write_mask(self, mask_array, window=None):
         """Write to the dataset's band mask.
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -2051,7 +2051,7 @@ cdef class DatasetWriterBase(DatasetReaderBase):
         None
 
         """
-        raise DatasetAttributeError("RAT write not supported")
+        raise RasterioIOError("RAT write not supported")
 
     def write_mask(self, mask_array, window=None):
         """Write to the dataset's band mask.

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -22,7 +22,7 @@ from rasterio._err import (
     CPLE_AWSObjectNotFoundError, CPLE_HttpResponseError, stack_errors)
 from rasterio.crs import CRS
 from rasterio import dtypes
-from rasterio.enums import ColorInterp, MaskFlags, Resampling
+from rasterio.enums import ColorInterp, MaskFlags, Resampling, RATTableType
 from rasterio.errors import (
     CRSError, DriverRegistrationError, RasterioIOError,
     NotGeoreferencedWarning, NodataShadowWarning, WindowError,
@@ -2086,9 +2086,9 @@ cdef class DatasetWriterBase(DatasetReaderBase):
                     GDALRATSetValueAsString(hRAT, irow, icol, value)
 
         if thematic:
-            GDALRATSetTableType(RATFieldType.Thematic)
+            GDALRATSetTableType(hRAT, RATTableType.Thematic)
         else:
-            GDALRATSetTableType(RATFieldType.Athematic)
+            GDALRATSetTableType(hRAT, RATTableType.Athematic)
 
         GDALSetDefaultRAT(hBand, hRAT)
 

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -45,6 +45,34 @@ class ColorInterp(IntEnum):
     Cr = 16
 
 
+class RATFieldType(IntEnum):
+    """Raster attribute table field type"""
+    Integer = 0
+    Real = 1
+    String = 2
+
+class RATFieldUsage(IntEnum):
+    """Raster attribute table field usage"""
+    Generic = 0
+    PixelCount = 1
+    Name = 2
+    Min = 3
+    Max = 4 
+    MinMax = 5
+    Red = 6
+    Green = 7
+    Blue = 8
+    Alpha = 9
+    RedMin = 10
+    GreenMin = 11
+    BlueMin = 12
+    AlphaMin = 13
+    RedMax = 14
+    GreenMax = 15
+    BlueMax = 16
+    AlphaMax = 17
+    MaxCount = 18
+
 class Resampling(IntEnum):
     """Available warp resampling algorithms.
     

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -73,6 +73,10 @@ class RATFieldUsage(IntEnum):
     AlphaMax = 17
     MaxCount = 18
 
+class RATTableType(IntEnum):
+    Thematic = 0
+    Athematic = 1
+
 class Resampling(IntEnum):
     """Available warp resampling algorithms.
     

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -308,6 +308,10 @@ cdef extern from "gdal.h" nogil:
         GFU_AlphaMax
         GFU_MaxCount
 
+    ctypedef enum GDALRATTableType:
+        GRTT_THEMATIC
+        GRTT_ATHEMATIC
+
     ctypedef struct GDALColorEntry:
         short c1
         short c2
@@ -431,13 +435,25 @@ cdef extern from "gdal.h" nogil:
     int GDALGetRasterColorInterpretation(GDALRasterBandH band)
     int GDALSetRasterColorInterpretation(GDALRasterBandH band, GDALColorInterp)
     GDALRasterAttributeTableH GDALGetDefaultRAT(GDALRasterBandH band)
+    CPLErr GDALSetDefaultRAT(GDALRasterBandH hBand, GDALRasterAttributeTableH hRAT)
+    GDALRasterAttributeTableH GDALCreateRasterAttributeTable()
+    CPLErr GDALSetDefaultRAT(GDALRasterBandH hBand, GDALRasterAttributeTableH hRAT)
+    CPLErr GDALRATCreateColumn(GDALRasterAttributeTableH hRAT,
+                               const char * pszFieldName,
+                               GDALRATFieldType eFieldType,
+                               GDALRATFieldUsage eFieldUsage)
     int GDALRATGetRowCount(GDALRasterAttributeTableH hRAT)
     int GDALRATGetColumnCount(GDALRasterAttributeTableH hRAT)
     const char* GDALRATGetValueAsString(GDALRasterAttributeTableH hRAT, int iRow, int iField)
     int GDALRATGetValueAsInt(GDALRasterAttributeTableH hRAT, int iRow, int iField)
     double GDALRATGetValueAsDouble(GDALRasterAttributeTableH hRAT, int iRow, int iField)
+    void GDALRATSetValueAsDouble(GDALRasterAttributeTableH hRAT, int iRow, int iField, double dfValue)
+    void GDALRATSetValueAsInt(GDALRasterAttributeTableH hRAT, int iRow, int iField, int nValue)
+    void GDALRATSetValueAsString(GDALRasterAttributeTableH hRAT, int iRow, int iField, const char * pszValue)
     GDALRATFieldType GDALRATGetTypeOfCol(GDALRasterAttributeTableH hRAT, int iCol)
     GDALRATFieldUsage GDALRATGetUsageOfCol(GDALRasterAttributeTableH hRAT, int iCol)
+    CPLErr GDALRATSetTableType(GDALRasterAttributeTableH hRAT, const GDALRATSetTableType elnTableType)
+    GDALRATSetTableType GDALRATGetTableType(GDALRasterAttributeTableH hRAT)
     const char *GDALRATGetNameOfCol(void *hRat, int col)
     int GDALGetMaskFlags(GDALRasterBandH band)
     int GDALCreateDatasetMaskBand(GDALDatasetH hds, int flags)

--- a/rasterio/gdal.pxi
+++ b/rasterio/gdal.pxi
@@ -281,6 +281,32 @@ cdef extern from "gdal.h" nogil:
         GCI_YCbCr_CbBand
         GCI_YCbCr_CrBand
         GCI_Max
+    
+    ctypedef enum GDALRATFieldType:
+        GFT_Integer
+        GFT_Real
+        GFT_String
+
+    ctypedef enum GDALRATFieldUsage:
+        GFU_Generic
+        GFU_PixelCount
+        GFU_Name
+        GFU_Min
+        GFU_Max
+        GFU_MinMax
+        GFU_Red
+        GFU_Green
+        GFU_Blue
+        GFU_Alpha
+        GFU_RedMin
+        GFU_GreenMin
+        GFU_BlueMin
+        GFU_AlphaMin
+        GFU_RedMax
+        GFU_GreenMax
+        GFU_BlueMax
+        GFU_AlphaMax
+        GFU_MaxCount
 
     ctypedef struct GDALColorEntry:
         short c1
@@ -404,6 +430,15 @@ cdef extern from "gdal.h" nogil:
     int GDALGetColorEntryCount(GDALColorTableH table)
     int GDALGetRasterColorInterpretation(GDALRasterBandH band)
     int GDALSetRasterColorInterpretation(GDALRasterBandH band, GDALColorInterp)
+    GDALRasterAttributeTableH GDALGetDefaultRAT(GDALRasterBandH band)
+    int GDALRATGetRowCount(GDALRasterAttributeTableH hRAT)
+    int GDALRATGetColumnCount(GDALRasterAttributeTableH hRAT)
+    const char* GDALRATGetValueAsString(GDALRasterAttributeTableH hRAT, int iRow, int iField)
+    int GDALRATGetValueAsInt(GDALRasterAttributeTableH hRAT, int iRow, int iField)
+    double GDALRATGetValueAsDouble(GDALRasterAttributeTableH hRAT, int iRow, int iField)
+    GDALRATFieldType GDALRATGetTypeOfCol(GDALRasterAttributeTableH hRAT, int iCol)
+    GDALRATFieldUsage GDALRATGetUsageOfCol(GDALRasterAttributeTableH hRAT, int iCol)
+    const char *GDALRATGetNameOfCol(void *hRat, int col)
     int GDALGetMaskFlags(GDALRasterBandH band)
     int GDALCreateDatasetMaskBand(GDALDatasetH hds, int flags)
     void *GDALGetMaskBand(GDALRasterBandH band)


### PR DESCRIPTION
Adds the ability to read and write raster attribute tables (RAT) per #3185. The RAT is represented in python as a list of dictionaries where each dictionary describes a column and contains the column values. The dictionary keys are:

        column_name Name of the column
        column_type Data type of the column values.
                    ``RATFieldType.<enum>``
                     see https://gdal.org/en/latest/doxygen/gdal_8h.html#a810154ac91149d1a63c42717258fe16e
        column_usage Indicates the specific usage of the column if defined. 
                    ``RATFieldUsage.<enum>``
                     see https://gdal.org/en/latest/doxygen/gdal_8h.html#a27bf786b965d5227da1acc2a4cab69a1
        Values list of column values
        
        
  RAT is read with:
    
```python
with rasterio.open(...) as src:
    rat, rat_type = src.rat(1)
```

and written with:
```python
with rasterio.open(..., 'w') as dst:
    dst.write_rat(1, rat, rat_type)
```

Potential changes to discuss:
* Create a python class to hold the raster attribute table rather than a list of dictionaries
* Have an option to read the RAT as a pandas DataFrame or numpy array

Todo:

- [ ] Add unit tests
- [ ] Add validation before a RAT is written
- [ ] Usage documentation

As far as I can tell, esri has it's own standard for writing raster attribute tables as .dbf sidecar files that GDAL does not read so this won't work for rasters written by ArcGIS products.