### PR TITLE
Add import for importlib.metadata

### DIFF
--- a/rasterio/_show_versions.py
+++ b/rasterio/_show_versions.py
@@ -5,7 +5,6 @@ adapted from :func:`sklearn.utils._show_versions`
 which was adapted from :func:`pandas.show_versions`
 """
 
-import importlib
 import importlib.metadata
 import os
 import platform

--- a/rasterio/_show_versions.py
+++ b/rasterio/_show_versions.py
@@ -6,6 +6,7 @@ which was adapted from :func:`pandas.show_versions`
 """
 
 import importlib
+import importlib.metadata
 import os
 import platform
 import sys


### PR DESCRIPTION
`rasterio.show_versions()` raises `AttributeError` since 1.5.0


`_show_versions.py` uses `importlib.metadata.version()` but the file only imports `importlib`, not `importlib.metadata`. The submodule needs explicit import.

```python
import rasterio; rasterio.show_versions()
AttributeError: module 'importlib' has no attribute 'metadata'
```


