### PR TITLE
rasterio.features: rasterio.bool_ is not an rst link

### DIFF
--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -78,7 +78,7 @@ def geometry_mask(
 
 @ensure_env
 def shapes(source, mask=None, connectivity=4, transform=IDENTITY):
-    """Get shapes and values of connected regions in a dataset or array.
+    r"""Get shapes and values of connected regions in a dataset or array.
 
     Parameters
     ----------
@@ -86,7 +86,7 @@ def shapes(source, mask=None, connectivity=4, transform=IDENTITY):
         Data type must be one of rasterio.int8, rasterio.int16, rasterio.int32,
         rasterio.uint8, rasterio.uint16, rasterio.float32, or rasterio.float64.
     mask : numpy.ndarray or rasterio Band object, optional
-        Must evaluate to bool (rasterio.bool_ or rasterio.uint8). Values
+        Must evaluate to bool (rasterio.bool\_ or rasterio.uint8). Values
         of False or 0 will be excluded from feature generation.  Note
         well that this is the inverse sense from Numpy's, where a mask
         value of True indicates invalid data in an array. If `source` is
@@ -131,7 +131,7 @@ def shapes(source, mask=None, connectivity=4, transform=IDENTITY):
 
 @ensure_env
 def sieve(source, size, out=None, mask=None, connectivity=4):
-    """Remove small polygon regions from a raster.
+    r"""Remove small polygon regions from a raster.
 
     Polygons are found for each set of neighboring pixels of the same
     value.
@@ -150,7 +150,7 @@ def sieve(source, size, out=None, mask=None, connectivity=4):
         results.
     mask : numpy ndarray or rasterio Band object, optional
         Values of False or 0 will be excluded from feature generation
-        Must evaluate to bool (rasterio.bool_ or rasterio.uint8)
+        Must evaluate to bool (rasterio.bool\_ or rasterio.uint8)
     connectivity : int, optional
         Use 4 or 8 pixel connectivity for grouping pixels into features
 


### PR DESCRIPTION
Sphinx treats things that end with an underscore as a hyperlink. However, `rasterio.bool_` is an object, not a link. We need to either escape the underscore or convert it to a formal link. This resolves the following warnings in RtD CI:
```
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3340/lib/python3.11/site-packages/rasterio/features.py:docstring of rasterio.features.shapes:: ERROR: Unknown target name: "rasterio.bool". [docutils]
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3340/lib/python3.11/site-packages/rasterio/features.py:docstring of rasterio.features.sieve:: ERROR: Unknown target name: "rasterio.bool". [docutils]
```
You can also check the docs and see the broken link that gets generated.

### Before

<img width="551" alt="Screenshot 2025-05-20 at 11 41 47 AM" src="https://github.com/user-attachments/assets/8e5ddfe3-9c24-4a1e-9d6f-dfe90ccde25e" />

### After

<img width="549" alt="Screenshot 2025-05-20 at 11 42 20 AM" src="https://github.com/user-attachments/assets/15bed11c-537e-4a19-9bc6-7b5c202261cc" />
