### PR TITLE
Accept a (dataset, bidx) tuple in features.shapes

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -15,6 +15,9 @@ Bug fixes:
 - rasterio.plot.show: Restore the ``adjust=False`` default so a user-supplied
   vmin/vmax/norm is honored for single-band data instead of being rescaled to
   0-1 (#3549).
+- rasterio.features.shapes: Accept a ``(dataset, bidx)`` tuple for ``source``,
+  as the docstring has always described. Such a tuple previously raised
+  ``AttributeError: 'tuple' object has no attribute 'dtype'`` (#3587).
 
 Full list of software versions: https://github.com/rasterio/rasterio/blob/1.5.1/ci/config.sh#L1-L25
 

--- a/rasterio/features.py
+++ b/rasterio/features.py
@@ -135,6 +135,12 @@ def shapes(source, mask=None, connectivity=4, transform=IDENTITY):
     - :cpp:func:`GDALFPolygonize`
 
     """
+    # A Band is a namedtuple, and the low-level implementation reads .dtype,
+    # .ds and .bidx off it. A plain (dataset, bidx) tuple passes the same
+    # isinstance check but has none of those, so promote it to a Band here.
+    if isinstance(source, tuple) and not isinstance(source, rasterio.Band):
+        source = rasterio.band(*source)
+
     if hasattr(source, "mask") and mask is None:
         mask = ~source.mask
         source = source.data

--- a/tests/test_features.py
+++ b/tests/test_features.py
@@ -956,6 +956,19 @@ def test_shapes_band(pixelated_image, pixelated_image_file):
         assert truth[0] == list(shapes(band, mask=band))[0]
 
 
+def test_shapes_dataset_bidx_tuple(pixelated_image, pixelated_image_file):
+    """A (dataset, bidx) tuple should behave like the band it names.
+
+    The docstring has always advertised this form, but the low-level
+    implementation reads .dtype, .ds and .bidx straight off the argument. A
+    plain tuple satisfies its isinstance check while having none of them.
+    """
+    truth = list(shapes(pixelated_image))
+
+    with rasterio.open(pixelated_image_file) as src:
+        assert truth == list(shapes((src, 1)))
+
+
 def test_shapes_connectivity_rook(diagonal_image):
     """
     Diagonals are not connected, so there will be 1 feature per pixel plus


### PR DESCRIPTION
Fixes #3587.

`shapes` documents `tuple(dataset, bidx)` among its accepted source types, but passing one raises:

```python
>>> import rasterio, rasterio.features
>>> src = rasterio.open("tests/data/shade.tif")
>>> list(rasterio.features.shapes((src, 1)))
AttributeError: 'tuple' object has no attribute 'dtype'
```

`_shapes` reads `.dtype` off the source before dispatching, and its `isinstance(image, tuple)` branch then reads `.ds` and `.bidx`. Those are fields of `Band`, which is a namedtuple — so a `Band` satisfies the tuple check *and* carries the attributes, while a plain tuple satisfies the check and carries none of them. That's why `rasterio.band(src, 1)` works and `(src, 1)` doesn't.

This promotes a plain tuple to a `Band` via the existing `rasterio.band()` helper before handing it down, which fills in the `dtype` and `shape` the lower level expects. It's the same shape of fix as the index-based access `rasterio.plot` already uses to accept either form.

I kept the check narrow — `isinstance(source, tuple) and not isinstance(source, rasterio.Band)` — so a `Band` still takes the existing path untouched.

### Scope

Only `shapes` advertises this form. `sieve` and the others document "ndarray, dataset, or Band", so I left them alone even though `_features.pyx` has the same `isinstance(..., tuple)` pattern at line 248. Happy to extend it if you'd rather they all accept tuples.

### Testing

New `test_shapes_dataset_bidx_tuple`, alongside the existing `test_shapes_band`, asserting the tuple form yields shapes identical to the array form. It fails on `main` with the `AttributeError` above at `_features.pyx:78` and passes here.

Built against GDAL 3.13.1 on macOS/arm64, Python 3.12. `tests/test_features.py` is 138 passed, 4 skipped, 1 xfailed, 1 xpassed. Full suite (`-m "not network"`) is 1948 passed, 12 failed — the same 12 fail identically with this change reverted, all in `test_warp.py`, `test_rio_warp.py` and `test_subdatasets.py`, so none are related.

`ruff check`, `ruff format --check` and `codespell` are clean using the versions pinned in `.pre-commit-config.yaml`.