### PR TITLE
rasterio.coords.BoundingBox: fix attribute docs

### DIFF
--- a/rasterio/coords.py
+++ b/rasterio/coords.py
@@ -3,6 +3,8 @@
 from collections import namedtuple
 
 BoundingBox = namedtuple('BoundingBox', ('left', 'bottom', 'right', 'top'))
+
+# Required to properly document this namedtuple and its attributes
 BoundingBox.__doc__ = \
     """Bounding box named tuple, defining extent in cartesian coordinates.
 

--- a/rasterio/coords.py
+++ b/rasterio/coords.py
@@ -9,18 +9,11 @@ BoundingBox.__doc__ = \
     .. code::
 
         BoundingBox(left, bottom, right, top)
-
-    Attributes
-    ----------
-    left :
-        Left coordinate
-    bottom :
-        Bottom coordinate
-    right :
-        Right coordinate
-    top :
-        Top coordinate
     """
+BoundingBox.left.__doc__ = "Left coordinate"
+BoundingBox.bottom.__doc__ = "Bottom coordinate"
+BoundingBox.right.__doc__ = "Right coordinate"
+BoundingBox.top.__doc__ = "Top coordinate"
 
 def disjoint_bounds(bounds1, bounds2):
     """Compare two bounds and determine if they are disjoint.


### PR DESCRIPTION
Resolves the following warnings in RtD CI:
```
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3350/lib/python3.11/site-packages/rasterio/coords.py:docstring of rasterio.coords.BoundingBox.bottom:1: WARNING: duplicate object description of rasterio.coords.BoundingBox.bottom, other instance in api/rasterio.coords, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3350/lib/python3.11/site-packages/rasterio/coords.py:docstring of rasterio.coords.BoundingBox.left:1: WARNING: duplicate object description of rasterio.coords.BoundingBox.left, other instance in api/rasterio.coords, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3350/lib/python3.11/site-packages/rasterio/coords.py:docstring of rasterio.coords.BoundingBox.right:1: WARNING: duplicate object description of rasterio.coords.BoundingBox.right, other instance in api/rasterio.coords, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3350/lib/python3.11/site-packages/rasterio/coords.py:docstring of rasterio.coords.BoundingBox.top:1: WARNING: duplicate object description of rasterio.coords.BoundingBox.top, other instance in api/rasterio.coords, use :no-index: for one of them
```

### Before

<img width="522" alt="Screenshot 2025-05-21 at 12 48 23 PM" src="https://github.com/user-attachments/assets/a7fd96f7-7b78-4f29-8fc9-cc0c351f7e42" />

### After

<img width="519" alt="Screenshot 2025-05-21 at 12 51 53 PM" src="https://github.com/user-attachments/assets/beaba0fc-23ee-4cd5-9663-cc6c61fc6dda" />
