### PR TITLE
Fix features.bounds() ignoring transform and north_up when a bbox is present

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,4 @@
 Changes
-=======
 
 1.5.1 (TBD)
 ------------------
@@ -15,6 +14,8 @@ Bug fixes:
 - rasterio.plot.show: Restore the ``adjust=False`` default so a user-supplied
   vmin/vmax/norm is honored for single-band data instead of being rescaled to
   0-1 (#3549).
+- Fix ``features.bounds()`` ignoring ``transform`` and ``north_up`` when the
+  input geometry carries a precomputed ``bbox`` (#3386).
 
 Full list of software versions: https://github.com/rasterio/rasterio/blob/1.5.1/ci/config.sh#L1-L25
 

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -439,7 +439,10 @@ def bounds(geometry, north_up=True, transform=None):
 
     geometry = getattr(geometry, "__geo_interface__", None) or geometry
 
-    if "bbox" in geometry:
+    # A cached bbox is the geometry's untransformed, north-up extent, so it can
+    # only be returned directly when neither a transform nor an axis flip is
+    # requested; otherwise fall through and compute from the coordinates.
+    if "bbox" in geometry and transform is None and north_up:
         return tuple(geometry["bbox"])
 
     geom = geometry.get("geometry") or geometry

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -117,6 +117,48 @@ def test_bounds_existing_bbox(basic_featurecollection):
     assert bounds(fc) == (0, 10, 10, 20)
 
 
+def test_bounds_existing_bbox_honors_transform():
+    """A cached bbox must not bypass the requested transform (gh-3386)."""
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [[[2, 2], [2, 4], [4, 4], [4, 2], [2, 2]]],
+    }
+    bbox = [2, 2, 4, 4]  # the geometry's exact extent
+    transform = Affine.translation(-1, -1) * Affine.scale(0.5)
+    with_bbox = {"type": "Feature", "bbox": bbox, "geometry": geometry}
+    without_bbox = {"type": "Feature", "geometry": geometry}
+    # The cached-bbox path must agree with the computed path, not return the
+    # untransformed bbox.
+    assert bounds(with_bbox, transform=transform) == bounds(
+        without_bbox, transform=transform
+    )
+
+
+def test_bounds_existing_bbox_honors_north_up():
+    """A cached bbox must not bypass north_up=False, which flips y (gh-3386)."""
+    geometry = {
+        "type": "Polygon",
+        "coordinates": [[[2, 2], [2, 4], [4, 4], [4, 2], [2, 2]]],
+    }
+    bbox = [2, 2, 4, 4]
+    with_bbox = {"type": "Feature", "bbox": bbox, "geometry": geometry}
+    without_bbox = {"type": "Feature", "geometry": geometry}
+    result = bounds(with_bbox, north_up=False)
+    assert result == bounds(without_bbox, north_up=False)
+    # Sanity check that north_up=False actually flips the vertical ordering.
+    assert result != bounds(with_bbox, north_up=True)
+
+
+def test_bounds_existing_bbox_used_by_default():
+    """With default arguments the cached bbox is still returned directly."""
+    feature = {
+        "type": "Feature",
+        "bbox": [0, 100, 10, 200],
+        "geometry": {"type": "Polygon", "coordinates": [[[2, 2], [4, 4], [4, 2]]]},
+    }
+    assert bounds(feature) == (0, 100, 10, 200)
+
+
 def test_geometry_mask(basic_geometry, basic_image_2x2):
     assert np.array_equal(
         basic_image_2x2 == 0,


### PR DESCRIPTION
Fixes #3386.

### The bug

`features.bounds(geometry, north_up=True, transform=None)` is documented to return `(left, bottom, right, top)`, applying `transform` to the geometry and flipping y when `north_up=False`. But it short-circuits at the top:

```python
if "bbox" in geometry:
    return tuple(geometry["bbox"])
```

So when the input GeoJSON Feature carries a precomputed `bbox` (Fiona/rasterio/GDAL routinely emit them), the raw bbox is returned and **both `transform` and `north_up` are silently ignored** — the bbox-absent path honours both, so the two diverge:

```python
from rasterio.features import bounds
from affine import Affine
geom = {"type": "Polygon", "coordinates": [[[2, 2], [2, 4], [4, 4], [4, 2], [2, 2]]]}
T = Affine.translation(-1, -1) * Affine.scale(0.5)
bounds({"type": "Feature", "bbox": [2, 2, 4, 4], "geometry": geom}, transform=T)  # -> (2, 2, 4, 4), T ignored
bounds({"type": "Feature", "geometry": geom}, transform=T)                        # -> transformed extent
```

The bbox is an exact cache of the geometry's extent, so both calls describe the same geometry and must agree. This also affects `geometry_window()`, which calls `bounds(shape, north_up=False)`.

### The fix

A cached bbox is the geometry's *untransformed, north-up* extent, so it can only be returned directly when neither a transform nor an axis flip is requested:

```python
if "bbox" in geometry and transform is None and north_up:
    return tuple(geometry["bbox"])
```

Otherwise the bounds are computed from the coordinates as before. The default fast path (no transform, north-up) is unchanged.

### Tests

Three regression tests after `test_bounds_existing_bbox`: `transform` is honoured (cached-bbox path agrees with the computed path), `north_up=False` is honoured (with a sanity check that y actually flips), and the default path still returns the cached bbox directly. The first two fail on `main` and pass with the fix; the existing `test_bounds_existing_bbox` still passes; `ruff check`/`ruff format` clean; `CHANGES.txt` updated.
