### PR TITLE
DOC: DatasetReader.sample returns a generator, not arrays

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -9,6 +9,9 @@ Documentation:
 - Note that PROJ transformation grids and the PROJ_NETWORK environment variable
   are required to apply vertical (datum) shifts when reprojecting or
   transforming (#2929).
+- DatasetReader.sample: Document that a generator is returned rather than
+  arrays, add an example of consuming it, and fix the malformed underline that
+  kept the "Returns" section from rendering (#3018).
 
 Bug fixes:
 

--- a/rasterio/_io.pyx
+++ b/rasterio/_io.pyx
@@ -1011,11 +1011,22 @@ cdef class DatasetReaderBase(DatasetBase):
             dataset.
 
         Returns
-        ------
-        iterable
-            Arrays of length equal to the number of specified indexes
+        -------
+        generator of numpy.ndarray
+            A generator, not a sequence: nothing is read until it is
+            iterated over. It yields one array per coordinate pair, each
+            of length equal to the number of specified indexes,
             containing the dataset values for the bands corresponding to
             those indexes.
+
+        Examples
+        --------
+        Consume the generator to get the values:
+
+        >>> with rasterio.open("tests/data/RGB.byte.tif") as dataset:
+        ...     values = list(dataset.sample([(220650.0, 2719200.0)]))
+        >>> values
+        [array([18, 25, 14], dtype=uint8)]
 
         """
         # In https://github.com/rasterio/rasterio/issues/378 a user has


### PR DESCRIPTION
Fixes #3018.

`DatasetReader.sample` documents its result as:

> **Returns**
> iterable
>     Arrays of length equal to the number of specified indexes containing the dataset values for the bands corresponding to those indexes.

which reads as "you get arrays back". It returns a generator that yields one such array per coordinate pair, and reads nothing until it's iterated:

```python
>>> dataset.sample([(220650.0, 2719200.0)])
<generator object sample_gen at 0x...>
```

The reporter also noted there was no guidance on how to interact with the result, so I added a short example of consuming it.

### The section wasn't rendering

Separately, the header was underlined with six dashes under a seven-character title:

```
        Returns
        ------
```

docutils rejects that:

```
(WARNING/2) Title underline too short.
Returns
------
```

so the block wasn't being parsed as a section at all. It's the only such underline in `_io.pyx` — the other nineteen `Returns`/`Yields` headings all use the correct width, so this is a typo rather than a house style.

### Scope

`sample_gen` in `rasterio/sample.py` already documents this correctly under `Yields`, so it needs no change. I've also kept this to `_io.pyx` deliberately: #3556 is in flight across a lot of `.py` docstrings but touches no `.pyx` files, so these shouldn't conflict.

### Testing

Rebuilt and confirmed against the compiled docstring: the `Returns` section now parses with no docutils warnings, and the example's output is exactly what the call produces — `[array([18, 25, 14], dtype=uint8)]` for that point in `tests/data/RGB.byte.tif`.

Built against GDAL 3.13.1 on macOS/arm64, Python 3.12. Full suite (`-m "not network"`): 1947 passed, 12 failed — the same 12 fail on an unmodified checkout, all in `test_warp.py`, `test_rio_warp.py` and `test_subdatasets.py`. `codespell` is clean.

Note the example isn't executed by CI — `testpaths` is `["tests"]` with no doctest module — so I verified its output by hand rather than relying on collection.