### PR TITLE
Docs: remove rio options documentation

### DIFF
--- a/docs/api/rasterio.rio.rst
+++ b/docs/api/rasterio.rio.rst
@@ -16,7 +16,6 @@ rio CLI
    rasterio.rio.insp
    rasterio.rio.mask
    rasterio.rio.merge
-   rasterio.rio.options
    rasterio.rio.overview
    rasterio.rio.rasterize
    rasterio.rio.rm


### PR DESCRIPTION
I don't fully understand whether or not `rio options` is supposed to work, but there is no rst document for it, resulting in the following warning in RtD CI:
```
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3340/docs/api/rasterio.rio.rst:4: WARNING: toctree contains reference to nonexisting document 'api/rasterio.rio.options' [toc.not_readable]
```