### PR TITLE
Fix sieve size guard for 3-D arrays

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,7 +11,9 @@ Documentation:
   transforming (#2929).
 
 Bug fixes:
--
+- rasterio.features.sieve: Fix the size guard for 3-D (band, row, col) arrays,
+  which compared size against bands * rows instead of rows * cols and could
+  reject valid sizes (#3412).
 
 Full list of software versions: https://github.com/rasterio/rasterio/blob/1.5.1/ci/config.sh#L1-L25
 

--- a/rasterio/_features.pyx
+++ b/rasterio/_features.pyx
@@ -224,7 +224,7 @@ def _sieve(image, size, out, mask, connectivity):
         raise ValueError('size must be greater than 0')
     elif type(size) == float:
         raise ValueError('size must be an integer number of pixels')
-    elif size > (image.shape[0] * image.shape[1]):
+    elif size > (image.shape[-2] * image.shape[-1]):
         raise ValueError('size must be smaller than size of image')
 
     if connectivity not in (4, 8):

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -1115,6 +1115,24 @@ def test_sieve_invalid_size(basic_image):
             sieve(basic_image, invalid_size)
 
 
+@pytest.mark.parametrize("size", [2, 9])
+def test_sieve_3d_size_guard(size):
+    """The size guard must compare against rows * cols, not bands * rows.
+
+    For a 3-D (band, row, col) array a valid size smaller than the number of
+    pixels per band must not raise (gh-3412).
+    """
+    image_2d = np.zeros((4, 4), dtype="int16")
+    image_2d[0, 0] = 1
+    image_3d = image_2d.reshape(1, 4, 4)
+
+    sieved_2d = sieve(image_2d, size)
+    sieved_3d = sieve(image_3d, size)
+
+    # A single-band 3-D input collapses to its 2-D equivalent on output.
+    assert np.array_equal(sieved_3d, sieved_2d)
+
+
 def test_sieve_connectivity_rook(diagonal_image):
     """Diagonals are not connected, so feature is removed."""
     assert not np.any(sieve(diagonal_image, diagonal_image.sum(), connectivity=4))


### PR DESCRIPTION
Fix sieve size guard for 3-D arrays

## What

`rasterio.features.sieve` validates the requested `size` against the number
of pixels in the image. The guard in `rasterio/_features.pyx` used
`image.shape[0] * image.shape[1]`. For a 3-D `(band, row, col)` array that
evaluates to `bands * rows`, not `rows * cols`, so a perfectly valid `size`
smaller than the per-band pixel count was rejected with
`ValueError: size must be smaller than size of image`.

This changes the expression to `image.shape[-2] * image.shape[-1]`, which
counts `rows * cols` for 2-D ndarrays, 3-D ndarrays, and Band tuples alike,
and matches the adjacent `image.shape[-2:]` mask-shape check a few lines down.

## Why

Reproduced on the released wheel (rasterio 1.5.0):

```python
import numpy as np
from rasterio import features

features.sieve(np.zeros((1, 4, 4), "int16"), size=9)
# ValueError: size must be smaller than size of image
# (the 2-D equivalent np.zeros((4, 4), ...) with size=9 works fine)
```

The image has 16 pixels per band, so `size=9` is valid; the old guard
compared against `1 * 4 = 4` and raised.

## Test

Added `test_sieve_3d_size_guard` in `tests/test_features.py`, parameterized
over `size=2` (already worked) and `size=9` (the bug), asserting the 3-D
result matches the 2-D equivalent. Red before the fix (the `size=9` case
raised), green after.

Closes #3412
