### PR TITLE
BLD: Avoid click 8.2.*

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,7 +4,8 @@
 affine~=2.3.0
 attrs>=19.2.0
 boto3>=1.3.1
-click~=8.0
+# Avoid pallets/click#2939
+click~=8.0,!=8.2.*
 click-plugins
 cligj>=0.5
 matplotlib

--- a/setup.py
+++ b/setup.py
@@ -250,7 +250,8 @@ inst_reqs = [
     "affine",
     "attrs",
     "certifi",
-    "click>=4.0",
+    # Avoid pallets/click#2939.
+    "click>=4.0,!=8.2.*",
     "cligj>=0.5",
     "importlib-metadata ; python_version < '3.10'",
     "numpy>=1.24",


### PR DESCRIPTION
Due to pallets/click#2939, input from a file is broken. This should be fixed by pallets/click#2940, which is scheduled to be in click 8.3.0.