### PR TITLE
Restore adjust=False default in plot.show() (fixes #3549)

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -11,7 +11,10 @@ Documentation:
   transforming (#2929).
 
 Bug fixes:
--
+
+- rasterio.plot.show: Restore the ``adjust=False`` default so a user-supplied
+  vmin/vmax/norm is honored for single-band data instead of being rescaled to
+  0-1 (#3549).
 
 Full list of software versions: https://github.com/rasterio/rasterio/blob/1.5.1/ci/config.sh#L1-L25
 

--- a/rasterio/plot.py
+++ b/rasterio/plot.py
@@ -42,7 +42,7 @@ def show(
     title=None,
     transform=None,
     percent_range=None,
-    adjust=True,
+    adjust=False,
     **kwargs,
 ):
     """Display a raster or raster band using matplotlib.

--- a/tests/test_plot.py
+++ b/tests/test_plot.py
@@ -320,6 +320,18 @@ def test_plot_normalize():
     np.testing.assert_array_almost_equal(np.linspace(0, 1, 10), b)
 
 
+def test_show_array_respects_vmin_vmax():
+    """show() must delegate value scaling to imshow() so a user-supplied
+    vmin/vmax applies to the real single-band values instead of the data
+    being crushed to 0-1 by adjust_band() (issue #3549)."""
+    data = np.linspace(-33.0, 0.0, 100).reshape(10, 10)
+    fig, ax = plt.subplots(1)
+    show(data, ax=ax, cmap="gray", vmin=-33.0, vmax=0.0)
+    displayed = np.asarray(ax.images[0].get_array())
+    plt.close(fig)
+    np.testing.assert_array_almost_equal(displayed, data)
+
+
 def test_issue3007():
     """Don't squeeze further than 2D."""
     with rasterio.open("tests/data/RGB.byte.tif") as src:


### PR DESCRIPTION
# Restore `adjust=False` default in `rasterio.plot.show()` (fixes #3549)

## Problem

`rasterio.plot.show()` silently ignores a user-supplied matplotlib `vmin`/`vmax`
(or `norm`) for single-band data. The colorbar/legend shows the requested range,
but the rendered pixels are wrong — e.g. all-negative dB data gets crushed to a
single color. Passing `adjust=False` works around it.

Minimal reproduction (from the issue thread):

```python
import numpy as np
from rasterio.plot import show
fake_data = np.random.random((100, 100)) * -33
show(fake_data, cmap="grey", vmin=-33, vmax=0)   # vmin/vmax ignored
show(fake_data, cmap="grey", vmin=-33, vmax=0, adjust=False)  # correct
```

## Root cause

`rasterio/plot.py:45` — PR #3171 changed the `adjust` default from `False` to
`True` and, at the same time, extended the adjustment to 2-D single-band arrays
(previously it only ran for 3-D RGB arrays: `if adjust and arr.ndim >= 3`).

With the new default, `show()` on a single band runs `adjust_band(arr)`
(`rasterio/plot.py:148-149`), which linearly rescales the data to 0-1:

```python
imin = np.float64(np.nanmin(band))
imax = np.float64(np.nanmax(band))
return (band - imin) / (imax - imin)
```

The array handed to `imshow()` is now 0-1, so any `vmin`/`vmax`/`norm` the user
passed — which refer to the *original* data range — no longer line up with the
pixels. As maintainer @sgillies noted, this lost "the intention to delegate
options to imshow()".

## Fix

Revert the `adjust` default to `False` (`rasterio/plot.py:45`), the value it held
before PR #3171 and the direction both maintainers agreed on in the issue
(@sgillies: "I'm opening to reverting to adjust=False"; @snowman2: "Changing the
default is fine with me"). With `adjust=False`, `show()` passes the raw data to
`imshow()`, which then honors `vmin`/`vmax`/`norm`. Users who still want the
per-band 0-1 stretch can pass `adjust=True` explicitly.

One line of source changes; the docstring `adjust` description already documents
both values.

## Tests

Added `tests/test_plot.py::test_show_array_respects_vmin_vmax`: builds a 2-D
all-negative array, calls `show(..., vmin=-33, vmax=0)`, and asserts the array
handed to `imshow()` (`ax.images[0].get_array()`) equals the raw input rather
than a 0-1 rescale.

## Verification

Environment: fresh conda env, GDAL 3.13.1, editable install of this branch.

```
# regression test — FAILS on base (adjust=True), PASSES with the fix
$ git stash                       # revert fix
$ pytest tests/test_plot.py::test_show_array_respects_vmin_vmax
  FAILED  (Mismatched elements: 100 / 100 ... x: array([[0.  , 0.01, ...]]))
$ git stash pop                   # reapply fix
$ pytest tests/test_plot.py::test_show_array_respects_vmin_vmax
  1 passed

# full plot suite still green with the fix
$ pytest tests/test_plot.py
  22 passed
```

## Compatibility

Restores the pre-1.5 / pre-#3171 default, so behavior matches every release up to
that PR. Single-band plots now respect `vmin`/`vmax`/`norm` out of the box. RGB
plotting is unaffected for the common uint8 case (matplotlib renders 0-255 RGB
directly); users relying on the automatic per-band stretch can opt back in with
`adjust=True`. No API/signature change beyond the default value.
