### PR TITLE
Move project metadata to pyproject.toml (PEP 621)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -63,6 +63,7 @@ target/
 
 # IDE's etc.
 .idea/
+.venv/
 venv/
 venv2/
 .vscode/

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,5 @@
 exclude *.rst *.txt *.py
-include CHANGES.txt AUTHORS.txt LICENSE.txt VERSION.txt README.rst setup.py pyproject.toml
+include CHANGES.txt AUTHORS.txt LICENSE.txt README.rst setup.py pyproject.toml
 include rasterio/*.pyx
 include rasterio/*.pxd
 include rasterio/*.pxi

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [build-system]
 requires = [
-    "setuptools>=67.8",
+    "setuptools>=77.0.3",
     "wheel",
     "cython~=3.1.0",
     "numpy>=2"
@@ -43,12 +43,12 @@ dependencies = [
     "affine",
     "attrs",
     "certifi",
-    # Avoid pallets/click#2939.
+    # Avoid https://github.com/pallets/click/issues/2939
     "click>=4.0,!=8.2.*",
+    "click-plugins",
     "cligj>=0.5",
     "importlib-metadata ; python_version < '3.10'",
     "numpy>=1.24",
-    "click-plugins",
     "pyparsing",
 ]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,6 @@ classifiers = [
     "Intended Audience :: Science/Research",
     "Programming Language :: C",
     "Programming Language :: Cython",
-    "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
@@ -38,7 +37,7 @@ classifiers = [
     "Topic :: Multimedia :: Graphics :: Graphics Conversion",
     "Topic :: Scientific/Engineering :: GIS",
 ]
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 dependencies = [
     "affine",
     "attrs",
@@ -47,7 +46,6 @@ dependencies = [
     "click>=4.0,!=8.2.*",
     "click-plugins",
     "cligj>=0.5",
-    "importlib-metadata ; python_version < '3.10'",
     "numpy>=1.24",
     "pyparsing",
 ]
@@ -69,6 +67,7 @@ test = [
     "boto3>=1.2.4",
     "fsspec",
     "hypothesis",
+    "matplotlib",
     "packaging",
     "pytest-cov>=2.2.0",
     "pytest>=2.8.2",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,12 +7,123 @@ requires = [
 ]
 build-backend = "setuptools.build_meta"
 
+[project]
+name = "rasterio"
+dynamic = ["version"]
+authors = [
+    {name = "Sean Gillies", email = "sean@mapbox.com"},
+]
+maintainers = [
+    {name = "Rasterio contributors"},
+]
+description = "Fast and direct raster I/O for use with NumPy and SciPy"
+readme = "README.rst"
+keywords = ["gis", "raster", "gdal"]
+license = "BSD-3-Clause"
+license-files = ["LICENSE.txt", "AUTHORS.txt"]
+classifiers = [
+    "Development Status :: 5 - Production/Stable",
+    "Intended Audience :: Developers",
+    "Intended Audience :: Information Technology",
+    "Intended Audience :: Science/Research",
+    "Programming Language :: C",
+    "Programming Language :: Cython",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
+    "Programming Language :: Python :: 3.14",
+    "Programming Language :: Python :: 3",
+    "Topic :: Multimedia :: Graphics :: Graphics Conversion",
+    "Topic :: Scientific/Engineering :: GIS",
+]
+requires-python = ">=3.9"
+dependencies = [
+    "affine",
+    "attrs",
+    "certifi",
+    # Avoid pallets/click#2939.
+    "click>=4.0,!=8.2.*",
+    "cligj>=0.5",
+    "importlib-metadata ; python_version < '3.10'",
+    "numpy>=1.24",
+    "click-plugins",
+    "pyparsing",
+]
+
+[project.optional-dependencies]
+all = ["rasterio[docs,ipython,plot,s3,test]"]
+docs = [
+    "ghp-import",
+    "numpydoc",
+    "sphinx",
+    "sphinx-click",
+    "sphinx-rtd-theme",
+]
+ipython = ["ipython>=2.0"]
+plot = ["matplotlib"]
+s3 = ["boto3>=1.2.4"]
+test = [
+    "aiohttp",
+    "boto3>=1.2.4",
+    "fsspec",
+    "hypothesis",
+    "packaging",
+    "pytest-cov>=2.2.0",
+    "pytest>=2.8.2",
+    "requests",
+    "shapely",
+]
+
+[project.urls]
+Documentation = "https://rasterio.readthedocs.io/"
+Repository = "https://github.com/rasterio/rasterio"
+
+[project.scripts]
+rio = "rasterio.rio.main:main_group"
+
+[project.entry-points."rasterio.rio_commands"]
+blocks = "rasterio.rio.blocks:blocks"
+bounds = "rasterio.rio.bounds:bounds"
+calc = "rasterio.rio.calc:calc"
+clip = "rasterio.rio.clip:clip"
+convert = "rasterio.rio.convert:convert"
+create = "rasterio.rio.create:create"
+edit-info = "rasterio.rio.edit_info:edit"
+env = "rasterio.rio.env:env"
+gcps = "rasterio.rio.gcps:gcps"
+info = "rasterio.rio.info:info"
+insp = "rasterio.rio.insp:insp"
+mask = "rasterio.rio.mask:mask"
+merge = "rasterio.rio.merge:merge"
+overview = "rasterio.rio.overview:overview"
+rasterize = "rasterio.rio.rasterize:rasterize"
+rm = "rasterio.rio.rm:rm"
+sample = "rasterio.rio.sample:sample"
+shapes = "rasterio.rio.shapes:shapes"
+stack = "rasterio.rio.stack:stack"
+transform = "rasterio.rio.transform:transform"
+warp = "rasterio.rio.warp:warp"
+
+[tool.setuptools]
+include-package-data = true
+packages = ["rasterio", "rasterio._vendor", "rasterio.rio"]
+package-dir = {"" = "."}
+
+[tool.setuptools.dynamic]
+version = {attr = "rasterio.__version__"}
+
 [tool.pytest.ini_options]
+testpaths = ["tests"]
 filterwarnings = [
     "ignore:FilePath is supplanted",
     "ignore:is_valid is not useful",
     "ignore:The given matrix is",
     "ignore:Dataset has no geotransform",
+    "ignore::rasterio.errors.NotGeoreferencedWarning",
+    "ignore::rasterio.errors.RasterioDeprecationWarning",
+    "ignore:numpy.ufunc size changed",
 ]
 markers = [
     "slow: marks tests as slow",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,9 +1,8 @@
 [build-system]
 requires = [
     "setuptools>=77.0.3",
-    "wheel",
-    "cython~=3.1.0",
-    "numpy>=2"
+    "cython>=3.1,<=3.2",
+    "numpy>=2,<3",
 ]
 build-backend = "setuptools.build_meta"
 
@@ -16,7 +15,7 @@ authors = [
 maintainers = [
     {name = "Rasterio contributors"},
 ]
-description = "Fast and direct raster I/O for use with NumPy and SciPy"
+description = "Fast and direct raster I/O for use with NumPy"
 readme = "README.rst"
 keywords = ["gis", "raster", "gdal"]
 license = "BSD-3-Clause"
@@ -105,10 +104,8 @@ stack = "rasterio.rio.stack:stack"
 transform = "rasterio.rio.transform:transform"
 warp = "rasterio.rio.warp:warp"
 
-[tool.setuptools]
-include-package-data = true
-packages = ["rasterio", "rasterio._vendor", "rasterio.rio"]
-package-dir = {"" = "."}
+[tool.setuptools.packages.find]
+include = ["rasterio", "rasterio.*"]
 
 [tool.setuptools.dynamic]
 version = {attr = "rasterio.__version__"}

--- a/requirements.txt
+++ b/requirements.txt
@@ -4,11 +4,11 @@
 affine~=2.3.0
 attrs>=19.2.0
 boto3>=1.3.1
-# Avoid pallets/click#2939
+# Avoid https://github.com/pallets/click/issues/2939
 click~=8.0,!=8.2.*
 click-plugins
 cligj>=0.5
 matplotlib
 numpy>=1.24
-setuptools>=20.0
+setuptools>=77.0.3
 pyparsing~=3.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,14 +1,3 @@
-[tool:pytest]
-testpaths = tests
-filterwarnings =
-    ignore::rasterio.errors.NotGeoreferencedWarning
-    ignore::rasterio.errors.RasterioDeprecationWarning
-    ignore:numpy.ufunc size changed
-markers =
-    wheel: tests of modules installed from a wheel
-    gdalbin: tests that require GDAL programs
-    network: tests that require a network connection
-
 [flake8]
 filename = *.py, *.pyx, *.pxd
 select =
@@ -23,29 +12,3 @@ per-file-ignores =
 [sdist]
 owner = root
 group = root
-
-[options.entry_points]
-console_scripts =
-    rio = rasterio.rio.main:main_group
-rasterio.rio_commands =
-    blocks = rasterio.rio.blocks:blocks
-    bounds = rasterio.rio.bounds:bounds
-    calc = rasterio.rio.calc:calc
-    clip = rasterio.rio.clip:clip
-    convert = rasterio.rio.convert:convert
-    create = rasterio.rio.create:create
-    edit-info = rasterio.rio.edit_info:edit
-    env = rasterio.rio.env:env
-    gcps = rasterio.rio.gcps:gcps
-    info = rasterio.rio.info:info
-    insp = rasterio.rio.insp:insp
-    mask = rasterio.rio.mask:mask
-    merge = rasterio.rio.merge:merge
-    overview = rasterio.rio.overview:overview
-    rasterize = rasterio.rio.rasterize:rasterize
-    rm = rasterio.rio.rm:rm
-    sample = rasterio.rio.sample:sample
-    shapes = rasterio.rio.shapes:shapes
-    stack = rasterio.rio.stack:stack
-    transform = rasterio.rio.transform:transform
-    warp = rasterio.rio.warp:warp

--- a/setup.py
+++ b/setup.py
@@ -10,7 +10,6 @@
 # binary wheels.
 
 import copy
-import itertools
 import logging
 import os
 import platform
@@ -38,18 +37,6 @@ def copy_data_tree(datadir, destdir):
 # python -W all setup.py ...
 if "all" in sys.warnoptions:
     log.level = logging.DEBUG
-
-# Parse the version from the rasterio module.
-with open("rasterio/__init__.py") as f:
-    for line in f:
-        if line.find("__version__") >= 0:
-            version = line.split("=")[1].strip()
-            version = version.strip('"')
-            version = version.strip("'")
-            continue
-
-with open("VERSION.txt", "w") as f:
-    f.write(version)
 
 # Use Cython if available.
 try:
@@ -241,88 +228,13 @@ if "clean" not in sys.argv:
         extensions, quiet=True, compile_time_env=compile_time_env, **cythonize_options
     )
 
-
-with open("README.rst", encoding="utf-8") as f:
-    readme = f.read()
-
-# Runtime requirements.
-inst_reqs = [
-    "affine",
-    "attrs",
-    "certifi",
-    # Avoid pallets/click#2939.
-    "click>=4.0,!=8.2.*",
-    "cligj>=0.5",
-    "importlib-metadata ; python_version < '3.10'",
-    "numpy>=1.24",
-    "click-plugins",
-    "pyparsing",
-]
-
-extra_reqs = {
-    "docs": [
-        "ghp-import",
-        "numpydoc",
-        "sphinx",
-        "sphinx-click",
-        "sphinx-rtd-theme",
-    ],
-    "ipython": ["ipython>=2.0"],
-    "plot": ["matplotlib"],
-    "s3": ["boto3>=1.2.4"],
-    "test": [
-        "boto3>=1.2.4",
-        "fsspec",
-        "hypothesis",
-        "packaging",
-        "pytest-cov>=2.2.0",
-        "pytest>=2.8.2",
-        "shapely",
-    ],
-}
-
-# Add all extra requirements
-extra_reqs["all"] = list(set(itertools.chain(*extra_reqs.values())))
-
-setup_args = dict(
-    name="rasterio",
-    version=version,
-    description="Fast and direct raster I/O for use with Numpy and SciPy",
-    long_description=readme,
-    classifiers=[
-        "Development Status :: 5 - Production/Stable",
-        "Intended Audience :: Developers",
-        "Intended Audience :: Information Technology",
-        "Intended Audience :: Science/Research",
-        "License :: OSI Approved :: BSD License",
-        "Programming Language :: C",
-        "Programming Language :: Cython",
-        "Programming Language :: Python :: 3.9",
-        "Programming Language :: Python :: 3.10",
-        "Programming Language :: Python :: 3.11",
-        "Programming Language :: Python :: 3.12",
-        "Programming Language :: Python :: 3.13",
-        "Programming Language :: Python :: 3.14",
-        "Programming Language :: Python :: 3",
-        "Topic :: Multimedia :: Graphics :: Graphics Conversion",
-        "Topic :: Scientific/Engineering :: GIS",
-    ],
-    keywords="raster gdal",
-    author="Sean Gillies",
-    author_email="sean@mapbox.com",
-    url="https://github.com/rasterio/rasterio",
-    license="BSD",
-    package_dir={"": "."},
-    packages=["rasterio", "rasterio._vendor", "rasterio.rio"],
-    include_package_data=True,
-    ext_modules=ext_modules,
-    zip_safe=False,
-    install_requires=inst_reqs,
-    extras_require=extra_reqs,
-    python_requires=">=3.9",
-)
-
+setup_args = {}
 if os.environ.get('PACKAGE_DATA'):
     setup_args['package_data'] = {'rasterio': ['gdal_data/*', 'proj_data/*']}
 
-setup(**setup_args)
+# See pyproject.toml for project metadata
+setup(
+    name="rasterio",  # need by GitHub dependency graph
+    ext_modules=ext_modules,
+    **setup_args,
+)


### PR DESCRIPTION
This PR moves the project metadata to pyproject.toml, following [PEP 621](https://peps.python.org/pep-0621/). Some other details:

- Simplify setup.py, don't write VERSION.txt (was this used by anything?) and remove unneeded dynamic content already supported by setuptools
- Merge duplicate pytest configuration from setup.cfg to pyproject.toml
- Use SPDX license identifier "BSD-3-Clause"; remove the PyPI Trove classifier for the license info, which is deprecated as a unnecessary duplicate
- Specify license-files with ["LICENSE.txt", "AUTHORS.txt"]
- Add URLs for Documentation  and Repository

Now it is possible to use modern tools like `uv sync --all-extras` and `uv run pytest` to build and test everything.