### PR TITLE
Add threadsafe flag to readonly rasters.

### DIFF
--- a/rasterio/_base.pyx
+++ b/rasterio/_base.pyx
@@ -32,6 +32,7 @@ from rasterio.errors import (
 from rasterio.profiles import Profile
 from rasterio.transform import Affine, guard_transform, tastes_like_gdal
 from rasterio._path import _parse_path
+from rasterio._version import get_gdal_version_info
 from rasterio import windows
 
 cimport cython
@@ -305,6 +306,10 @@ cdef class DatasetBase:
 
             # Read-only + Rasters + Sharing + Errors
             flags = 0x00 | 0x02 | sharing_flag | 0x40
+
+            # Threadsafe support added in GDAL 3.10 for Read-only rasters
+            if get_gdal_version_info("VERSION_NUM") >= "310":
+                flags |= 0x800
 
             try:
                 self._hds = open_dataset(filename, flags, driver, kwargs, None)


### PR DESCRIPTION
Experiment with adding the threadsafe flag to read-only rasters.

The new functionality are explained here: https://gdal.org/en/stable/development/rfc/rfc101_raster_dataset_threadsafety.html

One section of note:

> A Python equivalent of multireadtest has been written. Scalability depends on how much Python code is executed. If relatively few long-enough calls to GDAL are done, scalability tends to be good due to the Python Global Interpreter Lock (GIL) being dropped around them. If many short calls are done, the GIL itself, or its repeated acquisition and release, becomes the bottleneck. This is no different than using a GDALDataset per thread.

I've not extensively tested this, hence the draft PR. I'm not sure if there are other changes required in rasterio.

