### PR TITLE
Fix doubled word in helpers docstring

### DIFF
--- a/rasterio/rio/helpers.py
+++ b/rasterio/rio/helpers.py
@@ -11,7 +11,7 @@ from rasterio.errors import FileOverwriteError
 
 
 def coords(obj):
-    """Yield all coordinate coordinate tuples from a geometry or feature.
+    """Yield all coordinate tuples from a geometry or feature.
     From python-geojson package."""
     if isinstance(obj, (tuple, list)):
         coordinates = obj


### PR DESCRIPTION
Small doubled-word typo in `rasterio/rio/helpers.py`: "Yield all coordinate coordinate tuples" -> "Yield all coordinate tuples".
