### PR TITLE
rasterio.enums.Resampling: fix enum docs

### DIFF
--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -4,8 +4,8 @@ from enum import Enum, IntEnum
 
 class TransformDirection(IntEnum):
     """Coordinate transform direction
-    
-    Forward transform direction defined as image pixel (row, col) to 
+
+    Forward transform direction defined as image pixel (row, col) to
     geographic/projected (x, y) coordinates. Reverse transform direction defined as
     geographic/projected (x, y) to image pixel (row, col) coordinates.
 
@@ -69,40 +69,7 @@ class ColorInterp(IntEnum):
 
 class Resampling(IntEnum):
     """Available warp resampling algorithms.
-    
-    Attributes
-    ----------
-    nearest
-        Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality).
-    bilinear
-        Bilinear resampling.
-    cubic
-        Cubic resampling.
-    cubic_spline
-        Cubic spline resampling.
-    lanczos
-        Lanczos windowed sinc resampling.
-    average
-        Average resampling, computes the weighted average of all non-NODATA contributing pixels.
-    mode
-        Mode resampling, selects the value which appears most often of all the sampled points.
-    gauss
-        Gaussian resampling, Note: not available to the functions in rio.warp.
-    max
-        Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.0)
-    min
-        Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.0)
-    med
-        Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.0)
-    q1
-        Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.0)
-    q3
-        Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.0)
-    sum
-        Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.1)
-    rms
-        RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)
-    
+
     Notes
     ----------
     The first 8, 'nearest', 'bilinear', 'cubic', 'cubic_spline',
@@ -135,6 +102,23 @@ class Resampling(IntEnum):
     q3 = 12
     sum = 13
     rms = 14
+
+
+Resampling.nearest.__doc__ = "Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality)."
+Resampling.bilinear.__doc__ = "Bilinear resampling."
+Resampling.cubic.__doc__ = "Cubic resampling."
+Resampling.cubic_split.__doc__ = "Cubic spline resampling."
+Resampling.lanczos.__doc__ = "Lanczos windowed sinc resampling."
+Resampling.average.__doc__ = "Average resampling, computes the weighted average of all non-NODATA contributing pixels."
+Resampling.mode.__doc__ = "Mode resampling, selects the value which appears most often of all the sampled points."
+Resampling.gauss.__doc__ = "Gaussian resampling, Note: not available to the functions in rio.warp."
+Resampling.max.__doc__ = "Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.0)"
+Resampling.min.__doc__ = "Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.0)"
+Resampling.med.__doc__ = "Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.0)"
+Resampling.q1.__doc__ = "Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.0)"
+Resampling.q3.__doc__ = "Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.0)"
+Resampling.sum.__doc__ = "Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.1)"
+Resampling.rms.__doc__ = "RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)"
 
 
 class OverviewResampling(IntEnum):

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -107,7 +107,7 @@ class Resampling(IntEnum):
 Resampling.nearest.__doc__ = "Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality)."
 Resampling.bilinear.__doc__ = "Bilinear resampling."
 Resampling.cubic.__doc__ = "Cubic resampling."
-Resampling.cubic_split.__doc__ = "Cubic spline resampling."
+Resampling.cubic_spline.__doc__ = "Cubic spline resampling."
 Resampling.lanczos.__doc__ = "Lanczos windowed sinc resampling."
 Resampling.average.__doc__ = "Average resampling, computes the weighted average of all non-NODATA contributing pixels."
 Resampling.mode.__doc__ = "Mode resampling, selects the value which appears most often of all the sampled points."

