### PR TITLE
Docs: fix .. note:: directive

### DIFF
--- a/docs/topics/tags.rst
+++ b/docs/topics/tags.rst
@@ -16,7 +16,7 @@ I'm going to use the rasterio interactive inspector in these examples below.
     $ rio insp tests/data/RGB.byte.tif
     Rasterio 1.2.0 Interactive Inspector (Python 3.7.8)
     Type "src.name", "src.read(1)", or "help(src)" for more information.
-    >>> 
+    >>>
 
 Tags belong to namespaces. To get a copy of a dataset's tags from the default
 namespace, call :meth:`~.DatasetReader.tags` with no arguments.
@@ -33,12 +33,12 @@ for the first band, accessed using the positional band index argument of :meth:`
 
     >>> src.tags(1)['STATISTICS_MEAN']
     '29.947726688477'
-    
+
 These are the tags that came with the sample data I'm using to test rasterio. In
 practice, maintaining stats in the tags can be unreliable as there is no automatic
 update of the tags when the band's image data changes.
 
-The 3 standard, non-default GDAL tag namespaces are 'SUBDATASETS', 'IMAGE_STRUCTURE', 
+The 3 standard, non-default GDAL tag namespaces are 'SUBDATASETS', 'IMAGE_STRUCTURE',
 and 'RPC'. You can get the tags from these namespaces using the `ns` keyword of
 :meth:`~.DatasetReader.tags`.
 
@@ -52,9 +52,8 @@ and 'RPC'. You can get the tags from these namespaces using the `ns` keyword of
     {}
 
 .. note::
-
-A special case for GDAL tag namespaces are those prefixed with 'xml' e.g. 'xml:TRE' or 'xml:VRT'. 
-GDAL will treat these namespaces as a single xml string.
+   A special case for GDAL tag namespaces are those prefixed with 'xml' e.g. 'xml:TRE' or 'xml:VRT'.
+   GDAL will treat these namespaces as a single xml string.
 
 Writing tags
 ------------
@@ -64,28 +63,28 @@ using the :meth:`~.DatasetWriter.update_tags` method. Unicode tag values, too, a
 files.
 
 .. code-block:: python
-    
+
     import rasterio
 
     with rasterio.open(
-            '/tmp/test.tif', 
-            'w', 
-            driver='GTiff', 
-            count=1, 
-            dtype=rasterio.uint8, 
-            width=10, 
+            '/tmp/test.tif',
+            'w',
+            driver='GTiff',
+            count=1,
+            dtype=rasterio.uint8,
+            width=10,
             height=10) as dst:
 
         dst.update_tags(a='1', b='2')
         dst.update_tags(1, c=3)
         with pytest.raises(ValueError):
             dst.update_tags(4, d=4)
-        
+
         # True
         assert dst.tags() == {'a': '1', 'b': '2'}
         # True
         assert dst.tags(1) == {'c': '3' }
-        
+
         dst.update_tags(ns='rasterio_testing', rus=u'другая строка')
         # True
         assert dst.tags(ns='rasterio_testing') == {'rus': u'другая строка'}


### PR DESCRIPTION
Fixes the following warning in RtD CI:
```
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3340/docs/topics/tags.rst:54: ERROR: Content block expected for the "note" directive; none found. [docutils]
```