### PR TITLE
Fix MemoryFile.open docstring rendering

### DIFF
--- a/rasterio/io.py
+++ b/rasterio/io.py
@@ -136,13 +136,13 @@ class MemoryFile(MemoryFileBase):
         If data has already been written, the file is opened in 'r'
         mode. Otherwise, the file is opened in 'w' mode.
 
-        Parameters
-        ----------
+        Notes
+        -----
         Note well that there is no `path` parameter: a `MemoryFile`
         contains a single dataset and there is no need to specify a
         path.
 
-        Other parameters are optional and have the same semantics as the
+        Parameters other than `path` have the same semantics as the
         parameters of `rasterio.open()`.
         """
         mempath = _UnparsedPath(self.name)


### PR DESCRIPTION
Closes #2874.

This moves the `MemoryFile.open()` note about the missing `path` parameter out of the `Parameters` section and into `Notes`, which prevents the API docs from rendering the explanatory text as broken parameter bullets.

Validation:
- `python3 -m py_compile rasterio/io.py`

I did not run import-based Rasterio tests in this worktree because the local extension modules are not built here.
