### PR TITLE
Add support for affine 3.0 Affine class serialization

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -6,6 +6,7 @@ Changes
 
 Bug fixes:
 
+- Add support for JSON serialization of affine 3.0 Affine arrays (#3299).
 - Parsing of snuggs expressions containing "is" has been fixed (#3288).
 
 1.4.3 (2024-12-02)

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
-PYTHON_VERSION ?= 3.9
-GDAL ?= ubuntu-small-3.6.4
+PYTHON_VERSION ?= 3.12
+GDAL ?= ubuntu-small-3.9.3
 all: deps clean install test
 
 .PHONY: docs

--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -31,6 +31,7 @@ from rasterio.errors import (
     RasterBlockError, BandOverviewError)
 from rasterio.profiles import Profile
 from rasterio.transform import Affine, guard_transform, tastes_like_gdal
+from rasterio.serde import to_json
 from rasterio._path import _parse_path
 from rasterio import windows
 

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -8,7 +8,14 @@ import click
 
 import rasterio
 from rasterio.rio import options
-from rasterio.transform import from_gcps
+from rasterio.transform import Affine, from_gcps
+from rasterio.serde import to_json
+
+
+@to_json.register(Affine)
+def _(obj):
+    """Convert an Affine instance to a JSON serializable form."""
+    return obj._astuple
 
 
 @click.command(short_help="Print information about a data file.")
@@ -125,8 +132,11 @@ def info(ctx, input, aspect, indent, namespace, meta_member, verbose, bidx,
                 else:
                     click.echo(info[meta_member])
             else:
-                click.echo(json.dumps(info, sort_keys=True, indent=indent))
+                click.echo(
+                    json.dumps(info, sort_keys=True, indent=indent, default=to_json)
+                )
 
         elif aspect == 'tags':
             click.echo(
-                json.dumps(src.tags(ns=namespace), indent=indent))
+                json.dumps(src.tags(ns=namespace), indent=indent, default=to_json)
+            )

--- a/rasterio/rio/info.py
+++ b/rasterio/rio/info.py
@@ -14,7 +14,7 @@ from rasterio.serde import to_json
 
 @to_json.register(Affine)
 def _(obj):
-    """Convert an Affine instance to a JSON serializable form."""
+    """Convert an Affine (version 3) obj to a tuple."""
     return obj._astuple
 
 

--- a/rasterio/rio/sample.py
+++ b/rasterio/rio/sample.py
@@ -11,7 +11,7 @@ from rasterio.serde import to_json
 
 @to_json.register(numpy.ndarray)
 def _(obj):
-    """Convert an ndarry to a JSON serializable form."""
+    """Convert an ndarry to a list."""
     return obj.tolist()
 
 

--- a/rasterio/rio/sample.py
+++ b/rasterio/rio/sample.py
@@ -1,8 +1,18 @@
+"""Sampling raster values."""
+
 import json
 
 import click
+import numpy
 
 import rasterio
+from rasterio.serde import to_json
+
+
+@to_json.register(numpy.ndarray)
+def _(obj):
+    """Convert an ndarry to a JSON serializable form."""
+    return obj.tolist()
 
 
 @click.command(short_help="Sample a dataset.")
@@ -76,4 +86,4 @@ def sample(ctx, files, bidx):
             for vals in src.sample(
                 (json.loads(line) for line in points), indexes=indexes
             ):
-                click.echo(json.dumps(vals.tolist()))
+                click.echo(json.dumps(vals, default=to_json))

--- a/rasterio/rio/warp.py
+++ b/rasterio/rio/warp.py
@@ -15,11 +15,18 @@ from rasterio.rio import options
 from rasterio.rio.helpers import resolve_inout
 from rasterio.rio.options import _cb_key_val
 from rasterio.transform import Affine
+from rasterio.serde import to_json
 from rasterio.warp import (
     reproject, Resampling, SUPPORTED_RESAMPLING, transform_bounds,
     aligned_target, calculate_default_transform as calcdt)
 
 logger = logging.getLogger(__name__)
+
+
+@to_json.register(Affine)
+def _(obj):
+    """Convert an Affine instance to a JSON serializable form."""
+    return obj._astuple
 
 
 @click.command(short_help='Warp a raster dataset.')
@@ -384,7 +391,7 @@ def warp(
                         out_kwargs['crs'] = src.crs.to_string()
 
                 click.echo("Output dataset profile:")
-                click.echo(json.dumps(dict(**out_kwargs), indent=2))
+                click.echo(json.dumps(dict(**out_kwargs), indent=2, default=to_json))
             else:
                 with rasterio.open(output, "w", **out_kwargs) as dst:
                     reproject(

--- a/rasterio/serde.py
+++ b/rasterio/serde.py
@@ -1,0 +1,9 @@
+"""Serialization and deserialization."""
+
+from functools import singledispatch
+
+
+@singledispatch
+def to_json(obj):
+    """Convert obj to a JSON serializable form."""
+    return obj

--- a/tests/test_read.py
+++ b/tests/test_read.py
@@ -7,6 +7,7 @@ import pytest
 import rasterio
 from rasterio._err import CPLE_AppDefinedError
 from rasterio.errors import DatasetIOShapeError, RasterioIOError
+from rasterio.transform import Affine
 
 # Find out if we've got HDF support (needed below).
 try:
@@ -37,10 +38,16 @@ class ReaderContextTest(unittest.TestCase):
                 self.assertAlmostEqual(s.bounds[i], v)
             self.assertEqual(
                 s.transform,
-                (300.0379266750948, 0.0, 101985.0,
-                 0.0, -300.041782729805, 2826915.0,
-                 0, 0, 1.0))
-            self.assertEqual(s.meta['crs'], s.crs)
+                Affine(
+                    300.0379266750948,
+                    0.0,
+                    101985.0,
+                    0.0,
+                    -300.041782729805,
+                    2826915.0,
+                ),
+            )
+            self.assertEqual(s.meta["crs"], s.crs)
             self.assertEqual(
                 repr(s),
                 "<open DatasetReader name='tests/data/RGB.byte.tif' "
@@ -55,9 +62,15 @@ class ReaderContextTest(unittest.TestCase):
         self.assertEqual(s.crs.to_epsg(), 32618)
         self.assertEqual(
             s.transform,
-            (300.0379266750948, 0.0, 101985.0,
-             0.0, -300.041782729805, 2826915.0,
-             0, 0, 1.0))
+            Affine(
+                300.0379266750948,
+                0.0,
+                101985.0,
+                0.0,
+                -300.041782729805,
+                2826915.0,
+            ),
+        )
         self.assertEqual(
             repr(s),
             "<closed DatasetReader name='tests/data/RGB.byte.tif' "


### PR DESCRIPTION
Rasterio now defines a `to_json()` function to use with `json.dumps()`. By default it returns its argument. To turn objects like Affine instances into JSON serializable tupes, we register functions with the `to_json()` dispatcher in `rio/info.py`, `rio/sample.py`, and `rio/warp.py`.

I've tested this locally with the main branch of the affine project.

Resolves #3298.