### PR TITLE
Extend rasterio.mask to accept ndarrays.

### DIFF
--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -490,7 +490,7 @@ def geometry_window(
         height = dataset.height
         width = dataset.width
     except AttributeError:
-        height, width = dataset.shape[:-2]
+        height, width = dataset.shape[-2:]
 
     cols = []
     rows = []

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -492,19 +492,16 @@ def geometry_window(
     else:
         height, width = dataset.shape[:-2]
 
-    cols = [
-        x
-        for (left, bottom, right, top) in all_bounds
-        for x in (left - pad_x, right + pad_x, right + pad_x, left - pad_x)
-    ]
-    rows = [
-        y
-        for (left, bottom, right, top) in all_bounds
-        for y in (top - pad_y, top - pad_y, bottom + pad_y, bottom + pad_y)
-    ]
 
-    row_start, row_stop = int(math.floor(min(rows))), int(math.ceil(max(rows)))
-    col_start, col_stop = int(math.floor(min(cols))), int(math.ceil(max(cols)))
+    cols = []
+    rows = []
+    for shape in shapes:
+        left, bottom, right, top = bounds(shape, transform=~transform)
+        cols.extend((left - pad_x, right + pad_x, right + pad_x, left - pad_x))
+        rows.extend((top - pad_y, top - pad_y, bottom + pad_y, bottom + pad_y))
+
+    row_start, row_stop = math.floor(min(rows)), math.ceil(max(rows))
+    col_start, col_stop = math.floor(min(cols)), math.ceil(max(cols))
 
     window = Window(
         col_off=col_start,

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -486,11 +486,7 @@ def geometry_window(
         except AttributeError:
             raise ValueError("Unable to read transform from dataset. Please provide a transform.")
 
-    try:
-        height = dataset.height
-        width = dataset.width
-    except AttributeError:
-        height, width = dataset.shape[-2:]
+    height, width = dataset.shape[-2:]
 
     cols = []
     rows = []

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -486,12 +486,11 @@ def geometry_window(
         except AttributeError:
             raise ValueError("Unable to read transform from dataset. Please provide a transform.")
 
-    if isinstance(dataset, DatasetBase):
+    try:
         height = dataset.height
         width = dataset.width
-    else:
+    except AttributeError:
         height, width = dataset.shape[:-2]
-
 
     cols = []
     rows = []

--- a/rasterio/mask.py
+++ b/rasterio/mask.py
@@ -5,6 +5,7 @@ import warnings
 
 import numpy as np
 
+from rasterio.dtypes import is_ndarray
 from rasterio.errors import WindowError
 from rasterio.features import geometry_mask, geometry_window
 from rasterio import windows
@@ -125,8 +126,19 @@ def raster_geometry_mask(
     return mask, transform, window
 
 
-def mask(dataset, shapes, all_touched=False, invert=False, nodata=None,
-         filled=True, crop=False, pad=False, pad_width=0.5, indexes=None):
+def mask(
+        dataset,
+        shapes,
+        all_touched=False,
+        invert=False,
+        nodata=None,
+        filled=True,
+        crop=False,
+        pad=False,
+        pad_width=0.5,
+        indexes=None,
+        transform=None
+    ):
     """Creates a masked or filled array using input shapes.
     Pixels are masked or set to nodata outside the input shapes, unless
     `invert` is `True`.
@@ -136,7 +148,7 @@ def mask(dataset, shapes, all_touched=False, invert=False, nodata=None,
 
     Parameters
     ----------
-    dataset : a dataset object opened in 'r' mode
+    dataset : ndarray or dataset object opened in 'r' mode
         Raster to which the mask will be applied.
     shapes : iterable object
         The values must be a GeoJSON-like dict or an object that implements
@@ -165,6 +177,8 @@ def mask(dataset, shapes, all_touched=False, invert=False, nodata=None,
     indexes : list of ints or a single int (opt)
         If `indexes` is a list, the result is a 3D array, but is
         a 2D array if it is a band index number.
+    transform : Affine (opt)
+        Transform to use for masking. Only used if dataset doesn't have a transform.
 
     Returns
     -------
@@ -186,26 +200,43 @@ def mask(dataset, shapes, all_touched=False, invert=False, nodata=None,
                 Information for mapping pixel coordinates in `masked` to another
                 coordinate system.
     """
-
     if nodata is None:
-        if dataset.nodata is not None:
+        if hasattr(dataset, 'nodata') and dataset.nodata is not None:
             nodata = dataset.nodata
         else:
             nodata = 0
 
     shape_mask, transform, window = raster_geometry_mask(
-        dataset, shapes, all_touched=all_touched, invert=invert, crop=crop,
-        pad=pad, pad_width=pad_width)
+        dataset,
+        shapes,
+        all_touched=all_touched,
+        invert=invert,
+        crop=crop,
+        pad=pad,
+        pad_width=pad_width,
+        transform=transform)
 
     if indexes is None:
-        out_shape = (dataset.count, ) + shape_mask.shape
+        if len(dataset.shape) == 3:
+            out_shape = (dataset.shape[0], *shape_mask.shape)
+        elif hasattr(dataset, 'count'):
+            out_shape = (dataset.count, *shape_mask.shape)
+        else:
+            out_shape = (1, *shape_mask.shape)
+        ndindexes = slice(None)
     elif isinstance(indexes, int):
         out_shape = shape_mask.shape
+        ndindexes = out_shape[0]
     else:
         out_shape = (len(indexes), ) + shape_mask.shape
+        ndindexes = indexes
 
-    out_image = dataset.read(
-        window=window, out_shape=out_shape, masked=True, indexes=indexes)
+    if is_ndarray(dataset):
+        out_image = dataset[ndindexes, *window.toslices()]
+        out_image = np.ma.masked_equal(out_image, nodata)
+    else:
+        out_image = dataset.read(
+            window=window, out_shape=out_shape, masked=True, indexes=indexes)
 
     out_image.mask = out_image.mask | shape_mask
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -168,7 +168,7 @@ def test_geometry_window_no_pad(basic_image_file, basic_geometry):
 
 def test_geometry_window_array(basic_geometry):
     arr = np.zeros((10, 15))
-    window = geometry_window(arr, [basic_geometry], transform=identity)
+    window = geometry_window(arr, [basic_geometry], transform=Affine.identity())
     assert window.flatten() == (2, 2, 3, 3)
 
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -166,6 +166,18 @@ def test_geometry_window_no_pad(basic_image_file, basic_geometry):
         assert window.flatten() == (2, 2, 3, 3)
 
 
+def test_geometry_window_array(basic_geometry):
+    arr = np.zeros((10, 15))
+    window = geometry_window(arr, [basic_geometry], transform=identity)
+    assert window.flatten() == (2, 2, 3, 3)
+
+
+def test_geometry_window_no_transform(basic_geometry):
+    arr = np.zeros((10, 15))
+    with pytest.raises(ValueError):
+        window = geometry_window(arr, [basic_geometry])
+
+
 def test_geometry_window_geo_interface(basic_image_file, basic_geometry):
     with rasterio.open(basic_image_file) as src:
         window = geometry_window(src, [MockGeoInterface(basic_geometry)])


### PR DESCRIPTION
This addresses a very awkward usage of masking. Only datasets are accepted in the functions in `rasterio.mask` making it very awkward to mask raster data in passes. Most of the underlying functions in `rasterio.features` accept ndarrays as input with the exception of the important `geometry_window` function.

This PR updates `geometry_window` to accept either a dataset or ndarray + transform, consistent with the rest of the functions in that module. Now that `geometry_window` can accept ndarrays, the functions in `rasterio.mask` can now also easily support operating on ndarrays as well.

In my day job, we have a dataset that is masked in several passes. Currently, the code clumsily uses MemoryFile as the only viable/publicly supported way to satisfy the API of rasterio. This results in lots of excess code. Now, hopefully, the outputs of mask can be passed back in as inputs to mask.