### PR TITLE
avoid numpy shape assignment

### DIFF
--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -438,7 +438,7 @@ cdef class DatasetReaderBase(DatasetBase):
             return2d = True
 
             if out is not None and out.ndim == 2:
-                out.shape = (1,) + out.shape
+                out = np.expand_dims(out, axis=0)
 
         if not indexes:
             raise ValueError("No indexes to read")
@@ -657,7 +657,7 @@ cdef class DatasetReaderBase(DatasetBase):
                     out = np.ma.array(out, **kwds)
 
         if return2d:
-            out.shape = out.shape[1:]
+            out = np.squeeze(out, axis=0).copy()
 
         return out
 
@@ -731,7 +731,7 @@ cdef class DatasetReaderBase(DatasetBase):
             indexes = [indexes]
             return2d = True
             if out is not None and out.ndim == 2:
-                out.shape = (1,) + out.shape
+                out = np.expand_dims(out, 0)
         if not indexes:
             raise ValueError("No indexes to read")
 
@@ -828,7 +828,7 @@ cdef class DatasetReaderBase(DatasetBase):
                         indexes, out, Window(0, 0, window.width, window.height), None, masks=True)
 
         if return2d:
-            out.shape = out.shape[1:]
+            out = np.squeeze(out, axis=0).copy()
 
         return out
 


### PR DESCRIPTION
Closes https://github.com/rasterio/rasterio/issues/3592

This PR refactors parts of the code where a numpy array's `shape` was assigned to as this became deprecated in numpy 2.5: https://github.com/numpy/numpy/issues/28800

Before this PR, warnings such as the following were emitted in the test suite:

```
tests/test_warp.py: 10 warnings
  /home/glostis/rasterio/tests/test_warp.py:1764: DeprecationWarning: Setting the shape on a NumPy array has been deprecated in NumPy 2.5.
  As an alternative, you can create a new view using np.reshape (with copy=False if needed).
    source = src.read(1)
```