### PR TITLE
Docs: remove documentation of hidden modules

### DIFF
--- a/docs/api/rasterio._base.rst
+++ b/docs/api/rasterio._base.rst
@@ -1,7 +1,0 @@
-rasterio.\_base module
-======================
-
-.. automodule:: rasterio._base
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/rasterio._env.rst
+++ b/docs/api/rasterio._env.rst
@@ -1,7 +1,0 @@
-rasterio.\_env module
-=====================
-
-.. automodule:: rasterio._env
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/rasterio._err.rst
+++ b/docs/api/rasterio._err.rst
@@ -1,7 +1,0 @@
-rasterio.\_err module
-=====================
-
-.. automodule:: rasterio._err
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/rasterio._example.rst
+++ b/docs/api/rasterio._example.rst
@@ -1,7 +1,0 @@
-rasterio.\_example module
-=========================
-
-.. automodule:: rasterio._example
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/rasterio._features.rst
+++ b/docs/api/rasterio._features.rst
@@ -1,7 +1,0 @@
-rasterio.\_features module
-==========================
-
-.. automodule:: rasterio._features
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/rasterio._filepath.rst
+++ b/docs/api/rasterio._filepath.rst
@@ -1,8 +1,0 @@
-rasterio._filepath module
-=========================
-
-.. automodule:: rasterio._filepath
-   :inherited-members:
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/api/rasterio._fill.rst
+++ b/docs/api/rasterio._fill.rst
@@ -1,7 +1,0 @@
-rasterio.\_fill module
-======================
-
-.. automodule:: rasterio._fill
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/rasterio._io.rst
+++ b/docs/api/rasterio._io.rst
@@ -1,7 +1,0 @@
-rasterio.\_io module
-====================
-
-.. automodule:: rasterio._io
-    :members:
-    :undoc-members:
-    :show-inheritance:

--- a/docs/api/rasterio._transform.rst
+++ b/docs/api/rasterio._transform.rst
@@ -1,8 +1,0 @@
-rasterio._transform module
-==========================
-
-.. automodule:: rasterio._transform
-   :inherited-members:
-   :members:
-   :undoc-members:
-   :show-inheritance:

--- a/docs/api/rasterio._warp.rst
+++ b/docs/api/rasterio._warp.rst
@@ -1,7 +1,0 @@
-rasterio.\_warp module
-======================
-
-.. automodule:: rasterio._warp
-    :members:
-    :undoc-members:
-    :show-inheritance:


### PR DESCRIPTION
The following hidden modules have autodoc files, but aren't included in `index.rst`, meaning we waste time on generating webpages but never serve them. This results in the following warning in RtD CI:
```
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3348/docs/api/rasterio._base.rst: WARNING: document isn't included in any toctree [toc.not_included]
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3348/docs/api/rasterio._env.rst: WARNING: document isn't included in any toctree [toc.not_included]
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3348/docs/api/rasterio._err.rst: WARNING: document isn't included in any toctree [toc.not_included]
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3348/docs/api/rasterio._example.rst: WARNING: document isn't included in any toctree [toc.not_included]
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3348/docs/api/rasterio._features.rst: WARNING: document isn't included in any toctree [toc.not_included]
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3348/docs/api/rasterio._filepath.rst: WARNING: document isn't included in any toctree [toc.not_included]
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3348/docs/api/rasterio._fill.rst: WARNING: document isn't included in any toctree [toc.not_included]
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3348/docs/api/rasterio._io.rst: WARNING: document isn't included in any toctree [toc.not_included]
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3348/docs/api/rasterio._loading.rst: WARNING: document isn't included in any toctree [toc.not_included]
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3348/docs/api/rasterio._transform.rst: WARNING: document isn't included in any toctree [toc.not_included]
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/checkouts/3348/docs/api/rasterio._warp.rst: WARNING: document isn't included in any toctree [toc.not_included]
```