### PR TITLE
Remove default=False for flag_value of str type

### DIFF
--- a/rasterio/rio/edit_info.py
+++ b/rasterio/rio/edit_info.py
@@ -121,7 +121,7 @@ def colorinterp_handler(ctx, param, value):
 @click.option('--tag', 'tags', callback=tags_handler, multiple=True,
               metavar='KEY=VAL', help="New tag.")
 @click.option('--all', 'allmd', callback=all_handler, flag_value='like',
-              is_eager=True, default=False,
+              is_eager=True,
               help="Copy all metadata items from the template file.")
 @click.option(
     '--colorinterp', callback=colorinterp_handler,

--- a/rasterio/rio/options.py
+++ b/rasterio/rio/options.py
@@ -319,7 +319,6 @@ creation_options = click.option(
 rgb_opt = click.option(
     '--rgb', 'photometric',
     flag_value='rgb',
-    default=False,
     help="Set RGB photometric interpretation.")
 
 overwrite_opt = click.option(


### PR DESCRIPTION
According to click upstream [1], `default=False` was not supported with `flag_value='some string'`. Omitting the argument will keep it `None`, which should be about the same as `False`, mostly.

[1] https://github.com/pallets/click/issues/3054#issuecomment-3243872056