### PR TITLE
docs: fix minor typos

### DIFF
--- a/docs/topics/georeferencing.rst
+++ b/docs/topics/georeferencing.rst
@@ -40,7 +40,7 @@ argument.
 
 Coordinate Transformation
 -------------------------
-This section describes the three primary kinds of georefencing metadata supported by
+This section describes the three primary kinds of georeferencing metadata supported by
 rasterio.
 
 Affine

--- a/docs/topics/masks.rst
+++ b/docs/topics/masks.rst
@@ -4,7 +4,7 @@ Nodata Masks
 Nodata masks allow you to identify regions of valid data values. In using Rasterio,
 you'll encounter two different kinds of masks.
 
-One is the the valid data mask from GDAL, an unsigned byte array with the same number of
+One is the valid data mask from GDAL, an unsigned byte array with the same number of
 rows and columns as the dataset in which non-zero elements (typically 255) indicate that the
 corresponding data elements are valid. Other elements are invalid, or *nodata*
 elements.

--- a/docs/topics/reproject.rst
+++ b/docs/topics/reproject.rst
@@ -76,7 +76,7 @@ use case.  Rasterio provides a few utilities to make this even easier:
 
 :func:`~rasterio.warp.transform_bounds`
 transforms the bounding coordinates of the source raster to the target
-coordinate reference system, densifiying points along the edges to account
+coordinate reference system, densifying points along the edges to account
 for non-linear transformations of the edges.
 
 

--- a/docs/topics/switch.rst
+++ b/docs/topics/switch.rst
@@ -299,7 +299,7 @@ The :attr:`.DatasetReader.crs` attribute is an instance of Rasterio's
    >>> from pyproj import Transformer
    >>> src = rasterio.open('example.tif')
    >>> transformer = Transformer.from_crs(src.crs, "EPSG:3857", always_xy=True)
-   >>> transformer.transfform(101985.0, 2826915.0)
+   >>> transformer.transform(101985.0, 2826915.0)
    (-8789636.707871985, 2938035.238323653)
 
 Tags

--- a/docs/topics/writing.rst
+++ b/docs/topics/writing.rst
@@ -60,5 +60,5 @@ to produce the final output.
 
 Some formats are known to produce invalid results using the
 ``IndirectRasterUpdater``. These formats will raise a :class:`.RasterioIOError`
-if you attempt to write to the. Currently this applies to the ``netCDF``
+if you attempt to write to them. Currently this applies to the ``netCDF``
 driver but please let us know if you experience problems writing other formats.

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1027,7 +1027,7 @@ cdef class DatasetReaderBase(DatasetBase):
     def stats(self, *, indexes=None, approx=False):
         """Update stored statistics for all dataset bands.
 
-        If no stats are provided, statistics will be computed for all
+        If no indexes are provided, statistics will be computed for all
         bands of the dataset.
 
         Parameters


### PR DESCRIPTION
Fixes #3571

This fixes minor documentation typos reported in the issue, including spelling mistakes, a repeated word, an incomplete sentence, and the `stats` docstring wording.