### PR TITLE
Comparisons to `None` should always be done with `is` or `is not`

### DIFF
--- a/tests/test_crs.py
+++ b/tests/test_crs.py
@@ -75,7 +75,7 @@ def test_read_epsg():
 def test_read_compdcs():
     """Expect no match for a single EPSG for this COMPDCS"""
     with rasterio.open('zip://tests/data/ak-compdcs.zip!test.tif') as src:
-        assert src.crs.to_epsg() == None
+        assert src.crs.to_epsg() is None
 
 
 def test_read_no_crs():


### PR DESCRIPTION
https://docs.astral.sh/ruff/rules/none-comparison
```diff
- assert src.crs.to_epsg() == None
+ assert src.crs.to_epsg() is None
```