### PR TITLE
Force uint8 dtype for geometry mask

### DIFF
--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -72,7 +72,8 @@ def geometry_mask(
         transform=transform,
         all_touched=all_touched,
         fill=fill,
-        default_value=mask_value).astype('bool')
+        default_value=mask_value,
+        dtype='uint8').view('bool')
 
 
 @ensure_env


### PR DESCRIPTION
Addresses #3202 .

We know we are generating a mask, and can inform rasterize to use uint8 dtype. Because the return is uint8, we can simply return a boolean view of the array.