### PR TITLE
import gdal - windows fix

### DIFF
--- a/rasterio/__init__.py
+++ b/rasterio/__init__.py
@@ -22,6 +22,7 @@ if platform.system() == "Windows":
                 if p and glob.glob(os.path.join(p, "gdal*.dll")):
                     os.add_dll_directory(os.path.abspath(p))
 
+from osgeo import gdal
 from rasterio._base import DatasetBase
 from rasterio._io import Statistics
 from rasterio._vsiopener import _opener_registration


### PR DESCRIPTION
Add a single line to import gdal before _base. 

This fixes DLL load errors when importing rasterio (installed via conda-forge). 


