### PR TITLE
Accept 3-vertex polygons (triangles) in is_valid_geom and rasterize

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -5,7 +5,8 @@ Changes
 ------------------
 
 Bug fixes:
--
+
+- rasterio.features: Accept triangles (3-vertex polygons) in is_valid_geom and rasterize instead of skipping them (#3279)
 
 Full list of software versions: https://github.com/rasterio/rasterio/blob/1.5.1/ci/config.sh#L1-L25
 

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -606,25 +606,28 @@ def is_valid_geom(geom):
             return len(coords) >= 2 and len(coords[0]) >= 2
 
         if geom_type == "LinearRing":
-            # Rings must have at least 4 coordinates and at least x, y for
-            # a coordinate
-            return len(coords) >= 4 and len(coords[0]) >= 2
+            # Rings must have at least 3 coordinates and at least x, y for
+            # a coordinate. Unclosed rings are closed by GDAL on write.
+            return len(coords) >= 3 and len(coords[0]) >= 2
 
         if geom_type == "MultiLineString":
             # Multi lines must have at least one LineString
             return len(coords) > 0 and len(coords[0]) >= 2 and len(coords[0][0]) >= 2
 
         if geom_type == "Polygon":
-            # Polygons must have at least 1 ring, with at least 4 coordinates,
-            # with at least x, y for a coordinate
-            return len(coords) > 0 and len(coords[0]) >= 4 and len(coords[0][0]) >= 2
+            # Polygons must have at least 1 ring, with at least 3 coordinates,
+            # with at least x, y for a coordinate. Unclosed rings are closed by
+            # GDAL on write.
+            return len(coords) > 0 and len(coords[0]) >= 3 and len(coords[0][0]) >= 2
 
         if geom_type == "MultiPolygon":
-            # Multi polygons must have at least one Polygon
+            # Multi polygons must have at least one Polygon, whose first ring
+            # has at least 3 coordinates. Unclosed rings are closed by GDAL on
+            # write.
             return (
                 len(coords) > 0
                 and len(coords[0]) > 0
-                and len(coords[0][0]) >= 4
+                and len(coords[0][0]) >= 3
                 and len(coords[0][0][0]) >= 2
             )
 

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1,5 +1,6 @@
 from copy import deepcopy
 import math
+import warnings
 from unittest import mock
 
 from affine import Affine
@@ -359,6 +360,16 @@ def test_is_valid_geom_polygon(geojson_polygon):
 
     assert is_valid_geom(geojson_polygon)
 
+    # A triangle (3-coordinate ring) is valid (#3279)
+    geom = deepcopy(geojson_polygon)
+    geom["coordinates"] = [[(2, 2), (2, 4.25), (4.25, 2)]]
+    assert is_valid_geom(geom)
+
+    # A 2-coordinate ring is too few to form a polygon and is invalid
+    geom = deepcopy(geojson_polygon)
+    geom["coordinates"] = [[(2, 2), (4.25, 2)]]
+    assert not is_valid_geom(geom)
+
     # Empty iterables are invalid
     geom = deepcopy(geojson_polygon)
     geom["coordinates"] = []
@@ -382,6 +393,16 @@ def test_is_valid_geom_ring(geojson_polygon):
     geojson_ring["coordinates"] = geojson_ring["coordinates"][0]
     assert is_valid_geom(geojson_ring)
 
+    # A triangle ring (3 coordinates) is valid (#3279)
+    geom = deepcopy(geojson_ring)
+    geom["coordinates"] = [(2, 2), (2, 4.25), (4.25, 2)]
+    assert is_valid_geom(geom)
+
+    # A 2-coordinate ring is too few and is invalid
+    geom = deepcopy(geojson_ring)
+    geom["coordinates"] = [(2, 2), (4.25, 2)]
+    assert not is_valid_geom(geom)
+
     # Empty iterables are invalid
     geom = deepcopy(geojson_ring)
     geom["coordinates"] = []
@@ -396,6 +417,16 @@ def test_is_valid_geom_multipolygon(geojson_multipolygon):
     """Properly formed GeoJSON MultiPolygon is valid"""
 
     assert is_valid_geom(geojson_multipolygon)
+
+    # A multipolygon whose ring is a triangle (3 coordinates) is valid (#3279)
+    geom = deepcopy(geojson_multipolygon)
+    geom["coordinates"] = [[[(2, 2), (2, 4.25), (4.25, 2)]]]
+    assert is_valid_geom(geom)
+
+    # A 2-coordinate ring is too few and is invalid
+    geom = deepcopy(geojson_multipolygon)
+    geom["coordinates"] = [[[(2, 2), (4.25, 2)]]]
+    assert not is_valid_geom(geom)
 
     # Empty iterables are invalid
     geom = deepcopy(geojson_multipolygon)
@@ -433,6 +464,22 @@ def test_is_valid_geom_geomcollection(geojson_geomcollection):
 def test_is_valid_geom_invalid_inputs(geom):
     """Improperly formed GeoJSON objects should fail"""
     assert not is_valid_geom(geom)
+
+
+@pytest.mark.parametrize(
+    "geom",
+    [
+        {"type": "Polygon", "coordinates": [[(2, 2), (2, 8), (8, 2)]]},
+        {"type": "MultiPolygon", "coordinates": [[[(2, 2), (2, 8), (8, 2)]]]},
+    ],
+)
+def test_rasterize_triangle(geom):
+    """Triangles are rasterized rather than skipped (#3279)."""
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", ShapeSkipWarning)
+        out = rasterize([geom], out_shape=DEFAULT_SHAPE)
+
+    assert out.sum() > 0
 
 
 def test_rasterize_point(geojson_point):


### PR DESCRIPTION
Resolves #3279

`rasterio.features.rasterize` silently skips triangles (3-vertex polygons) with a `ShapeSkipWarning` because `is_valid_geom` requires rings to have at least 4 coordinates, a holdover from GeoJSON RFC 7946's closed-ring rule. This relaxes the coordinate count from 4 to 3 for `LinearRing`, `Polygon`, and `MultiPolygon`. Unclosed rings are still closed by GDAL on write via `OGR_G_CloseRings`, so a 3-coordinate ring is safe to accept.

Testing: added triangle-is-valid assertions for the three geometry types in `is_valid_geom` (and assertions that a 2-coordinate ring is still rejected, to pin the lower bound), plus a parametrized test that rasterizes a triangle (Polygon and MultiPolygon) and asserts it is not skipped. The new tests fail without the change, and the existing features, rasterize, and shapes tests still pass.
