### PR TITLE
rasterio.merge.merge: fix formatting of pre-defined method docs

### DIFF
--- a/rasterio/merge.py
+++ b/rasterio/merge.py
@@ -164,10 +164,12 @@ def merge(
         Default: `Resampling.nearest`.
     method : str or callable
         pre-defined method:
-            first: reverse painting
-            last: paint valid new on top of existing
-            min: pixel-wise min of existing and new
-            max: pixel-wise max of existing and new
+
+            * first: reverse painting
+            * last: paint valid new on top of existing
+            * min: pixel-wise min of existing and new
+            * max: pixel-wise max of existing and new
+
         or custom callable with signature:
             merged_data : array_like
                 array to update with new_data


### PR DESCRIPTION
Fixes the formatting of the "pre-defined method" section of the [merge](https://rasterio.readthedocs.io/en/stable/api/rasterio.merge.html#rasterio.merge.merge) docs.

### Before

<img width="562" alt="Screenshot 2025-05-19 at 8 18 19 PM" src="https://github.com/user-attachments/assets/3e5771db-c5eb-4e8e-9444-09b456bb6276" />

### After

<img width="383" alt="Screenshot 2025-05-20 at 9 54 46 AM" src="https://github.com/user-attachments/assets/dae3a8dd-65cd-475a-9f69-4bccb32db0bc" />
