### PR TITLE
Docs: update conf.py with modern Sphinx syntax

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -40,7 +40,7 @@ templates_path = ['_templates']
 # The suffix(es) of source filenames.
 # You can specify multiple suffix as a list of string:
 # source_suffix = ['.rst', '.md']
-source_suffix = '.rst'
+source_suffix = {'.rst': 'restructuredtext'}
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'
@@ -75,7 +75,7 @@ except:
 #
 # This is also used if you do content translation via gettext catalogs.
 # Usually you set "language" from the command line for these cases.
-language = None
+language = 'en'
 
 # There are two options for replacing |today|: either, you set today to some
 # non-false value, then it is used:
@@ -367,8 +367,8 @@ epub_exclude_files = ['search.html']
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    "python": ("https://docs.python.org/", None),
-    "gdal": ("https://gdal.org/", None),
+    "python": ("https://docs.python.org/3/", None),
+    "gdal": ("https://gdal.org/en/stable/", None),
     "numpy": ("https://numpy.org/doc/stable", None),
     "matplotlib": ("https://matplotlib.org/stable/", None),
 }


### PR DESCRIPTION
Resolves the following compatibility warnings/conversions in CI:
```
WARNING: Invalid configuration value found: 'language = None'. Update your configuration to a valid language code. Falling back to 'en' (English).
Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`.
intersphinx inventory has moved: https://docs.python.org/objects.inv -> https://docs.python.org/3/objects.inv
intersphinx inventory has moved: https://gdal.org/objects.inv -> https://gdal.org/en/stable/objects.inv
```