### PR TITLE
Docs: remove docs for rasterio._loading

### DIFF
--- a/docs/api/rasterio._loading.rst
+++ b/docs/api/rasterio._loading.rst
@@ -1,8 +1,0 @@
-rasterio._loading module
-========================
-
-.. automodule:: rasterio._loading
-   :inherited-members:
-   :members:
-   :undoc-members:
-   :show-inheritance:


### PR DESCRIPTION
`rasterio._loading` appears to be a historical module that was removed. This rst page results in the following warning in RtD CI:
```
WARNING: autodoc: failed to import module '_loading' from module 'rasterio'; the following exception was raised:
['Traceback (most recent call last):\n', '  File "/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3340/lib/python3.11/site-packages/sphinx/ext/autodoc/importer.py", line 269, in import_object\n    module = import_module(modname, try_reload=True)\n             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n', '  File "/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3340/lib/python3.11/site-packages/sphinx/ext/autodoc/importer.py", line 172, in import_module\n    raise ModuleNotFoundError(msg, name=modname)  # NoQA: TRY301\n    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^\n', "ModuleNotFoundError: No module named 'rasterio._loading'\n"] [autodoc.import_object]
```