### PR TITLE
Support all GDALFillNodata() options in rasterio.fill

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -7,7 +7,7 @@ Changes
 Bug fixes:
 
 - All options of GDALFillNodata() are now supported by the method in
-  rasterio.fill (#).
+  rasterio.fill (#3265).
 - The flag for GDAL driver registration has been changed to an _env module
   attribute. Drivers should only be registered once per process at most
   (#3260). A side effect of this is that the GDAL_SKIP configuration option,

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,8 @@ Changes
 
 Bug fixes:
 
+- All options of GDALFillNodata() are now supported by the method in
+  rasterio.fill (#).
 - The flag for GDAL driver registration has been changed to an _env module
   attribute. Drivers should only be registered once per process at most
   (#3260). A side effect of this is that the GDAL_SKIP configuration option,

--- a/rasterio/_fill.pyx
+++ b/rasterio/_fill.pyx
@@ -34,7 +34,9 @@ def _fillnodata(
             mask_band = mask_dataset.band(1)
 
         for k, v in filloptions.items():
-            alg_options = CSLSetNameValue(alg_options, k.upper(), v)
+            k = k.upper()
+            v = str(v)
+            alg_options = CSLSetNameValue(alg_options, k, v)
 
         if CSLFindName(alg_options, "TEMP_FILE_DRIVER") < 0:
             alg_options = CSLSetNameValue(alg_options, "TEMP_FILE_DRIVER", "MEM")

--- a/rasterio/_fill.pyx
+++ b/rasterio/_fill.pyx
@@ -1,4 +1,5 @@
 # distutils: language = c++
+# cython: c_string_type=unicode, c_string_encoding=utf8
 
 """Raster fill."""
 
@@ -9,8 +10,13 @@ from rasterio._err cimport exc_wrap_int
 from rasterio._io cimport MemoryDataset
 
 
-def _fillnodata(image, mask, double max_search_distance=100.0,
-                int smoothing_iterations=0):
+def _fillnodata(
+    image,
+    mask,
+    double max_search_distance=100.0,
+    int smoothing_iterations=0,
+    **filloptions
+):
     cdef GDALRasterBandH image_band = NULL
     cdef GDALRasterBandH mask_band = NULL
     cdef char **alg_options = NULL
@@ -27,11 +33,26 @@ def _fillnodata(image, mask, double max_search_distance=100.0,
             mask_dataset = MemoryDataset(mask_cast)
             mask_band = mask_dataset.band(1)
 
-        alg_options = CSLSetNameValue(alg_options, "TEMP_FILE_DRIVER", "MEM")
+        for k, v in filloptions.items():
+            alg_options = CSLSetNameValue(alg_options, k.upper(), v)
+
+        if CSLFindName(alg_options, "TEMP_FILE_DRIVER") < 0:
+            alg_options = CSLSetNameValue(alg_options, "TEMP_FILE_DRIVER", "MEM")
+
         exc_wrap_int(
-            GDALFillNodata(image_band, mask_band, max_search_distance, 0,
-                           smoothing_iterations, alg_options, NULL, NULL))
+            GDALFillNodata(
+                image_band,
+                mask_band,
+                max_search_distance,
+                0,
+                smoothing_iterations,
+                alg_options,
+                NULL,
+                NULL
+            )
+        )
         return np.asarray(image_dataset)
+
     finally:
         if image_dataset is not None:
             image_dataset.close()

--- a/rasterio/fill.py
+++ b/rasterio/fill.py
@@ -47,7 +47,10 @@ def fillnodata(
         The number of 3x3 smoothing filter passes to run. The default is
         0.
     filloptions :
-        See https://gdal.org/en/stable/api/gdal_alg.html.
+        Keyword arguments providing finer control over filling. See
+        https://gdal.org/en/stable/api/gdal_alg.html. Lowercase option
+        names and numerical values are allowed. For example:
+        nodata=0 is a valid keyword argument.
 
     Returns
     -------

--- a/rasterio/fill.py
+++ b/rasterio/fill.py
@@ -9,10 +9,8 @@ from rasterio import dtypes
 
 @ensure_env
 def fillnodata(
-        image,
-        mask=None,
-        max_search_distance=100.0,
-        smoothing_iterations=0):
+    image, mask=None, max_search_distance=100.0, smoothing_iterations=0, **filloptions
+):
     """Fill holes in raster data by interpolation
 
     This algorithm will interpolate values for all designated nodata
@@ -48,6 +46,8 @@ def fillnodata(
     smoothing_iterations : integer, optional
         The number of 3x3 smoothing filter passes to run. The default is
         0.
+    filloptions :
+        See https://gdal.org/en/stable/api/gdal_alg.html.
 
     Returns
     -------
@@ -66,5 +66,4 @@ def fillnodata(
 
     max_search_distance = float(max_search_distance)
     smoothing_iterations = int(smoothing_iterations)
-    return _fillnodata(
-        image, mask, max_search_distance, smoothing_iterations)
+    return _fillnodata(image, mask, max_search_distance, smoothing_iterations)


### PR DESCRIPTION
Part enhancement, part bug fix since we've generally considered missing options to be bugs.

Resolves #3175.