### PR TITLE
Fix `**filloptions` not being passed to `_fillnodata`

### DIFF
--- a/rasterio/fill.py
+++ b/rasterio/fill.py
@@ -69,4 +69,4 @@ def fillnodata(
 
     max_search_distance = float(max_search_distance)
     smoothing_iterations = int(smoothing_iterations)
-    return _fillnodata(image, mask, max_search_distance, smoothing_iterations)
+    return _fillnodata(image, mask, max_search_distance, smoothing_iterations, **filloptions)


### PR DESCRIPTION
`**filloptions` kwargs are not passed to `_fillnodata` function, and, so, are never used. 

Is it for some reason or it is just a mistake?