### PR TITLE
RtD CI: attempt to fix build

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -16,5 +16,5 @@ conda:
 
 python:
   install:
-    - method: setuptools
+    - method: pip
       path: .


### PR DESCRIPTION
The `python setup.py install` (setuptools) method of installation is deprecated, let's see if changing this fixes the missing attrs install.