### PR TITLE
Deps: attrs -> attr

### DIFF
--- a/rasterio/_show_versions.py
+++ b/rasterio/_show_versions.py
@@ -59,7 +59,7 @@ def _get_deps_info():
     """
     deps = [
         "affine",
-        "attrs",
+        "attr",
         "certifi",
         "click",
         "cligj",

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # testing rasterio. It is used in the project's CI builds.
 
 affine~=2.3.0
-attrs>=19.2.0
+attr
 boto3>=1.3.1
 click~=8.0
 click-plugins

--- a/setup.py
+++ b/setup.py
@@ -248,7 +248,7 @@ with open("README.rst", encoding="utf-8") as f:
 # Runtime requirements.
 inst_reqs = [
     "affine",
-    "attrs",
+    "attr",
     "certifi",
     "click>=4.0",
     "cligj>=0.5",

--- a/tests/test_show_versions.py
+++ b/tests/test_show_versions.py
@@ -28,7 +28,7 @@ def test_get_deps_info():
     deps_info = _get_deps_info()
 
     assert "affine" in deps_info
-    assert "attrs" in deps_info
+    assert "attr" in deps_info
     assert "certifi" in deps_info
     assert "click" in deps_info
     assert "click-plugins" in deps_info


### PR DESCRIPTION
I'm very confused about how this could have possibly gone unnoticed for 5+ years, but...

We currently have an explicit dependency on `attrs`, but we don't actually import `attrs` anywhere. Instead, we import `attr`. Perhaps this was being installed as an indirect dependency? It seems like this may have changed, at least in RtD CI: https://app.readthedocs.org/projects/rasterio/builds/28225487/