### PR TITLE
Clarify write_colormap docstring

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1911,8 +1911,8 @@ cdef class DatasetWriterBase(DatasetReaderBase):
     def write_colormap(self, bidx, colormap):
         """Write a colormap for a band to the dataset.
 
-        A colormap maps pixel values of a single-band dataset to RGB or
-        RGBA colors.
+        A colormap maps pixel values of a dataset band to RGB or RGBA
+        colors.
 
         Parameters
         ----------


### PR DESCRIPTION
Closes #2872.

This updates the `write_colormap()` docstring to describe a dataset band instead of implying the method only applies to single-band datasets, which better matches the `bidx` argument and current behavior.

Validation:
- source inspection only; this is a docstring-only change in `rasterio/_io.pyx`

I did not run import-based Rasterio tests in this worktree because the local extension modules are not built here.