--- a/rasterio/enums.py
+++ b/rasterio/enums.py
@@ -88,37 +88,35 @@ class Resampling(IntEnum):
     Note: 'gauss' is not available to the functions in rio.warp.
     """
     nearest = 0
+    """Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality)."""
     bilinear = 1
+    """Bilinear resampling."""
     cubic = 2
+    """Cubic resampling."""
     cubic_spline = 3
+    """Cubic spline resampling."""
     lanczos = 4
+    """Lanczos windowed sinc resampling."""
     average = 5
+    """Average resampling, computes the weighted average of all non-NODATA contributing pixels."""
     mode = 6
+    """Mode resampling, selects the value which appears most often of all the sampled points."""
     gauss = 7
+    """Gaussian resampling, Note: not available to the functions in rio.warp."""
     max = 8
+    """Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.0)"""
     min = 9
+    """Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.0)"""
     med = 10
+    """Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.0)"""
     q1 = 11
+    """Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.0)"""
     q3 = 12
+    """Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.0)"""
     sum = 13
+    """Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.1)"""
     rms = 14
-
-
-Resampling.nearest.__doc__ = "Nearest neighbor resampling (default, fastest algorithm, worst interpolation quality)."
-Resampling.bilinear.__doc__ = "Bilinear resampling."
-Resampling.cubic.__doc__ = "Cubic resampling."
-Resampling.cubic_spline.__doc__ = "Cubic spline resampling."
-Resampling.lanczos.__doc__ = "Lanczos windowed sinc resampling."
-Resampling.average.__doc__ = "Average resampling, computes the weighted average of all non-NODATA contributing pixels."
-Resampling.mode.__doc__ = "Mode resampling, selects the value which appears most often of all the sampled points."
-Resampling.gauss.__doc__ = "Gaussian resampling, Note: not available to the functions in rio.warp."
-Resampling.max.__doc__ = "Maximum resampling, selects the maximum value from all non-NODATA contributing pixels. (GDAL >= 2.0)"
-Resampling.min.__doc__ = "Minimum resampling, selects the minimum value from all non-NODATA contributing pixels. (GDAL >= 2.0)"
-Resampling.med.__doc__ = "Median resampling, selects the median value of all non-NODATA contributing pixels. (GDAL >= 2.0)"
-Resampling.q1.__doc__ = "Q1, first quartile resampling, selects the first quartile value of all non-NODATA contributing pixels. (GDAL >= 2.0)"
-Resampling.q3.__doc__ = "Q3, third quartile resampling, selects the third quartile value of all non-NODATA contributing pixels. (GDAL >= 2.0)"
-Resampling.sum.__doc__ = "Sum, compute the weighted sum of all non-NODATA contributing pixels. (GDAL >= 3.1)"
-Resampling.rms.__doc__ = "RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)"
+    """RMS, root mean square / quadratic mean of all non-NODATA contributing pixels. (GDAL >= 3.3)"""
 
 
 class OverviewResampling(IntEnum):


### PR DESCRIPTION
Resolves the following warnings in RtD CI:
```
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.average:1: WARNING: duplicate object description of rasterio.enums.Resampling.average, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.bilinear:1: WARNING: duplicate object description of rasterio.enums.Resampling.bilinear, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.cubic:1: WARNING: duplicate object description of rasterio.enums.Resampling.cubic, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.cubic_spline:1: WARNING: duplicate object description of rasterio.enums.Resampling.cubic_spline, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.gauss:1: WARNING: duplicate object description of rasterio.enums.Resampling.gauss, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.lanczos:1: WARNING: duplicate object description of rasterio.enums.Resampling.lanczos, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.max:1: WARNING: duplicate object description of rasterio.enums.Resampling.max, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.med:1: WARNING: duplicate object description of rasterio.enums.Resampling.med, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.min:1: WARNING: duplicate object description of rasterio.enums.Resampling.min, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.mode:1: WARNING: duplicate object description of rasterio.enums.Resampling.mode, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.nearest:1: WARNING: duplicate object description of rasterio.enums.Resampling.nearest, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.q1:1: WARNING: duplicate object description of rasterio.enums.Resampling.q1, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.q3:1: WARNING: duplicate object description of rasterio.enums.Resampling.q3, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.rms:1: WARNING: duplicate object description of rasterio.enums.Resampling.rms, other instance in api/rasterio.enums, use :no-index: for one of them
/home/docs/checkouts/readthedocs.org/user_builds/rasterio/conda/3351/lib/python3.11/site-packages/rasterio/enums.py:docstring of rasterio.enums.Resampling.sum:1: WARNING: duplicate object description of rasterio.enums.Resampling.sum, other instance in api/rasterio.enums, use :no-index: for one of them
```

### Before

<img width="247" alt="Screenshot 2025-05-21 at 1 00 26 PM" src="https://github.com/user-attachments/assets/cb23540f-2e6f-4ebd-8dd9-7d87413c83c6" />

### After

<img width="372" alt="Screenshot 2025-05-21 at 1 20 51 PM" src="https://github.com/user-attachments/assets/7fcc1f8e-8367-40f0-a21c-6351e4cabf2b" />
