### PR TITLE
Fix reproject for masked arrays with numpy.ma.nomask

### DIFF
--- a/rasterio/_warp.pyx
+++ b/rasterio/_warp.pyx
@@ -378,7 +378,14 @@ def _reproject(
             src_bidx = range(1, src_count + 1)
 
             if hasattr(source, "mask"):
-                mask = ~np.logical_or.reduce(source.mask) * np.uint8(255)
+                if source.mask is np.ma.nomask:
+                    if source.ndim == 2:
+                        mask_shape = source.shape
+                    else:
+                        mask_shape = source.shape[1:]
+                    mask = np.full(mask_shape, np.uint8(255))
+                else:
+                    mask = ~np.logical_or.reduce(source.mask) * np.uint8(255)
                 source_arr = np.concatenate((source.data, [mask]))
                 src_alpha = src_alpha or source_arr.shape[0]
             else:


### PR DESCRIPTION
Masked arrays can have their `mask` attribute set to [`numpy.ma.nomask`](https://numpy.org/doc/stable/reference/maskedarray.baseclass.html#numpy.ma.nomask) to indicate that no values are masked. If I try to reproject such an array using `rasterio.warp.reproject`, I get the following error:

```
ValueError: all the input arrays must have same number of dimensions, but the array at index 0 has 3 dimension(s) and the array at index 1 has 1 dimension(s)
```

The error comes from this line: https://github.com/rasterio/rasterio/blob/7adb4f5b32c006067cca2aaa8a4004ed100f994a/rasterio/_warp.pyx#L382

This pull request is an attempt to fix the issue by filling the alpha mask with `255` if the input array's mask is set to the `numpy.ma.nomask` constant.