### PR TITLE
Docs: asterisk does not always mean italics

### DIFF
--- a/rasterio/rio/bounds.py
+++ b/rasterio/rio/bounds.py
@@ -48,7 +48,7 @@ def bounds(
     geojson_type,
 ):
     """Write bounding boxes to stdout as GeoJSON for use with, e.g.,
-    geojsonio
+    geojsonio::
 
       $ rio bounds *.tif | geojsonio
 

--- a/rasterio/rio/calc.py
+++ b/rasterio/rio/calc.py
@@ -91,7 +91,7 @@ def calc(ctx, command, files, output, driver, name, dtype, masked, overwrite, me
           the limits of the dataset's natural data type.
         * (take foo j) evaluates to the j-th band of a dataset named foo
           (see help on the --name option above).
-        * Standard numpy array operators (+, -, *, /) are available.
+        * Standard numpy array operators (+, -, \*, /) are available.
         * When the final result is a list of arrays, a multiple band
           output file is written.
         * When the final result is a single array, a single band output


### PR DESCRIPTION
When Sphinx sees an asterisk, it assumes you want italics. However, asterisks also appear in code or as math. We need to either convert these to formal code/math or escape the asterisk to prevent the following warnings in RtD CI:
```
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3340/docs/api/rasterio.rio.bounds.rst:4: WARNING: Inline emphasis start-string without end-string. [docutils]
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3340/docs/api/rasterio.rio.calc.rst:19: WARNING: Inline emphasis start-string without end-string. [docutils]
```

### Before

<img width="535" alt="Screenshot 2025-05-20 at 11 55 12 AM" src="https://github.com/user-attachments/assets/7edae65e-653f-4ad6-96d8-a455b3b79698" />
<img width="416" alt="Screenshot 2025-05-20 at 11 56 08 AM" src="https://github.com/user-attachments/assets/5dc73256-52e7-4cc9-9215-9a1d11a22cb4" />


### After

<img width="539" alt="Screenshot 2025-05-20 at 11 55 21 AM" src="https://github.com/user-attachments/assets/66bda7a5-a287-4dc7-98ea-305efc06ce1a" />
<img width="411" alt="Screenshot 2025-05-20 at 11 56 13 AM" src="https://github.com/user-attachments/assets/3331c4c2-857a-4223-96b2-fde6baebd472" />
