### PR TITLE
Don't fill masked output when reprojecting

### DIFF
--- a/rasterio/warp.py
+++ b/rasterio/warp.py
@@ -382,7 +382,7 @@ def reproject(
                 (int(dst_count), int(dst_height), int(dst_width)), dtype=source.dtype
             )
             if masked:
-                destination = np.ma.masked_array(destination).filled(dst_nodata)
+                destination = np.ma.masked_array(destination)
 
     dest = _reproject(
         source,

--- a/tests/test_warp.py
+++ b/tests/test_warp.py
@@ -1405,6 +1405,20 @@ def test_reproject_masked_masked_output(test3d, count_nonzero, path_rgb_byte_tif
     assert np.count_nonzero(out[out != np.ma.masked]) == count_nonzero
 
 
+@pytest.mark.skipif(not gdal_version.at_least("3.8"), reason="Requires GDAL >= 3.8")
+def test_reproject_to_masked_output(path_rgb_byte_tif):
+    with rasterio.open(path_rgb_byte_tif) as src:
+        inp = src.read(1)
+    out, _ = reproject(
+        inp,
+        src_transform=src.transform,
+        src_crs=src.crs,
+        dst_crs="EPSG:3857",
+        masked=True,
+    )
+    assert isinstance(out, np.ma.MaskedArray)
+
+
 @pytest.mark.parametrize("method", SUPPORTED_RESAMPLING)
 def test_reproject_resampling_alpha(method):
     """Reprojection of a source with alpha band succeeds"""


### PR DESCRIPTION
https://github.com/rasterio/rasterio/pull/3156 added a `masked` argument to `rasterio.warp.reproject`: https://github.com/rasterio/rasterio/blob/64474c1795d5d47c03e271386d21c3b244769946/rasterio/warp.py#L254-L255

I tried calling `rasterio.warp.warp` with `masked=True`, without passing a destination array. The documentation above suggests the output should be a masked array, but it's not. Reading through the code, it looks like a masked array is created but then immediately filled in: https://github.com/rasterio/rasterio/blob/64474c1795d5d47c03e271386d21c3b244769946/rasterio/warp.py#L385

I tried removing the `.filled(dst_nodata)`. The tests pass when I run them locally. I added a small test to check that the output is a masked array.